### PR TITLE
fix(setForcedVariation): Treats empty variation key as invalid and does not reset forced variation.

### DIFF
--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -54,6 +54,7 @@ class Optimizely
     const FEATURE_FLAG_KEY = 'Feature Flag Key';
     const USER_ID = 'User ID';
     const VARIABLE_KEY = 'Variable Key';
+    const VARIATION_KEY = 'Variation Key';
 
     /**
      * @var ProjectConfig

--- a/src/Optimizely/ProjectConfig.php
+++ b/src/Optimizely/ProjectConfig.php
@@ -42,6 +42,8 @@ use Optimizely\Exceptions\InvalidVariationException;
 use Optimizely\Logger\LoggerInterface;
 use Optimizely\Utils\ConditionDecoder;
 use Optimizely\Utils\ConfigParser;
+use Optimizely\Utils\Errors;
+use Optimizely\Utils\Validator;
 
 /**
  * Class ProjectConfig
@@ -644,6 +646,12 @@ class ProjectConfig
         // check for null and empty string user ID
         if (strlen($userId) == 0) {
             $this->_logger->log(Logger::DEBUG, 'User ID is invalid');
+            return false;
+        }
+
+        // check for empty string Variation key
+        if (!is_null($variationKey) && !Validator::validateNonEmptyString($variationKey)) {
+            $this->_logger->log(Logger::ERROR, sprintf(Errors::INVALID_FORMAT, Optimizely::VARIATION_KEY));
             return false;
         }
 

--- a/tests/ProjectConfigTest.php
+++ b/tests/ProjectConfigTest.php
@@ -715,7 +715,7 @@ class ProjectConfigTest extends \PHPUnit_Framework_TestCase
         $invalidVariationKey = 'invalid_variation';
         $callIndex = 0;
 
-        $this->loggerMock->expects($this->exactly(4))
+        $this->loggerMock->expects($this->exactly(5))
             ->method('log');
         $this->loggerMock->expects($this->at($callIndex++))
             ->method('log')
@@ -723,6 +723,9 @@ class ProjectConfigTest extends \PHPUnit_Framework_TestCase
         $this->loggerMock->expects($this->at($callIndex++))
             ->method('log')
             ->with(Logger::DEBUG, sprintf('Variation mapped to experiment "%s" has been removed for user "%s".', $experimentKey, $userId));
+        $this->loggerMock->expects($this->at($callIndex++))
+            ->method('log')
+            ->with(Logger::ERROR, sprintf('Provided %s is in an invalid format.', Optimizely::VARIATION_KEY));
         $this->loggerMock->expects($this->at($callIndex++))
             ->method('log')
             ->with(Logger::ERROR, sprintf('No variation key "%s" defined in datafile for experiment "%s".', $invalidVariationKey, $experimentKey));
@@ -734,6 +737,7 @@ class ProjectConfigTest extends \PHPUnit_Framework_TestCase
 
         $this->config->setForcedVariation($invalidExperimentKey, $userId, $variationKey);
         $this->config->setForcedVariation($experimentKey, $userId, null);
+        $this->config->setForcedVariation($experimentKey, $userId, '');
         $this->config->setForcedVariation($experimentKey, $userId, $invalidVariationKey);
         $this->config->setForcedVariation($experimentKey, $userId, $variationKey);
     }


### PR DESCRIPTION
## Summary
Forced variation key passed as an empty String will be invalid argument.
- Updated inputs validation for setForcedVariation.
- Updated unit tests for empty string variation key.
