### PR TITLE
Make event payload log readable

### DIFF
--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -239,7 +239,7 @@ class Optimizely
             sprintf(
                 'Dispatching impression event to URL %s with params %s.',
                 $impressionEvent->getUrl(),
-                http_build_query($impressionEvent->getParams())
+                json_encode($impressionEvent->getParams())
             )
         );
 
@@ -356,7 +356,7 @@ class Optimizely
                 sprintf(
                     'Dispatching conversion event to URL %s with params %s.',
                     $conversionEvent->getUrl(),
-                    http_build_query($conversionEvent->getParams())
+                    json_encode($conversionEvent->getParams())
                 )
             );
 

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -889,7 +889,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(
                 Logger::DEBUG,
-                'Dispatching conversion event to URL logx.optimizely.com/track with params param1=val1.'
+                'Dispatching conversion event to URL logx.optimizely.com/track with params {"param1":"val1"}.'
             );
 
         $optlyObject = new Optimizely($this->datafile, new ValidEventDispatcher(), $this->loggerMock);
@@ -1027,7 +1027,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(
                 Logger::DEBUG,
-                'Dispatching conversion event to URL logx.optimizely.com/track with params param1=val1.'
+                'Dispatching conversion event to URL logx.optimizely.com/track with params {"param1":"val1"}.'
             );
 
         $optlyObject = new Optimizely($this->datafile, new ValidEventDispatcher(), $this->loggerMock);
@@ -1167,7 +1167,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(
                 Logger::DEBUG,
-                'Dispatching conversion event to URL logx.optimizely.com/track with params param1=val1.'
+                'Dispatching conversion event to URL logx.optimizely.com/track with params {"param1":"val1"}.'
             );
 
         $optlyObject = new Optimizely($this->datafile, new ValidEventDispatcher(), $this->loggerMock);
@@ -1303,7 +1303,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(
                 Logger::DEBUG,
-                'Dispatching conversion event to URL logx.optimizely.com/track with params param1=val1.'
+                'Dispatching conversion event to URL logx.optimizely.com/track with params {"param1":"val1"}.'
             );
 
         $optlyObject = new Optimizely($this->datafile, new ValidEventDispatcher(), $this->loggerMock);
@@ -1429,7 +1429,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(
                 Logger::DEBUG,
-                'Dispatching conversion event to URL logx.optimizely.com/track with params param1=val1.'
+                'Dispatching conversion event to URL logx.optimizely.com/track with params {"param1":"val1"}.'
             );
 
         $optlyObject = new Optimizely($this->datafile, new ValidEventDispatcher(), $this->loggerMock);
@@ -1524,7 +1524,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->with(Logger::INFO, 'Tracking event "purchase" for user "test_user".');
         $this->loggerMock->expects($this->at($callIndex++))
             ->method('log')
-            ->with(Logger::DEBUG, 'Dispatching conversion event to URL logx.optimizely.com/track with params param1=val1.');
+            ->with(Logger::DEBUG, 'Dispatching conversion event to URL logx.optimizely.com/track with params {"param1":"val1"}.');
 
         $optlyObject = new Optimizely($this->datafile, new ValidEventDispatcher(), $this->loggerMock);
 
@@ -1668,7 +1668,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(
                 Logger::DEBUG,
-                'Dispatching conversion event to URL logx.optimizely.com/track with params param1=val1.'
+                'Dispatching conversion event to URL logx.optimizely.com/track with params {"param1":"val1"}.'
             );
 
 
@@ -1808,7 +1808,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(
                 Logger::DEBUG,
-                'Dispatching conversion event to URL logx.optimizely.com/track with params param1=val1.'
+                'Dispatching conversion event to URL logx.optimizely.com/track with params {"param1":"val1"}.'
             );
 
         $optlyObject = new Optimizely($this->datafile, new ValidEventDispatcher(), $this->loggerMock);
@@ -3093,7 +3093,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(
                 Logger::DEBUG,
-                'Dispatching impression event to URL logx.optimizely.com/decision with params param1=val1&param2=val2.'
+                'Dispatching impression event to URL logx.optimizely.com/decision with params {"param1":"val1","param2":"val2"}.'
             );
 
         $optlyObject->sendImpressionEvent('group_experiment_1', 'group_exp_1_var_2', 'user_1', null);
@@ -3172,7 +3172,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(
                 Logger::DEBUG,
-                'Dispatching impression event to URL logx.optimizely.com/decision with params param1=val1.'
+                'Dispatching impression event to URL logx.optimizely.com/decision with params {"param1":"val1"}.'
             );
 
         $eventBuilder = new \ReflectionProperty(Optimizely::class, '_eventBuilder');


### PR DESCRIPTION
📝 Convert http_build_query to json_encode
**Current:** 

> URL https://logx.optimizely.com/v1/events with params account_id=7947771809&project_id=8168934166&visitors%5B0%5D%5Bsnapshots%5D%5B0%5D%5Bdecisions%5D%5B0%5D%5Bcampaign_id%5D=10165816054&visitors%5B0%5D%5Bsnapshots%5D%5B0%5D%5Bdecisions%5D%5B0%5D%5Bexperiment_id%5D=10160995869&visitors%5B0%5D%5Bsnapshots%5D%5B0%5D%5Bdecisions%5D%5B0%5D%5Bvariation_id%5D=10177144923&visitors%5B0%5D%5Bsnapshots%5D%5B0%5D%5Bevents%5D%5B0%5D%5Bentity_id%5D=8237670087&visitors%5B0%5D%5Bsnapshots%5D%5B0%5D%5Bevents%5D%5B0%5D%5Btimestamp%5D=1519383011000&visitors%5B0%5D%5Bsnapshots%5D%5B0%5D%5Bevents%5D%5B0%5D%5Buuid%5D=4e466784-8b2c-4d33-8ff2-9e3e198e2e0e&visitors%5B0%5D%5Bsnapshots%5D%5B0%5D%5Bevents%5D%5B0%5D%5Bkey%5D=order&visitors%5B0%5D%5Bsnapshots%5D%5B0%5D%5Bevents%5D%5B0%5D%5Brevenue%5D=3730&visitors%5B0%5D%5Bsnapshots%5D%5B0%5D%5Bevents%5D%5B0%5D%5Btags%5D%5Brevenue%5D=3730&visitors%5B0%5D%5Bvisitor_id%5D=mage_5a6bb6df4afdagQqT8M6l&revision=125&client_name=php-sdk&client_version=1.5.0&anonymize_ip=0.


**After json encode:**

> URL https://logx.optimizely.com/v1/events with params {"account_id":"7947771809","project_id":"8168934166","visitors":[{"snapshots":[{"decisions":[{"campaign_id":"10165816054","experiment_id":10160995869,"variation_id":"10177144923"}],"events":[{"entity_id":"8237670087","timestamp":1519382976000,"uuid":"2502765e-8cbc-45eb-a068-9f3989bce0ea","key":"order","revenue":3730,"tags":{"revenue":3730}}]}],"visitor_id":"mage_5a6bb6df4afdagQqT8M6l","attributes":[]}],"revision":"125","client_name":"php-sdk","client_version":"1.5.0","anonymize_ip":false}.