### PR TITLE
fix(audience evaluation): evaluate unknown audience id to null and continue

### DIFF
--- a/src/Optimizely/ProjectConfig.php
+++ b/src/Optimizely/ProjectConfig.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016, 2018, Optimizely
+ * Copyright 2016, 2018-2019 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -455,7 +455,7 @@ class ProjectConfig
      * @param $audienceId string ID of the audience.
      *
      * @return Audience Entity corresponding to the ID.
-     *         Dummy entity is returned if ID is invalid.
+     *         Null is returned if ID is invalid.
      */
     public function getAudience($audienceId)
     {
@@ -465,7 +465,8 @@ class ProjectConfig
 
         $this->_logger->log(Logger::ERROR, sprintf('Audience ID "%s" is not in datafile.', $audienceId));
         $this->_errorHandler->handleError(new InvalidAudienceException('Provided audience is not in datafile.'));
-        return new Audience();
+
+        return null;
     }
 
     /**

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,7 +160,12 @@ class Validator
 
         $evaluateAudience = function($audienceId) use ($config, $evaluateCustomAttr) {
             $conditionTreeEvaluator = new ConditionTreeEvaluator();
+
             $audience = $config->getAudience($audienceId);
+            if ($audience === null) {
+                return null;
+            }
+
             return $conditionTreeEvaluator->evaluate($audience->getConditionsList(), $evaluateCustomAttr);
         };
 

--- a/tests/ProjectConfigTest.php
+++ b/tests/ProjectConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -546,7 +546,7 @@ class ProjectConfigTest extends \PHPUnit_Framework_TestCase
             ->method('handleError')
             ->with(new InvalidAudienceException('Provided audience is not in datafile.'));
 
-        $this->assertEquals(new Audience(), $this->config->getAudience('invalid_id'));
+        $this->assertNull($this->config->getAudience('invalid_id'));
     }
 
     public function testGetAttributeValidKey()

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -336,6 +336,24 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         // Both audience Ids and audience conditions exist. Audience Ids is ignored.
         $experiment->setAudienceIds([]);
         $experiment->setAudienceConditions('7718080042');
+        
+        $this->assertTrue(
+            Validator::isUserInExperiment(
+                $config,
+                $experiment,
+                ['device_type' => 'iPhone', 'location' => 'San Francisco']
+            )
+        );
+    }
+
+    public function testIsUserInExperimentWithUnknownAudienceId()
+    {
+        $config = new ProjectConfig(DATAFILE, $this->loggerMock, new NoOpErrorHandler());
+        $experiment = $config->getExperimentFromKey('test_experiment');
+
+        // Both audience Ids and audience conditions exist. Audience Ids is ignored.
+        $experiment->setAudienceIds([]);
+        $experiment->setAudienceConditions(["or", "unknown_audience_id", "7718080042"]);
         
         $this->assertTrue(
             Validator::isUserInExperiment(

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -355,6 +355,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $experiment->setAudienceIds([]);
         $experiment->setAudienceConditions(["or", "unknown_audience_id", "7718080042"]);
         
+        // User qualifies for audience with ID "7718080042".
         $this->assertTrue(
             Validator::isUserInExperiment(
                 $config,


### PR DESCRIPTION
## Summary
In Audience Evaluation, evaluate unknown audience to null and continue evaluation for other audiences. 
Though we trust the datafile generation part won't generate such scenario, we still check to sync up with compat suite test here:
https://github.com/optimizely/fullstack-sdk-compatibility-suite/pull/196

## Test plan
Ran compatibility suite including audience combination tests. 

## Issues
- OASIS-3921
