### PR TITLE
log to stdout instead of output.

### DIFF
--- a/src/Optimizely/Logger/DefaultLogger.php
+++ b/src/Optimizely/Logger/DefaultLogger.php
@@ -40,7 +40,7 @@ class DefaultLogger implements LoggerInterface
     public function __construct($minLevel = Logger::INFO)
     {
         $formatter = new LineFormatter("[%datetime%] %channel%.%level_name%: %message%\n");
-        $streamHandler = new StreamHandler('php://output', $minLevel);
+        $streamHandler = new StreamHandler('php://stdout', $minLevel);
         $streamHandler->setFormatter($formatter);
         $this->logger = new Logger('Optimizely');
         $this->logger->pushHandler($streamHandler);


### PR DESCRIPTION
Output returns logs as part of the HTTP request
Stdout will log to stdout on the server