### PR TITLE
feat(attribute_value): Don't target NAN, INF, -INF and > 2^53

### DIFF
--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -110,7 +110,7 @@ class Validator
             return false;
         }        
 
-        if (abs($value) > (2**53)) {
+        if (abs($value) > pow(2,53)) {
             return false;
         }
 

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -71,11 +71,35 @@ class Validator
     }
 
     /**
+     * @param $value The value to validate.
+     *
+     * @return boolean Representing whether attribute's value is
+     * a number and not NAN, INF, -INF or greater than absolute limit of 2^53.
+     */
+    public static function isFiniteNumber($value)
+    {
+        if (!(is_int($value) || is_float($value))) {
+            return false;
+        }
+       
+        if (is_nan($value) || is_infinite($value)) {
+            return false;
+        }        
+
+        if (abs($value) > pow(2, 53)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * @param $attributeKey The key to validate.
      * @param $attributeValue The value to validate.
      *
      * @return boolean Representing whether attribute's key and value are
-     * valid for event payload or not.
+     * valid for event payload or not. Valid attribute key must be a string.
+     * Valid attribute value can be a string, bool, or a finite number.
      */
     public static function isAttributeValid($attributeKey, $attributeValue)
     {
@@ -92,29 +116,6 @@ class Validator
         }
 
         return false;
-    }
-
-    /**
-     * @param $value The value to validate.
-     *
-     * @return boolean Representing whether attribute's value is
-     * a number and not NAN, INF, -INF or greater than 2^53.
-     */
-    public static function isFiniteNumber($value)
-    {
-        if (!(is_int($value) || is_float($value))) {
-            return false;
-        }
-       
-        if (is_nan($value) || is_infinite($value)) {
-            return false;
-        }        
-
-        if (abs($value) > pow(2,53)) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -79,8 +79,42 @@ class Validator
      */
     public static function isAttributeValid($attributeKey, $attributeValue)
     {
-        $validTypes = array('boolean', 'double', 'integer', 'string');
-        return is_string($attributeKey) && in_array(gettype($attributeValue), $validTypes);
+        if (!is_string($attributeKey)) {
+            return false;
+        }
+
+        if (is_string($attributeValue) || is_bool($attributeValue)) {
+            return true;
+        }
+
+        if (is_int($attributeValue) || is_float($attributeValue)) {
+            return Validator::isFiniteNumber($attributeValue);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param $value The value to validate.
+     *
+     * @return boolean Representing whether attribute's value is
+     * a number and not NAN, INF, -INF or greater than 2^53.
+     */
+    public static function isFiniteNumber($value)
+    {
+        if (!(is_int($value) || is_float($value))) {
+            return false;
+        }
+       
+        if (is_nan($value) || is_infinite($value)) {
+            return false;
+        }        
+
+        if (abs($value) > (2**53)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -134,10 +134,10 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(Validator::IsFiniteNumber(INF));
         $this->assertFalse(Validator::IsFiniteNumber(-INF));
         $this->assertFalse(Validator::IsFiniteNumber(NAN));
-        $this->assertFalse(Validator::IsFiniteNumber((2**53) + 1));
-        $this->assertFalse(Validator::IsFiniteNumber(-(2**53) - 1));
-        $this->assertFalse(Validator::IsFiniteNumber((2**53) + 2.0));
-        $this->assertFalse(Validator::IsFiniteNumber(-(2**53) - 2.0));
+        $this->assertFalse(Validator::IsFiniteNumber(pow(2,53) + 1));
+        $this->assertFalse(Validator::IsFiniteNumber(-pow(2,53) - 1));
+        $this->assertFalse(Validator::IsFiniteNumber(pow(2,53) + 2.0));
+        $this->assertFalse(Validator::IsFiniteNumber(-pow(2,53) - 2.0));
     }
 
     public function testIsFiniteNumberWithValidValues()
@@ -145,9 +145,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Validator::IsFiniteNumber(0));
         $this->assertTrue(Validator::IsFiniteNumber(5));
         $this->assertTrue(Validator::IsFiniteNumber(5.5));
-        $this->assertTrue(Validator::IsFiniteNumber((2**53) + 1.0));
-        $this->assertTrue(Validator::IsFiniteNumber(-(2**53) - 1.0));
-        $this->assertTrue(Validator::IsFiniteNumber((2**53)));
+        $this->assertTrue(Validator::IsFiniteNumber(pow(2,53) + 1.0));
+        $this->assertTrue(Validator::IsFiniteNumber(-pow(2,53) - 1.0));
+        $this->assertTrue(Validator::IsFiniteNumber(pow(2,53)));
     }
 
     public function testAreEventTagsValidValidEventTags()

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -123,6 +123,33 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(Validator::isAttributeValid(5.5, 'value'));
     }
 
+    public function testIsFiniteNumberWithInvalidValues()
+    {
+        $this->assertFalse(Validator::IsFiniteNumber('HelloWorld'));
+        $this->assertFalse(Validator::IsFiniteNumber(true));
+        $this->assertFalse(Validator::IsFiniteNumber(false));
+        $this->assertFalse(Validator::IsFiniteNumber(null));
+        $this->assertFalse(Validator::IsFiniteNumber((object)[]));
+        $this->assertFalse(Validator::IsFiniteNumber([]));
+        $this->assertFalse(Validator::IsFiniteNumber(INF));
+        $this->assertFalse(Validator::IsFiniteNumber(-INF));
+        $this->assertFalse(Validator::IsFiniteNumber(NAN));
+        $this->assertFalse(Validator::IsFiniteNumber((2**53) + 1));
+        $this->assertFalse(Validator::IsFiniteNumber(-(2**53) - 1));
+        $this->assertFalse(Validator::IsFiniteNumber((2**53) + 2.0));
+        $this->assertFalse(Validator::IsFiniteNumber(-(2**53) - 2.0));
+    }
+
+    public function testIsFiniteNumberWithValidValues()
+    {
+        $this->assertTrue(Validator::IsFiniteNumber(0));
+        $this->assertTrue(Validator::IsFiniteNumber(5));
+        $this->assertTrue(Validator::IsFiniteNumber(5.5));
+        $this->assertTrue(Validator::IsFiniteNumber((2**53) + 1.0));
+        $this->assertTrue(Validator::IsFiniteNumber(-(2**53) - 1.0));
+        $this->assertTrue(Validator::IsFiniteNumber((2**53)));
+    }
+
     public function testAreEventTagsValidValidEventTags()
     {
         // Empty attributes

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -145,6 +145,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Validator::IsFiniteNumber(0));
         $this->assertTrue(Validator::IsFiniteNumber(5));
         $this->assertTrue(Validator::IsFiniteNumber(5.5));
+        // float(2**53) + 1.0 evaluates to float(2**53)
         $this->assertTrue(Validator::IsFiniteNumber(pow(2,53) + 1.0));
         $this->assertTrue(Validator::IsFiniteNumber(-pow(2,53) - 1.0));
         $this->assertTrue(Validator::IsFiniteNumber(pow(2,53)));

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -145,7 +145,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Validator::IsFiniteNumber(0));
         $this->assertTrue(Validator::IsFiniteNumber(5));
         $this->assertTrue(Validator::IsFiniteNumber(5.5));
-        // float(2**53) + 1.0 evaluates to float(2**53)
+        // float pow(2,53) + 1.0 evaluates to float pow(2,53)
         $this->assertTrue(Validator::IsFiniteNumber(pow(2,53) + 1.0));
         $this->assertTrue(Validator::IsFiniteNumber(-pow(2,53) - 1.0));
         $this->assertTrue(Validator::IsFiniteNumber(pow(2,53)));


### PR DESCRIPTION
Summary
-------
Don't target NAN, INF or -INF doubles
Don't target Values > 2^53.
Both in EventBuilder payload and Audience Evaluation

## Test plan

## Issues
- OASIS-3656
- https://github.com/optimizely/python-sdk/pull/146#discussion_r237850806
