### PR TITLE
Use + operator instead of array_merge

### DIFF
--- a/src/Optimizely/ProjectConfig.php
+++ b/src/Optimizely/ProjectConfig.php
@@ -203,7 +203,7 @@ class ProjectConfig
                 $experiment->setGroupId($group->getId());
                 $experiment->setGroupPolicy($group->getPolicy());
             }
-            $this->_experimentKeyMap = array_merge($this->_experimentKeyMap, $experimentsInGroup);
+            $this->_experimentKeyMap = $this->_experimentKeyMap + $experimentsInGroup;
         }
 
         forEach(array_values($this->_experimentKeyMap) as $experiment) {


### PR DESCRIPTION
In PHP, if a numeric string is a valid integer, it is auto converted into an integer before being stored as a key in an associative array. So you can not have integer string as a key. 

array_merge has a weird behavior, it re-indexes all numerical keys, starting from zero. 
See this here: https://repl.it/@oakbani/arraymerge-or

Since we allow experiment and variation keys to be saved only as numbers, this could break SDK functionality. We can use + operator instead as we will have unique keys in our data file. 