### PR TITLE
Add logger to getNumericValue in EventBuilder

### DIFF
--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2017, Optimizely
+ * Copyright 2016-2018, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,20 @@ class EventBuilder
     private static $HTTP_HEADERS = [
         'Content-Type' => 'application/json'
     ];
+
+    /**
+     * @var LoggerInterface Logger for logging messages.
+     */
+    private $_logger;
+
+    /**
+     * Event Builder constructor to set logger
+     * @param $logger LoggerInterface
+     */
+    public function __construct($logger)
+    {
+        $this->_logger = $logger;
+    }
 
     /**
      * Helper function to get parameters common to impression and conversion events.
@@ -194,7 +208,7 @@ class EventBuilder
                     $singleSnapshot[EVENTS][0][EventTagUtils::REVENUE_EVENT_METRIC_NAME] = $revenue;
                 }
 
-                $eventValue = EventTagUtils::getNumericValue($eventTags);
+                $eventValue = EventTagUtils::getNumericValue($eventTags, $this->_logger);
                 if (!is_null($eventValue)) {
                     $singleSnapshot[EVENTS][0][EventTagUtils::NUMERIC_EVENT_METRIC_NAME] = $eventValue;
                 }

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -135,7 +135,7 @@ class Optimizely
             return;
         }
 
-        $this->_eventBuilder = new EventBuilder();
+        $this->_eventBuilder = new EventBuilder($this->_logger);
         $this->_decisionService = new DecisionService($this->_logger, $this->_config, $userProfileService);
         $this->notificationCenter = new NotificationCenter($this->_logger, $this->_errorHandler);
     }

--- a/src/Optimizely/Utils/EventTagUtils.php
+++ b/src/Optimizely/Utils/EventTagUtils.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017, Optimizely
+ * Copyright 2017-2018, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,42 +62,40 @@ class EventTagUtils
      * The value of 'value' can be a float or a numeric string
      *
      * @param  $eventTags array Representing metadata associated with the event.
+     * @param $logger instance of LoggerInterface
+     *
      * @return float value of 'value' or null
      */
-    public static function getNumericValue($eventTags, LoggerInterface $logger = null)
+    public static function getNumericValue($eventTags, $logger)
     {
         if (!$eventTags) {
-            if ($logger) {
-                $logger->log(Logger::DEBUG, "Event tags is undefined.");
-            }
+            $logger->log(Logger::DEBUG, "Event tags is undefined.");
             return null;
-        } elseif (!is_array($eventTags)) {
-            if ($logger) {
-                $logger->log(Logger::DEBUG, "Event tags is not a dictionary.");
-            }
+        }
+
+        if (!is_array($eventTags)) {
+            $logger->log(Logger::DEBUG, "Event tags is not a dictionary.");
             return null;
-        } elseif (!isset($eventTags[self::NUMERIC_EVENT_METRIC_NAME])) {
-            if ($logger) {
-                $logger->log(Logger::DEBUG, "The numeric metric key is not defined in the event tags or is null.");
-            }
+        }
+
+        if (!isset($eventTags[self::NUMERIC_EVENT_METRIC_NAME])) {
+            $logger->log(Logger::DEBUG, "The numeric metric key is not defined in the event tags or is null.");
             return null;
-        } elseif (!is_numeric($eventTags[self::NUMERIC_EVENT_METRIC_NAME])) {
-            if ($logger) {
-                $logger->log(Logger::DEBUG, "Numeric metric value is not an integer or float, or is not a numeric string.");
-            }
+        }
+
+        if (!is_numeric($eventTags[self::NUMERIC_EVENT_METRIC_NAME])) {
+            $logger->log(Logger::DEBUG, "Numeric metric value is not an integer or float, or is not a numeric string.");
             return null;
-        } elseif (is_nan($eventTags[self::NUMERIC_EVENT_METRIC_NAME]) || is_infinite(floatval($eventTags[self::NUMERIC_EVENT_METRIC_NAME]))) {
-            if ($logger) {
-                $logger->log(Logger::DEBUG, "Provided numeric value is in an invalid format.");
-            }
+        }
+
+        if (is_nan($eventTags[self::NUMERIC_EVENT_METRIC_NAME]) || is_infinite(floatval($eventTags[self::NUMERIC_EVENT_METRIC_NAME]))) {
+            $logger->log(Logger::DEBUG, "Provided numeric value is in an invalid format.");
             return null;
         }
 
         $rawValue = $eventTags[self::NUMERIC_EVENT_METRIC_NAME];
         // # Log the final numeric metric value
-        if ($logger) {
-            $logger->log(Logger::INFO, "The numeric metric value {$rawValue} will be sent to results.");
-        }
+        $logger->log(Logger::INFO, "The numeric metric value {$rawValue} will be sent to results.");
 
         return floatval($rawValue);
     }

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -40,7 +40,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $this->testUserId = 'testUserId';
         $logger = new NoOpLogger();
         $this->config = new ProjectConfig(DATAFILE, $logger, new NoOpErrorHandler());
-        $this->eventBuilder = new EventBuilder();
+        $this->eventBuilder = new EventBuilder($logger);
         $this->timestamp = time()*1000;
         $this->uuid = 'a68cf1ad-0393-4e18-af87-efe8f01a7c9c';
         $this->differ = new Differ();

--- a/tests/NotificationTests/NotificationCenterTest.php
+++ b/tests/NotificationTests/NotificationCenterTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017, Optimizely
+ * Copyright 2017-2018, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,7 +125,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
         ///////////////////////////////////////////////////////////////////////////////////////////////////////
         // === should add, log and return notification ID when an object method is passed as an argument === //
         ///////////////////////////////////////////////////////////////////////////////////////////////////////
-        $eBuilder = new EventBuilder;
+        $eBuilder = new EventBuilder(new NoOpLogger());
         $callbackInput = array($eBuilder, 'createImpressionEvent');
 
         $this->loggerMock->expects($this->at(0))
@@ -289,7 +289,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
         /////////////////////////////////////////////////////////////////////////
         // ===== verify that an object method with same body isn't re-added ===== //
         /////////////////////////////////////////////////////////////////////////
-        $eBuilder = new EventBuilder;
+        $eBuilder = new EventBuilder(new NoOpLogger());
         $callbackInput = array($eBuilder, 'createImpressionEvent');
 
         $this->loggerMock->expects($this->at(0))

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -64,6 +64,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         // Mock EventBuilder
         $this->eventBuilderMock = $this->getMockBuilder(EventBuilder::class)
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('createImpressionEvent', 'createConversionEvent'))
             ->getMock();
 

--- a/tests/UtilsTests/EventTagUtilsTest.php
+++ b/tests/UtilsTests/EventTagUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017, Optimizely
+ * Copyright 2017-2018, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ class EventTagUtilsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => 'abcd'), $this->loggerMock));
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => true), $this->loggerMock));
-        $this->assertNull(EventTagUtils::getNumericValue(array('value' => array(1, 2, 3),$this->loggerMock)));
+        $this->assertNull(EventTagUtils::getNumericValue(array('value' => array(1, 2, 3)),$this->loggerMock));
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => false), $this->loggerMock));
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => array()), $this->loggerMock));
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => '1,234'), $this->loggerMock));


### PR DESCRIPTION
https://github.com/optimizely/php-sdk/pull/91 revealed that though we do log in EventTagUtils-getNumericValue(), we do not pass it a logger from event builder, thus nothing is logged in actual activate/track use case.  