### PR TITLE
Lowered version for json-schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "justinrainbow/json-schema": "4.0.0",
+    "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0",
     "lastguest/murmurhash": "1.3.0",
     "guzzlehttp/guzzle": "~5.3|~6.2",
     "monolog/monolog": "1.21.0"


### PR DESCRIPTION
**Copy of https://github.com/optimizely/php-sdk/issues/20 (moved to `devel` branch)**

Composer itself (and related packages such as webmozart/json) requires json-schema ^1.6 or ^2.0, making this package impossible to use within a project.

I've added the required versions, and tests still run fine. However I'm assuming this was set to 4.0.0 for a reason?