### PR TITLE
fix(generateBucketValue): Avoid negative bucket number for PHP x86

### DIFF
--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -86,7 +86,13 @@ class Bucketer
     {
         $hashCode = $this->generateHashCode($bucketingKey);
         $ratio = $hashCode / Bucketer::$MAX_HASH_VALUE;
-        return intval(floor($ratio * Bucketer::$MAX_TRAFFIC_VALUE));
+        $bucketVal = intval(floor($ratio * Bucketer::$MAX_TRAFFIC_VALUE));
+
+        if ($bucketVal < 0) {
+            $bucketVal += 10000;
+        }
+
+        return $bucketVal;
     }
 
     /**


### PR DESCRIPTION
## Summary
on x86, when 32 bit hash code is generated, it overflows and fall into float type which causes the number into negative and beyond out of range. 

The "why", or other context.

## Test plan

## Issues
- "THING-1234" or "Fixes #123"
