### PR TITLE
Removed logger overrides

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
     "psr-4": {
       "": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Optimizely\\Tests\\": "tests/"
+    }
   }
 }

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -21,7 +21,6 @@ use Optimizely\Exceptions\InvalidAttributeException;
 use Throwable;
 use Monolog\Logger;
 use Optimizely\Entity\Experiment;
-use Optimizely\Logger\DefaultLogger;
 use Optimizely\ErrorHandler\ErrorHandlerInterface;
 use Optimizely\ErrorHandler\NoOpErrorHandler;
 use Optimizely\Event\Builder\EventBuilder;
@@ -82,12 +81,13 @@ class Optimizely
      * @param $errorHandler ErrorHandlerInterface
      * @param $skipJsonValidation boolean representing whether JSON schema validation needs to be performed.
      */
-    public function __construct($datafile,
-                                EventDispatcherInterface $eventDispatcher = null,
-                                LoggerInterface $logger = null,
-                                ErrorHandlerInterface $errorHandler = null,
-                                $skipJsonValidation = false)
-    {
+    public function __construct(
+        $datafile,
+        EventDispatcherInterface $eventDispatcher = null,
+        LoggerInterface $logger = null,
+        ErrorHandlerInterface $errorHandler = null,
+        $skipJsonValidation = false
+    ) {
         $this->_isValid = true;
         $this->_eventDispatcher = $eventDispatcher ?: new DefaultEventDispatcher();
         $this->_logger = $logger ?: new NoOpLogger();
@@ -95,7 +95,6 @@ class Optimizely
 
         if (!$this->validateInputs($datafile, $skipJsonValidation)) {
             $this->_isValid = false;
-            $this->_logger = new DefaultLogger();
             $this->_logger->log(Logger::ERROR, 'Provided "datafile" has invalid schema.');
             return;
         }
@@ -105,13 +104,11 @@ class Optimizely
         }
         catch (Throwable $exception) {
             $this->_isValid = false;
-            $this->_logger = new DefaultLogger();
             $this->_logger->log(Logger::ERROR, 'Provided "datafile" is in an invalid format.');
             return;
         }
         catch (Exception $exception) {
             $this->_isValid = false;
-            $this->_logger = new DefaultLogger();
             $this->_logger->log(Logger::ERROR, 'Provided "datafile" is in an invalid format.');
             return;
         }

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -31,14 +31,14 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
     private $config;
     private $loggerMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->testUserId = 'testUserId';
         // Mock Logger
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
             ->setMethods(array('log'))
             ->getMock();
-        $this->config = new ProjectConfig(DATAFILE, $this->loggerMock, new NoOpErrorHandler());
+        $this->config = new ProjectConfig(Fixtures::DATAFILE, $this->loggerMock, new NoOpErrorHandler());
     }
 
     private function getBucketingId($userId, $experimentId)

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -34,7 +34,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->testUserId = 'testUserId';
         $logger = new NoOpLogger();
-        $this->config = new ProjectConfig(DATAFILE, $logger, new NoOpErrorHandler());
+        $this->config = new ProjectConfig(Fixtures::DATAFILE, $logger, new NoOpErrorHandler());
         $this->eventBuilder = new EventBuilder(new Bucketer($logger));
     }
 

--- a/tests/Fixtures.php
+++ b/tests/Fixtures.php
@@ -16,13 +16,9 @@
  */
 namespace Optimizely\Tests;
 
-use Exception;
-use Optimizely\Bucketer;
-use Optimizely\Event\Dispatcher\EventDispatcherInterface;
-use Optimizely\Event\LogEvent;
-
-define('DATAFILE',
-    '{"experiments": [{"status": "Running", "key": "test_experiment", "layerId": "7719770039", 
+class Fixtures
+{
+    const DATAFILE = '{"experiments": [{"status": "Running", "key": "test_experiment", "layerId": "7719770039", 
     "trafficAllocation": [{"entityId": "7722370027", "endOfRange": 4000}, 
     {"entityId": "7721010009", "endOfRange": 8000}], "audienceIds": ["7718080042"], 
     "variations": [{"id": "7722370027", "key": "control"}, {"id": "7721010009", "key": "variation"}], 
@@ -37,47 +33,5 @@ define('DATAFILE',
     "attributes": [{"id": "7723280020", "key": "device_type"}, {"id": "7723340004", "key": "location"}], 
     "projectId": "7720880029", "accountId": "1592310167", 
     "events": [{"experimentIds": ["7716830082", "7723330021", "7718750065", "7716830585"], "id": "7718020063", "key": "purchase"}], 
-    "revision": "15"}');
-
-/**
- * Class TestBucketer
- * Extending Bucketer for the sake of tests.
- * In PHP we cannot mock private/protected methods and so this was the most novel way to test.
- *
- * @package Optimizely\Tests
- */
-class TestBucketer extends Bucketer
-{
-    private $values;
-
-    public function setBucketValues($values)
-    {
-        $this->values = $values;
-    }
-
-    public function generateBucketValue($bucketingId)
-    {
-        return array_shift($this->values);
-    }
-}
-
-
-class ValidEventDispatcher implements EventDispatcherInterface
-{
-    public function dispatchEvent(LogEvent $event) {}
-}
-
-class InvalidEventDispatcher
-{
-    public function dispatchEvent(LogEvent $event) {}
-}
-
-class InvalidLogger
-{
-    public function log($logLevel, $logMessage) {}
-}
-
-class InvalidErrorHandler
-{
-    public function handleError(Exception $error) {}
+    "revision": "15"}';
 }

--- a/tests/ProjectConfigTest.php
+++ b/tests/ProjectConfigTest.php
@@ -16,7 +16,6 @@
  */
 
 namespace Optimizely\Tests;
-include('TestData.php');
 
 use Monolog\Logger;
 use Optimizely\Entity\Attribute;
@@ -52,7 +51,7 @@ class ProjectConfigTest extends \PHPUnit_Framework_TestCase
             ->setMethods(array('handleError'))
             ->getMock();
 
-        $this->config = new ProjectConfig(DATAFILE, $this->loggerMock, $this->errorHandlerMock);
+        $this->config = new ProjectConfig(Fixtures::DATAFILE, $this->loggerMock, $this->errorHandlerMock);
     }
 
     public function testInit()

--- a/tests/TestBucketer.php
+++ b/tests/TestBucketer.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright 2016, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Optimizely\Tests;
+
+use Optimizely\Bucketer;
+
+/**
+ * Class TestBucketer
+ * Extending Bucketer for the sake of tests.
+ * In PHP we cannot mock private/protected methods and so this was the most novel way to test.
+ *
+ * @package Optimizely\Tests
+ */
+class TestBucketer extends Bucketer
+{
+    private $values;
+
+    public function setBucketValues($values)
+    {
+        $this->values = $values;
+    }
+
+    public function generateBucketValue($bucketingId)
+    {
+        return array_shift($this->values);
+    }
+}

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -27,7 +27,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
     public function testValidateJsonSchemaValidFile()
     {
-        $this->assertTrue(Validator::validateJsonSchema(DATAFILE));
+        $this->assertTrue(Validator::validateJsonSchema(Fixtures::DATAFILE));
     }
 
     public function testValidateJsonSchemaInvalidFile()
@@ -74,7 +74,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testIsUserInExperimentNoAudienceUsedInExperiment()
     {
-        $config = new ProjectConfig(DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
+        $config = new ProjectConfig(Fixtures::DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
         $this->assertTrue(Validator::isUserInExperiment(
             $config,
             $config->getExperimentFromKey('paused_experiment'),
@@ -84,7 +84,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testIsUserInExperimentAudienceUsedInExperimentNoAttributesProvided()
     {
-        $config = new ProjectConfig(DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
+        $config = new ProjectConfig(Fixtures::DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
 
         // Test with empty attributes
         $this->assertFalse(Validator::isUserInExperiment(
@@ -103,7 +103,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testIsUserInExperimentAudienceMatch()
     {
-        $config = new ProjectConfig(DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
+        $config = new ProjectConfig(Fixtures::DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
         $this->assertTrue(Validator::isUserInExperiment(
             $config,
             $config->getExperimentFromKey('test_experiment'),
@@ -113,7 +113,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testIsUserInExperimentAudienceNoMatch()
     {
-        $config = new ProjectConfig(DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
+        $config = new ProjectConfig(Fixtures::DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
         $this->assertFalse(Validator::isUserInExperiment(
             $config,
             $config->getExperimentFromKey('test_experiment'),


### PR DESCRIPTION
see #29

afaik there is no reason to use the `DefaultLogger` at all here, either the user passes it's own logger or the `NoOpLogger` is used.