### PR TITLE
Add prefix to PSR-4 autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "autoload": {
     "psr-4": {
-      "": "src/"
+      "Optimizely\\": "src/Optimizely"
     }
   }
 }


### PR DESCRIPTION
PSR-4 autoloaders with no prefix can hurt performance, especially in large projects with many dependencies. When resolving class names to files, if Composer cannot use a prefix to limit the search paths, it has to search every autoloader with a blank prefix.

This change adds a prefix to the autoloader, to avoid this problem.

Running `composer diagnose` previously reported this:

```
~/src/php-sdk % composer diagnose
Checking composer.json: WARNING
Defining autoload.psr-4 with an empty namespace prefix is a bad idea for performance
```

With this change, `composer diagnose` is happy.

I couldn't add tests for this, because it's not a code change. But, I did run the test suite to verify that it everything still passes as expected.