### PR TITLE
Feature Toggle

### DIFF
--- a/src/Optimizely/Entity/Variation.php
+++ b/src/Optimizely/Entity/Variation.php
@@ -47,7 +47,7 @@ class Variation
     private $_variableIdToVariableUsageInstanceMap;
 
 
-    public function __construct($id = null, $key = null, $featureEnabled = 'false', $variableUsageInstances = [])
+    public function __construct($id = null, $key = null, $featureEnabled = false, $variableUsageInstances = [])
     {
         $this->_id = $id;
         $this->_key = $key;

--- a/src/Optimizely/Entity/Variation.php
+++ b/src/Optimizely/Entity/Variation.php
@@ -47,10 +47,11 @@ class Variation
     private $_variableIdToVariableUsageInstanceMap;
 
 
-    public function __construct($id = null, $key = null, $variableUsageInstances = [])
+    public function __construct($id = null, $key = null, $featureEnabled = 'false', $variableUsageInstances = [])
     {
         $this->_id = $id;
         $this->_key = $key;
+        $this->_featureEnabled = $featureEnabled;
 
         $this->_variableUsageInstances = ConfigParser::generateMap($variableUsageInstances, null, VariableUsage::class);
 
@@ -87,6 +88,22 @@ class Variation
     public function setKey($key)
     {
         $this->_key = $key;
+    }
+
+    /**
+     * @return boolean featureEnabled property
+     */
+    public function getFeatureEnabled()
+    {
+        return $this->_featureEnabled;
+    }
+
+    /**
+     * @param boolean $flag
+     */
+    public function setFeatureEnabled($flag)
+    {
+        $this->_featureEnabled = $flag;
     }
 
     /**

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -517,7 +517,7 @@ class Optimizely
         }
 
         $variation = $decision->getVariation();
-        if ($variation->getFeatureEnabled() == 'true') {
+        if ($variation->getFeatureEnabled()) {
             $this->sendImpressionEvent($experiment->getKey(), $variation->getKey(), $userId, $attributes);
             $this->_logger->log(Logger::INFO, "Feature Flag '{$featureFlagKey}' is enabled for user '{$userId}'.");
             return true;

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -510,15 +510,21 @@ class Optimizely
         $experiment = $decision->getExperiment();
         $variation = $decision->getVariation();
 
-        if ($decision->getSource() == FeatureDecision::DECISION_SOURCE_EXPERIMENT) {
-            $this->sendImpressionEvent($experiment->getKey(), $variation->getKey(), $userId, $attributes);
-        } else {
+        if ($decision->getSource() == FeatureDecision::DECISION_SOURCE_ROLLOUT) {
             $this->_logger->log(Logger::INFO, "The user '{$userId}' is not being experimented on Feature Flag '{$featureFlagKey}'.");
+            $this->_logger->log(Logger::INFO, "Feature Flag '{$featureFlagKey}' is enabled for user '{$userId}'.");
+            return true;
         }
 
-        $this->_logger->log(Logger::INFO, "Feature Flag '{$featureFlagKey}' is enabled for user '{$userId}'.");
+        $variation = $decision->getVariation();
+        if ($variation->getFeatureEnabled() == 'true') {
+            $this->sendImpressionEvent($experiment->getKey(), $variation->getKey(), $userId, $attributes);
+            $this->_logger->log(Logger::INFO, "Feature Flag '{$featureFlagKey}' is enabled for user '{$userId}'.");
+            return true;
+        }
 
-        return true;
+        $this->_logger->log(Logger::INFO, "Feature Flag '{$featureFlagKey}' is not enabled for user '{$userId}'.");
+        return false;
     }
 
     /**

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -208,6 +208,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             new Variation(
                 '7722260071',
                 'group_exp_1_var_1',
+                'true',
                 [
                 [
                   "id" => "155563",
@@ -245,6 +246,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             new Variation(
                 '7722360022',
                 'group_exp_1_var_2',
+                'true',
                 [
                 [
                   "id" => "155563",
@@ -375,6 +377,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             new Variation(
                 '7725250007',
                 'group_exp_2_var_2',
+                'true',
                 [
                 [
                   "id" => "155563",
@@ -408,6 +411,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
         $expectedVariation = new Variation(
             '177778',
             '177778',
+            'true',
             [
                 [
                   "id"=> "155556",

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -208,7 +208,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             new Variation(
                 '7722260071',
                 'group_exp_1_var_1',
-                'true',
+                true,
                 [
                 [
                   "id" => "155563",
@@ -246,7 +246,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             new Variation(
                 '7722360022',
                 'group_exp_1_var_2',
-                'true',
+                true,
                 [
                 [
                   "id" => "155563",
@@ -377,7 +377,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             new Variation(
                 '7725250007',
                 'group_exp_2_var_2',
-                'true',
+                true,
                 [
                 [
                   "id" => "155563",
@@ -411,7 +411,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
         $expectedVariation = new Variation(
             '177778',
             '177778',
-            'true',
+            true,
             [
                 [
                   "id"=> "155556",

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -150,7 +150,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $expectedVariation = new Variation(
             '7722260071',
             'group_exp_1_var_1',
-            'true',
+            true,
             [
                 [
                   "id" => "155563",

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -150,6 +150,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $expectedVariation = new Variation(
             '7722260071',
             'group_exp_1_var_1',
+            'true',
             [
                 [
                   "id" => "155563",

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -2225,7 +2225,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($optimizelyObj->isFeatureEnabled('mutex_group_feature', "user_id"), false);
     }
 
-    public function testIsFeatureEnabledGivenFeatureFlagIsNotEnabledForUser()
+    public function testIsFeatureEnabledGivenGetVariationForFeatureReturnsNull()
     {
         // should return false when no variation is returned for user
         $optimizelyMock = $this->getMockBuilder(Optimizely::class)
@@ -2261,13 +2261,10 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::INFO, "Feature Flag 'double_single_variable_feature' is not enabled for user 'user_id'.");
 
-        $this->assertSame(
-            $optimizelyMock->isFeatureEnabled('double_single_variable_feature', 'user_id'),
-            false
-        );
+        $this->assertFalse($optimizelyMock->isFeatureEnabled('double_single_variable_feature', 'user_id'));
     }
 
-    public function testIsFeatureEnabledGivenFeatureFlagIsEnabledAndUserIsBeingExperimented()
+    public function testIsFeatureEnabledGivenFeatureExperimentAndFeatureEnabledIsTrue()
     {
         $optimizelyMock = $this->getMockBuilder(Optimizely::class)
             ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
@@ -2286,6 +2283,12 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Mock getVariationForFeature to return a valid decision with experiment and variation keys
         $experiment = $this->projectConfig->getExperimentFromKey('test_experiment_double_feature');
         $variation = $this->projectConfig->getVariationFromKey('test_experiment_double_feature', 'control');
+
+        // assert that featureEnabled for $variation is 'true'
+        $this->assertEquals(
+            'true',
+            $variation->getFeatureEnabled()
+        );
 
         $expected_decision = new FeatureDecision(
             $experiment,
@@ -2306,13 +2309,56 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::INFO, "Feature Flag 'double_single_variable_feature' is enabled for user 'user_id'.");
 
-        $this->assertSame(
-            $optimizelyMock->isFeatureEnabled('double_single_variable_feature', 'user_id', []),
-            true
-        );
+        $this->assertTrue($optimizelyMock->isFeatureEnabled('double_single_variable_feature', 'user_id', []));
     }
 
-    public function testIsFeatureEnabledGivenFeatureFlagIsEnabledAndUserIsNotBeingExperimented()
+    public function testIsFeatureEnabledGivenFeatureExperimentAndFeatureEnabledIsFalse()
+    {
+        $optimizelyMock = $this->getMockBuilder(Optimizely::class)
+            ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
+            ->setMethods(array('sendImpressionEvent'))
+            ->getMock();
+
+        $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
+            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setMethods(array('getVariationForFeature'))
+            ->getMock();
+
+        $decisionService = new \ReflectionProperty(Optimizely::class, '_decisionService');
+        $decisionService->setAccessible(true);
+        $decisionService->setValue($optimizelyMock, $decisionServiceMock);
+
+        // Mock getVariationForFeature to return a valid decision with experiment and variation keys
+        $experiment = $this->projectConfig->getExperimentFromKey('test_experiment_double_feature');
+        $variation = $this->projectConfig->getVariationFromKey('test_experiment_double_feature', 'variation');
+
+        // assert that featureEnabled for $variation is 'false'
+        $this->assertEquals(
+            'false',
+            $variation->getFeatureEnabled()
+        );
+
+        $expected_decision = new FeatureDecision(
+            $experiment,
+            $variation,
+            FeatureDecision::DECISION_SOURCE_EXPERIMENT
+        );
+
+        $decisionServiceMock->expects($this->exactly(1))
+            ->method('getVariationForFeature')
+            ->will($this->returnValue($expected_decision));
+
+        $optimizelyMock->expects($this->never())
+            ->method('sendImpressionEvent');
+
+        $this->loggerMock->expects($this->at(0))
+            ->method('log')
+            ->with(Logger::INFO, "Feature Flag 'double_single_variable_feature' is not enabled for user 'user_id'.");
+
+        $this->assertFalse($optimizelyMock->isFeatureEnabled('double_single_variable_feature', 'user_id', []));
+    }
+
+    public function testIsFeatureEnabledGivenFeatureRollout()
     {
         $optimizelyMock = $this->getMockBuilder(Optimizely::class)
             ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
@@ -2332,6 +2378,16 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         $rollout = $this->projectConfig->getRolloutFromId('166660');
         $experiment = $rollout->getExperiments()[0];
         $variation = $experiment->getVariations()[0];
+        $variation->setFeatureEnabled('false');
+
+        // assert variation's 'featureEnabled' is set to 'false' to ensure that this property
+        // has no effect when Decision object is from Rollout
+        $this->assertEquals(
+            'false',
+            $variation->getFeatureEnabled()
+        );
+        
+
         $expected_decision = new FeatureDecision(
             $experiment,
             $variation,
@@ -2357,10 +2413,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::INFO, "Feature Flag 'boolean_single_variable_feature' is enabled for user 'user_id'.");
 
-        $this->assertSame(
-            $optimizelyMock->isFeatureEnabled('boolean_single_variable_feature', 'user_id', []),
-            true
-        );
+        $this->assertTrue($optimizelyMock->isFeatureEnabled('boolean_single_variable_feature', 'user_id', []));
     }
 
     public function testGetEnabledFeaturesGivenInvalidDataFile()

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -2284,11 +2284,8 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         $experiment = $this->projectConfig->getExperimentFromKey('test_experiment_double_feature');
         $variation = $this->projectConfig->getVariationFromKey('test_experiment_double_feature', 'control');
 
-        // assert that featureEnabled for $variation is 'true'
-        $this->assertEquals(
-            'true',
-            $variation->getFeatureEnabled()
-        );
+        // assert that featureEnabled for $variation is true
+        $this->assertTrue($variation->getFeatureEnabled());
 
         $expected_decision = new FeatureDecision(
             $experiment,
@@ -2332,11 +2329,8 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         $experiment = $this->projectConfig->getExperimentFromKey('test_experiment_double_feature');
         $variation = $this->projectConfig->getVariationFromKey('test_experiment_double_feature', 'variation');
 
-        // assert that featureEnabled for $variation is 'false'
-        $this->assertEquals(
-            'false',
-            $variation->getFeatureEnabled()
-        );
+        // assert that featureEnabled for $variation is false
+        $this->assertFalse($variation->getFeatureEnabled());
 
         $expected_decision = new FeatureDecision(
             $experiment,
@@ -2378,15 +2372,11 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         $rollout = $this->projectConfig->getRolloutFromId('166660');
         $experiment = $rollout->getExperiments()[0];
         $variation = $experiment->getVariations()[0];
-        $variation->setFeatureEnabled('false');
+        $variation->setFeatureEnabled(false);
 
-        // assert variation's 'featureEnabled' is set to 'false' to ensure that this property
+        // assert variation's 'featureEnabled' is set to false to ensure that this property
         // has no effect when Decision object is from Rollout
-        $this->assertEquals(
-            'false',
-            $variation->getFeatureEnabled()
-        );
-        
+        $this->assertFalse($variation->getFeatureEnabled());
 
         $expected_decision = new FeatureDecision(
             $experiment,

--- a/tests/ProjectConfigTest.php
+++ b/tests/ProjectConfigTest.php
@@ -309,15 +309,22 @@ class ProjectConfigTest extends \PHPUnit_Framework_TestCase
         );
 
 
-        // Check variable usage
+        // Check variation entity
         $variableUsages = [
             new VariableUsage("155560", "F"),
             new VariableUsage("155561", "red")
         ];
-        $expectedVariation = new Variation("122231", "Fred", $variableUsages);
+        $expectedVariation = new Variation("122231", "Fred", 'true', $variableUsages);
         $actualVariation = $this->config->getVariationFromKey("test_experiment_multivariate", "Fred");
 
         $this->assertEquals($expectedVariation, $actualVariation);
+
+        // Check variation by default has featureEnabled set to 'false'
+        $variation = new Variation();
+        $this->assertSame(
+            'false',
+            $variation->getFeatureEnabled()
+        );
     }
 
     public function testGetAccountId()

--- a/tests/ProjectConfigTest.php
+++ b/tests/ProjectConfigTest.php
@@ -314,17 +314,14 @@ class ProjectConfigTest extends \PHPUnit_Framework_TestCase
             new VariableUsage("155560", "F"),
             new VariableUsage("155561", "red")
         ];
-        $expectedVariation = new Variation("122231", "Fred", 'true', $variableUsages);
+        $expectedVariation = new Variation("122231", "Fred", true, $variableUsages);
         $actualVariation = $this->config->getVariationFromKey("test_experiment_multivariate", "Fred");
 
         $this->assertEquals($expectedVariation, $actualVariation);
 
-        // Check variation by default has featureEnabled set to 'false'
+        // Check variation by default has featureEnabled set to false
         $variation = new Variation();
-        $this->assertSame(
-            'false',
-            $variation->getFeatureEnabled()
-        );
+        $this->assertFalse($variation->getFeatureEnabled());
     }
 
     public function testGetAccountId()

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -136,7 +136,8 @@ define(
               "id": "155561",
               "value": "red"
             }
-          ]
+          ],
+          "featureEnabled": "true"
         },
         {
           "id": "122232",
@@ -150,7 +151,8 @@ define(
               "id": "155561",
               "value": "eorge"
             }
-          ]
+          ],
+          "featureEnabled": "true"
         },
         {
           "id": "122233",
@@ -164,7 +166,8 @@ define(
               "id": "155561",
               "value": "red"
             }
-          ]
+          ],
+          "featureEnabled": "true"
         },
         {
           "id": "122234",
@@ -178,7 +181,8 @@ define(
               "id": "155561",
               "value": "eorge"
             }
-          ]
+          ],
+          "featureEnabled": "true"
         }
       ]
     },
@@ -212,7 +216,8 @@ define(
               "id": "155558",
               "value": "cta_1"
             }
-          ]
+          ],
+          "featureEnabled": "true"
         },
         {
           "id": "122237",
@@ -222,7 +227,8 @@ define(
               "id": "155558",
               "value": "cta_2"
             }
-          ]
+          ],
+          "featureEnabled": "true"
         }
       ]
     },
@@ -256,7 +262,8 @@ define(
               "id": "155551",
               "value": "42.42"
             }
-          ]
+          ],
+          "featureEnabled": "true"
         },
         {
           "id": "122240",
@@ -266,7 +273,8 @@ define(
               "id": "155551",
               "value": "13.37"
             }
-          ]
+          ],
+          "featureEnabled": "false"
         }
       ]
     },
@@ -300,7 +308,8 @@ define(
               "id": "155553",
               "value": "42"
             }
-          ]
+          ],
+          "featureEnabled": "true"
         },
         {
           "id": "122243",
@@ -310,7 +319,8 @@ define(
               "id": "155553",
               "value": "13"
             }
-          ]
+          ],
+          "featureEnabled": "true"
         }
       ]
     }
@@ -372,7 +382,8 @@ define(
                   "id": "155563",
                   "value": "groupie_1_v1"
                 }
-              ]
+              ],
+          "featureEnabled": "true"
             },
             {
               "id": "7722360022",
@@ -382,7 +393,8 @@ define(
                   "id": "155563",
                   "value": "groupie_1_v2"
                 }
-              ]
+              ],
+          "featureEnabled": "true"
             }
           ],
           "forcedVariations": {
@@ -416,7 +428,8 @@ define(
                   "id": "155563",
                   "value": "groupie_2_v1"
                 }
-              ]
+              ],
+          "featureEnabled": "true"
             },
             {
               "id": "7725250007",
@@ -426,7 +439,8 @@ define(
                   "id": "155563",
                   "value": "groupie_2_v1"
                 }
-              ]
+              ],
+          "featureEnabled": "true"
             }
           ],
           "forcedVariations": {
@@ -618,7 +632,8 @@ define(
                   "id": "155556",
                   "value": "true"
                 }
-              ]
+              ],
+              "featureEnabled": "true"
             }
           ],
           "trafficAllocation": [
@@ -645,7 +660,8 @@ define(
                   "id": "155556",
                   "value": "false"
                 }
-              ]
+              ],
+              "featureEnabled": "true"
             }
           ],
           "trafficAllocation": [
@@ -672,7 +688,8 @@ define(
                   "id": "155556",
                   "value": "false"
                 }
-              ]
+              ],
+              "featureEnabled": "true"
             }
           ],
           "trafficAllocation": [
@@ -701,7 +718,8 @@ define(
               "key": "177775",
               "variables": [
                 
-              ]
+              ],
+              "featureEnabled": "true"
             }
           ],
           "trafficAllocation": [
@@ -725,7 +743,8 @@ define(
               "key": "177780",
               "variables": [
                 
-              ]
+              ],
+              "featureEnabled": "true"
             }
           ],
           "trafficAllocation": [

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -137,7 +137,7 @@ define(
               "value": "red"
             }
           ],
-          "featureEnabled": "true"
+          "featureEnabled": true
         },
         {
           "id": "122232",
@@ -152,7 +152,7 @@ define(
               "value": "eorge"
             }
           ],
-          "featureEnabled": "true"
+          "featureEnabled": true
         },
         {
           "id": "122233",
@@ -167,7 +167,7 @@ define(
               "value": "red"
             }
           ],
-          "featureEnabled": "true"
+          "featureEnabled": true
         },
         {
           "id": "122234",
@@ -182,7 +182,7 @@ define(
               "value": "eorge"
             }
           ],
-          "featureEnabled": "true"
+          "featureEnabled": true
         }
       ]
     },
@@ -217,7 +217,7 @@ define(
               "value": "cta_1"
             }
           ],
-          "featureEnabled": "true"
+          "featureEnabled": true
         },
         {
           "id": "122237",
@@ -228,7 +228,7 @@ define(
               "value": "cta_2"
             }
           ],
-          "featureEnabled": "true"
+          "featureEnabled": true
         }
       ]
     },
@@ -263,7 +263,7 @@ define(
               "value": "42.42"
             }
           ],
-          "featureEnabled": "true"
+          "featureEnabled": true
         },
         {
           "id": "122240",
@@ -274,7 +274,7 @@ define(
               "value": "13.37"
             }
           ],
-          "featureEnabled": "false"
+          "featureEnabled": false
         }
       ]
     },
@@ -309,7 +309,7 @@ define(
               "value": "42"
             }
           ],
-          "featureEnabled": "true"
+          "featureEnabled": true
         },
         {
           "id": "122243",
@@ -320,7 +320,7 @@ define(
               "value": "13"
             }
           ],
-          "featureEnabled": "true"
+          "featureEnabled": true
         }
       ]
     }
@@ -383,7 +383,7 @@ define(
                   "value": "groupie_1_v1"
                 }
               ],
-          "featureEnabled": "true"
+          "featureEnabled": true
             },
             {
               "id": "7722360022",
@@ -394,7 +394,7 @@ define(
                   "value": "groupie_1_v2"
                 }
               ],
-          "featureEnabled": "true"
+          "featureEnabled": true
             }
           ],
           "forcedVariations": {
@@ -429,7 +429,7 @@ define(
                   "value": "groupie_2_v1"
                 }
               ],
-          "featureEnabled": "true"
+          "featureEnabled": true
             },
             {
               "id": "7725250007",
@@ -440,7 +440,7 @@ define(
                   "value": "groupie_2_v1"
                 }
               ],
-          "featureEnabled": "true"
+          "featureEnabled": true
             }
           ],
           "forcedVariations": {
@@ -633,7 +633,7 @@ define(
                   "value": "true"
                 }
               ],
-              "featureEnabled": "true"
+              "featureEnabled": true
             }
           ],
           "trafficAllocation": [
@@ -661,7 +661,7 @@ define(
                   "value": "false"
                 }
               ],
-              "featureEnabled": "true"
+              "featureEnabled": true
             }
           ],
           "trafficAllocation": [
@@ -689,7 +689,7 @@ define(
                   "value": "false"
                 }
               ],
-              "featureEnabled": "true"
+              "featureEnabled": true
             }
           ],
           "trafficAllocation": [
@@ -719,7 +719,7 @@ define(
               "variables": [
                 
               ],
-              "featureEnabled": "true"
+              "featureEnabled": true
             }
           ],
           "trafficAllocation": [
@@ -744,7 +744,7 @@ define(
               "variables": [
                 
               ],
-              "featureEnabled": "true"
+              "featureEnabled": true
             }
           ],
           "trafficAllocation": [


### PR DESCRIPTION
# Unit Tests
1. Test that `isFeatureEnabled` returns false if the feature experiment variation’s `featureEnabled` property is false  -- **testIsFeatureEnabledGivenFeatureExperimentAndFeatureEnabledIsFalse**

2. Test that `isFeatureEnabled` returns true if the feature experiment variation’s `featureEnabled` property is true **testIsFeatureEnabledGivenFeatureExperimentAndFeatureEnabledIsTrue**

3. Test that `isFeatureEnabled` returns false if the user is NOT bucketed into the rollout experiment’s variation **testIsFeatureEnabledGivenGetVariationForFeatureReturnsNull**

4. Test that `isFeatureEnabled` returns true if the user is bucketed into the rollout experiment’s variation **testIsFeatureEnabledGivenFeatureRollout**

5. Test Variation's 'featureEnabled' by default is set to false if no property is given **ProjectConfigTest- init**
