### PR TITLE
Rashid/bucket variation bug

### DIFF
--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2017, Optimizely
+ * Copyright 2016-2018, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -127,7 +127,7 @@ class Bucketer
     public function bucket(ProjectConfig $config, Experiment $experiment, $bucketingId, $userId)
     {
         if (is_null($experiment->getKey())) {
-            return new Variation();
+            return null;
         }
 
         // Determine if experiment is in a mutually exclusive group.
@@ -135,13 +135,13 @@ class Bucketer
             $group = $config->getGroup($experiment->getGroupId());
 
             if (is_null($group->getId())) {
-                return new Variation();
+                return null;
             }
 
             $userExperimentId = $this->findBucket($bucketingId, $userId, $group->getId(), $group->getTrafficAllocation());
             if (empty($userExperimentId)) {
                 $this->_logger->log(Logger::INFO, sprintf('User "%s" is in no experiment.', $userId));
-                return new Variation();
+                return null;
             }
 
             if ($userExperimentId != $experiment->getId()) {
@@ -154,7 +154,7 @@ class Bucketer
                         $experiment->getGroupId()
                     )
                 );
-                return new Variation();
+                return null;
             }
 
             $this->_logger->log(
@@ -186,6 +186,6 @@ class Bucketer
         }
         
         $this->_logger->log(Logger::INFO, sprintf('User "%s" is in no variation.', $userId));
-        return new Variation();
+        return null;
     }
 }

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2017, Optimizely
+ * Copyright 2016-2018, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -107,8 +107,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::INFO, 'User "testUserId" is in no variation.');
 
-        $this->assertEquals(
-            new Variation(),
+        $this->assertNull(
             $bucketer->bucket(
                 $this->config,
                 $this->config->getExperimentFromKey('test_experiment'),
@@ -167,8 +166,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::INFO, 'User "testUserId" is in no variation.');
 
-        $this->assertEquals(
-            new Variation(),
+        $this->assertNull(
             $bucketer->bucket(
                 $this->config,
                 $this->config->getExperimentFromKey('test_experiment'),
@@ -271,8 +269,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::INFO, 'User "testUserId" is not in experiment group_experiment_1 of group 7722400015.');
 
-        $this->assertEquals(
-            new Variation(),
+        $this->assertNull(
             $bucketer->bucket(
                 $this->config,
                 $this->config->getExperimentFromKey('group_experiment_1'),
@@ -290,8 +287,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::INFO, 'User "testUserId" is in no experiment.');
 
-        $this->assertEquals(
-            new Variation(),
+        $this->assertNull(
             $bucketer->bucket(
                 $this->config,
                 $this->config->getExperimentFromKey('group_experiment_1'),
@@ -308,8 +304,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
         $this->loggerMock->expects($this->at(1))
             ->method('log')
             ->with(Logger::INFO, 'User "testUserId" is in no experiment.');
-        $this->assertEquals(
-            new Variation(),
+        $this->assertNull(
             $bucketer->bucket(
                 $this->config,
                 $this->config->getExperimentFromKey('group_experiment_1'),
@@ -325,8 +320,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
         $this->loggerMock->expects($this->never())
             ->method('log');
 
-        $this->assertEquals(
-            new Variation(),
+        $this->assertNull(
             $bucketer->bucket($this->config, new Experiment(), $this->testBucketingIdControl, $this->testUserId)
         );
     }
@@ -356,8 +350,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
         $bucketer = new TestBucketer($this->loggerMock);
         $bucketer->setBucketValues([1000, 3000, 7000, 9000]);
 
-        $this->assertEquals(
-            new Variation(),
+        $this->assertNull(
             $bucketer->bucket(
                 $this->config,
                 $this->config->getExperimentFromKey('invalid_experiment'),
@@ -430,8 +423,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->assertEquals(
-            new Variation(),
+        $this->assertNull(
             $bucketer->bucket(
                 $this->config,
                 $rollout_rule,


### PR DESCRIPTION
Ok, we investigated this issue and it is in PHP-SDK, instead of returning NULL, variation empty object was returned when user is not bucketed. and in the is_featureenabled we had a condition if variation is NULL then return false. so it was always returning true because of empty variation object and getenabledfeatures was using that isfeatureenabled method. 

https://github.com/optimizely/php-testapp/issues/16