### PR TITLE
docs (generateBucketValue): Reasoning for incrementing bucket num by 10,000 for x86

### DIFF
--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -88,13 +88,13 @@ class Bucketer
         $ratio = $hashCode / Bucketer::$MAX_HASH_VALUE;
         $bucketVal = intval(floor($ratio * Bucketer::$MAX_TRAFFIC_VALUE));
 
-        // murmurhash3_int returns both positive and negative integers for PHP x86 versions
-        // it returns negative integers when it tries to create 2^32 integers while PHP doesn't support
-        // unsigned integers and can store integers only upto 2^31. 
-        // Observing generated hashcodes and their corresponding bucket values after normalization
-        // indicates that a negative bucket number on x86 is exactly 10,000 less than it's 
-        // corresponding bucket number on x64. Hence we can safely add 10,000 to a negative number to
-        // make it consistent across both of the PHP variants.
+        /* murmurhash3_int returns both positive and negative integers for PHP x86 versions
+        it returns negative integers when it tries to create 2^32 integers while PHP doesn't support
+        unsigned integers and can store integers only upto 2^31. 
+        Observing generated hashcodes and their corresponding bucket values after normalization
+        indicates that a negative bucket number on x86 is exactly 10,000 less than it's 
+        corresponding bucket number on x64. Hence we can safely add 10,000 to a negative number to
+        make it consistent across both of the PHP variants. */
         
         if ($bucketVal < 0) {
             $bucketVal += 10000;

--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -88,6 +88,14 @@ class Bucketer
         $ratio = $hashCode / Bucketer::$MAX_HASH_VALUE;
         $bucketVal = intval(floor($ratio * Bucketer::$MAX_TRAFFIC_VALUE));
 
+        // murmurhash3_int returns both positive and negative integers for PHP x86 versions
+        // it returns negative integers when it tries to create 2^32 integers while PHP doesn't support
+        // unsigned integers and can store integers only upto 2^31. 
+        // Observing generated hashcodes and their corresponding bucket values after normalization
+        // indicates that a negative bucket number on x86 is exactly 10,000 less than it's 
+        // corresponding bucket number on x64. Hence we can safely add 10,000 to a negative number to
+        // make it consistent across both of the PHP variants.
+        
         if ($bucketVal < 0) {
             $bucketVal += 10000;
         }


### PR DESCRIPTION
## Summary
docs for change in https://github.com/optimizely/php-sdk/pull/137

## Test plan

## Issues
- OASIS-3730
