### PR TITLE
feat(Audience Evaluation): Audience Logging

### DIFF
--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -93,8 +93,8 @@ class DecisionService
     {
         $bucketingIdKey = ControlAttributes::BUCKETING_ID;
 
-        if (isset($userAttributes[$bucketingIdKey])){
-            if (is_string($userAttributes[$bucketingIdKey])){
+        if (isset($userAttributes[$bucketingIdKey])) {
+            if (is_string($userAttributes[$bucketingIdKey])) {
                 return $userAttributes[$bucketingIdKey];
             }
             $this->_logger->log(Logger::WARNING, 'Bucketing ID attribute is not a string. Defaulted to user ID.');

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2018, Optimizely Inc and Contributors
+ * Copyright 2017-2019, Optimizely Inc and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,7 +145,7 @@ class DecisionService
             }
         }
 
-        if (!Validator::isUserInExperiment($this->_projectConfig, $experiment, $attributes)) {
+        if (!Validator::isUserInExperiment($this->_projectConfig, $experiment, $attributes, $this->_logger)) {
             $this->_logger->log(
                 Logger::INFO,
                 sprintf('User "%s" does not meet conditions to be in experiment "%s".', $userId, $experiment->getKey())
@@ -188,10 +188,10 @@ class DecisionService
                 Logger::INFO,
                 "User '{$userId}' is bucketed into rollout for feature flag '{$featureFlag->getKey()}'."
             );
-      
+
             return $decision;
         }
-            
+
         $this->_logger->log(
             Logger::INFO,
             "User '{$userId}' is not bucketed into rollout for feature flag '{$featureFlag->getKey()}'."
@@ -291,7 +291,7 @@ class DecisionService
             $experiment = $rolloutRules[$i];
 
             // Evaluate if user meets the audience condition of this rollout rule
-            if (!Validator::isUserInExperiment($this->_projectConfig, $experiment, $userAttributes)) {
+            if (!Validator::isUserInExperiment($this->_projectConfig, $experiment, $userAttributes, $this->_logger)) {
                 $this->_logger->log(
                     Logger::DEBUG,
                     sprintf("User '%s' did not meet the audience conditions to be in rollout rule '%s'.", $userId, $experiment->getKey())
@@ -308,17 +308,17 @@ class DecisionService
             break;
         }
         // Evaluate Everyone Else Rule / Last Rule now
-        $experiment = $rolloutRules[sizeof($rolloutRules)-1];        
-        
+        $experiment = $rolloutRules[sizeof($rolloutRules)-1];
+
         // Evaluate if user meets the audience condition of Everyone Else Rule / Last Rule now
-        if (!Validator::isUserInExperiment($this->_projectConfig, $experiment, $userAttributes)) {
+        if (!Validator::isUserInExperiment($this->_projectConfig, $experiment, $userAttributes, $this->_logger)) {
             $this->_logger->log(
                 Logger::DEBUG,
                 sprintf("User '%s' did not meet the audience conditions to be in rollout rule '%s'.", $userId, $experiment->getKey())
             );
             return null;
         }
-        
+
         $variation = $this->_bucketer->bucket($this->_projectConfig, $experiment, $bucketing_id, $userId);
         if ($variation && $variation->getKey()) {
             return new FeatureDecision($experiment, $variation, FeatureDecision::DECISION_SOURCE_ROLLOUT);

--- a/src/Optimizely/Enums/AudienceEvaluationLogs.php
+++ b/src/Optimizely/Enums/AudienceEvaluationLogs.php
@@ -23,11 +23,13 @@ class AudienceEvaluationLogs
     const AUDIENCE_EVALUATION_RESULT_COMBINED = "Audiences for experiment \"%s\" collectively evaluated to %s.";
     const EVALUATING_AUDIENCES = "Evaluating audiences for experiment \"%s\": \"%s\".";
     const EVALUATING_AUDIENCE_WITH_CONDITIONS = "Starting to evaluate audience \"%s\" with conditions: \"%s\".";
+    const INFINITE_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN for user attribute \"%s\" is not in the range [-2^53, +2^53].";
     const MISSING_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN because no value was passed for user attribute \"%s\".";
     const NO_AUDIENCE_ATTACHED = "No Audience attached to experiment \"%s\". Evaluated to True.";
     const NULL_ATTRIBUTE_VALUE = "Audience condition \"%s\" evaluated to UNKNOWN because a null value was passed for user attribute \"%s\".";
     const UNEXPECTED_TYPE = "Audience condition %s evaluated to UNKNOWN because a value of type \"%s\" was passed for user attribute \"%s\".";
 
     const UNKNOWN_CONDITION_TYPE = "Audience condition \"%s\" uses an unknown condition type. You may need to upgrade to anewer release of the Optimizely SDK.";
+    const UNKNOWN_CONDITION_VALUE = "Audience condition \"%s\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.";
     const UNKNOWN_MATCH_TYPE = "Audience condition \"%s\" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK.";
 }

--- a/src/Optimizely/Enums/AudienceEvaluationLogs.php
+++ b/src/Optimizely/Enums/AudienceEvaluationLogs.php
@@ -21,11 +21,10 @@ class AudienceEvaluationLogs
 {
     const AUDIENCE_EVALUATION_RESULT = "Audience \"%s\" evaluated to %s.";
     const AUDIENCE_EVALUATION_RESULT_COMBINED = "Audiences for experiment \"%s\" collectively evaluated to %s.";
-    const EVALUATING_AUDIENCES = "Evaluating audiences for experiment \"%s\": \"%s\".";
-    const EVALUATING_AUDIENCE_WITH_CONDITIONS = "Starting to evaluate audience \"%s\" with conditions: \"%s\".";
+    const EVALUATING_AUDIENCES_COMBINED = "Evaluating audiences for experiment \"%s\": %s.";
+    const EVALUATING_AUDIENCE = "Starting to evaluate audience \"%s\" with conditions: \"%s\".";
     const INFINITE_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN for user attribute \"%s\" is not in the range [-2^53, +2^53].";
     const MISSING_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN because no value was passed for user attribute \"%s\".";
-    const NO_AUDIENCE_ATTACHED = "No Audience attached to experiment \"%s\". Evaluated to True.";
     const NULL_ATTRIBUTE_VALUE = "Audience condition \"%s\" evaluated to UNKNOWN because a null value was passed for user attribute \"%s\".";
     const UNEXPECTED_TYPE = "Audience condition %s evaluated to UNKNOWN because a value of type \"%s\" was passed for user attribute \"%s\".";
 

--- a/src/Optimizely/Enums/AudienceEvaluationLogs.php
+++ b/src/Optimizely/Enums/AudienceEvaluationLogs.php
@@ -23,12 +23,12 @@ class AudienceEvaluationLogs
     const AUDIENCE_EVALUATION_RESULT_COMBINED = "Audiences for experiment \"%s\" collectively evaluated to %s.";
     const EVALUATING_AUDIENCES_COMBINED = "Evaluating audiences for experiment \"%s\": %s.";
     const EVALUATING_AUDIENCE = "Starting to evaluate audience \"%s\" with conditions: %s.";
-    const INFINITE_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN for user attribute \"%s\" is not in the range [-2^53, +2^53].";
+    const INFINITE_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN because the number value for user attribute \"%s\" is not in the range [-2^53, +2^53].";
     const MISSING_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN because no value was passed for user attribute \"%s\".";
-    const NULL_ATTRIBUTE_VALUE = "Audience condition \"%s\" evaluated to UNKNOWN because a null value was passed for user attribute \"%s\".";
+    const NULL_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN because a null value was passed for user attribute \"%s\".";
     const UNEXPECTED_TYPE = "Audience condition %s evaluated to UNKNOWN because a value of type \"%s\" was passed for user attribute \"%s\".";
 
-    const UNKNOWN_CONDITION_TYPE = "Audience condition \"%s\" uses an unknown condition type. You may need to upgrade to anewer release of the Optimizely SDK.";
-    const UNKNOWN_CONDITION_VALUE = "Audience condition \"%s\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.";
-    const UNKNOWN_MATCH_TYPE = "Audience condition \"%s\" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK.";
+    const UNKNOWN_CONDITION_TYPE = "Audience condition %s uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK.";
+    const UNKNOWN_CONDITION_VALUE = "Audience condition %s has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.";
+    const UNKNOWN_MATCH_TYPE = "Audience condition %s uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK.";
 }

--- a/src/Optimizely/Enums/AudienceEvaluationLogs.php
+++ b/src/Optimizely/Enums/AudienceEvaluationLogs.php
@@ -19,15 +19,15 @@ namespace Optimizely\Enums;
 
 class AudienceEvaluationLogs
 {
-    const AUDIENCE_EVALUATION_RESULT = "Audience \"%s\" evaluated as %s.";
-    const AUDIENCE_EVALUATION_RESULT_COMBINED = "Audiences for experiment \"%s\" collectively evaluated as %s.";
+    const AUDIENCE_EVALUATION_RESULT = "Audience \"%s\" evaluated to %s.";
+    const AUDIENCE_EVALUATION_RESULT_COMBINED = "Audiences for experiment \"%s\" collectively evaluated to %s.";
     const EVALUATING_AUDIENCES = "Evaluating audiences for experiment \"%s\": \"%s\".";
     const EVALUATING_AUDIENCE_WITH_CONDITIONS = "Starting to evaluate audience \"%s\" with conditions: \"%s\".";
-    const MISMATCH_TYPE = "Audience condition %s evaluated as UNKNOWN because the value for user attribute \"%s\" is \"%s\" while expected is \"%s\".";
-    const MISSING_ATTRIBUTE_VALUE = "Audience condition %s evaluated as UNKNOWN because no value was passed for user attribute \"%s\".";
-    const NO_AUDIENCE_ATTACHED = "No Audience attached to experiment \"%s\". Evaluated as True.";
-    const UNEXPECTED_TYPE = "Audience condition %s evaluated as UNKNOWN because the value for user attribute \"%s\" is inapplicable: \"%s\".";
-    const UNKNOWN_CONDITION_TYPE = "Audience condition \"%s\" has an unknown condition type.";
-    const UNKNOWN_MATCH_TYPE = "Audience condition \"%s\" uses an unknown match type.";
-    const USER_ATTRIBUTES = "User attributes: \"%s\".";
+    const MISSING_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN because no value was passed for user attribute \"%s\".";
+    const NO_AUDIENCE_ATTACHED = "No Audience attached to experiment \"%s\". Evaluated to True.";
+    const NULL_ATTRIBUTE_VALUE = "Audience condition \"%s\" evaluated to UNKNOWN because a null value was passed for user attribute \"%s\".";
+    const UNEXPECTED_TYPE = "Audience condition %s evaluated to UNKNOWN because a value of type \"%s\" was passed for user attribute \"%s\".";
+
+    const UNKNOWN_CONDITION_TYPE = "Audience condition \"%s\" uses an unknown condition type. You may need to upgrade to anewer release of the Optimizely SDK.";
+    const UNKNOWN_MATCH_TYPE = "Audience condition \"%s\" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK.";
 }

--- a/src/Optimizely/Enums/AudienceEvaluationLogs.php
+++ b/src/Optimizely/Enums/AudienceEvaluationLogs.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright 2019, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Optimizely\Enums;
+
+class AudienceEvaluationLogs
+{
+    const AUDIENCE_EVALUATION_RESULT = "Audience \"%s\" evaluated as %s.";
+    const AUDIENCE_EVALUATION_RESULT_COMBINED = "Audiences for experiment \"%s\" collectively evaluated as %s.";
+    const EVALUATING_AUDIENCES = "Evaluating audiences for experiment \"%s\": \"%s\".";
+    const EVALUATING_AUDIENCE_WITH_CONDITIONS = "Starting to evaluate audience \"%s\" with conditions: \"%s\".";
+    const MISMATCH_TYPE = "Audience condition %s evaluated as UNKNOWN because the value for user attribute \"%s\" is \"%s\" while expected is \"%s\".";
+    const MISSING_ATTRIBUTE_VALUE = "Audience condition %s evaluated as UNKNOWN because no value was passed for user attribute \"%s\".";
+    const NO_AUDIENCE_ATTACHED = "No Audience attached to experiment \"%s\". Evaluated as True.";
+    const UNEXPECTED_TYPE = "Audience condition %s evaluated as UNKNOWN because the value for user attribute \"%s\" is inapplicable: \"%s\".";
+    const UNKNOWN_CONDITION_TYPE = "Audience condition \"%s\" has an unknown condition type.";
+    const UNKNOWN_MATCH_TYPE = "Audience condition \"%s\" uses an unknown match type.";
+    const USER_ATTRIBUTES = "User attributes: \"%s\".";
+}

--- a/src/Optimizely/Enums/AudienceEvaluationLogs.php
+++ b/src/Optimizely/Enums/AudienceEvaluationLogs.php
@@ -22,7 +22,7 @@ class AudienceEvaluationLogs
     const AUDIENCE_EVALUATION_RESULT = "Audience \"%s\" evaluated to %s.";
     const AUDIENCE_EVALUATION_RESULT_COMBINED = "Audiences for experiment \"%s\" collectively evaluated to %s.";
     const EVALUATING_AUDIENCES_COMBINED = "Evaluating audiences for experiment \"%s\": %s.";
-    const EVALUATING_AUDIENCE = "Starting to evaluate audience \"%s\" with conditions: \"%s\".";
+    const EVALUATING_AUDIENCE = "Starting to evaluate audience \"%s\" with conditions: %s.";
     const INFINITE_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN for user attribute \"%s\" is not in the range [-2^53, +2^53].";
     const MISSING_ATTRIBUTE_VALUE = "Audience condition %s evaluated to UNKNOWN because no value was passed for user attribute \"%s\".";
     const NULL_ATTRIBUTE_VALUE = "Audience condition \"%s\" evaluated to UNKNOWN because a null value was passed for user attribute \"%s\".";

--- a/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
+++ b/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
@@ -98,11 +98,11 @@ class CustomAttributeConditionEvaluator
      *
      * @param  $value Input to check.
      *
-     * @return boolean true if given input is a string/boolean/finite number, false otherwise.
+     * @return boolean true if given input is a string/boolean/number, false otherwise.
      */
-    protected function isValueValidForExactConditions($value)
+    protected function isValueTypeValidForExactConditions($value)
     {
-        if (is_string($value) || is_bool($value) || Validator::isFiniteNumber($value)) {
+        if (is_string($value) || is_bool($value) || is_int($value) || is_float($value)) {
             return true;
         }
 
@@ -126,16 +126,8 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if ((is_int($userValue) || is_float($userValue)) && !Validator::isFiniteNumber($userValue)) {
-            $this->logger->log(Logger::DEBUG, sprintf(
-                logs::INFINITE_ATTRIBUTE_VALUE,
-                json_encode($condition),
-                $conditionName
-            ));
-            return null;
-        }
-
-        if (!$this->isValueValidForExactConditions($conditionValue)) {
+        if (!$this->isValueTypeValidForExactConditions($conditionValue) ||
+            ((is_int($conditionValue) || is_float($conditionValue)) && !Validator::isFiniteNumber($conditionValue))) {
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNKNOWN_CONDITION_VALUE,
                 json_encode($condition)
@@ -143,11 +135,22 @@ class CustomAttributeConditionEvaluator
             return null;
         }
 
-        if (!$this->isValueValidForExactConditions($userValue) || !Validator::areValuesSameType($conditionValue, $userValue)) {
-            $this->logger->log(Logger::DEBUG, sprintf(
+        if (!$this->isValueTypeValidForExactConditions($userValue) ||
+            !Validator::areValuesSameType($conditionValue, $userValue)) {
+            $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
                 gettype($userValue),
+                $conditionName
+            ));
+            return null;
+        }
+
+        if ((is_int($userValue) || is_float($userValue)) &&
+            !Validator::isFiniteNumber($userValue)) {
+            $this->logger->log(Logger::WARNING, sprintf(
+                logs::INFINITE_ATTRIBUTE_VALUE,
+                json_encode($condition),
                 $conditionName
             ));
             return null;
@@ -188,15 +191,6 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if ((is_int($userValue) || is_float($userValue)) && !Validator::isFiniteNumber($userValue)) {
-            $this->logger->log(Logger::DEBUG, sprintf(
-                logs::INFINITE_ATTRIBUTE_VALUE,
-                json_encode($condition),
-                $conditionName
-            ));
-            return null;
-        }
-
         if (!Validator::isFiniteNumber($conditionValue)) {
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNKNOWN_CONDITION_VALUE,
@@ -205,11 +199,20 @@ class CustomAttributeConditionEvaluator
             return null;
         }
 
-        if (!Validator::isFiniteNumber($userValue)) {
-            $this->logger->log(Logger::DEBUG, sprintf(
+        if (!(is_int($userValue) || is_float($userValue))) {
+            $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
                 gettype($userValue),
+                $conditionName
+            ));
+            return null;
+        }
+
+        if (!Validator::isFiniteNumber($userValue)) {
+            $this->logger->log(Logger::WARNING, sprintf(
+                logs::INFINITE_ATTRIBUTE_VALUE,
+                json_encode($condition),
                 $conditionName
             ));
             return null;
@@ -234,15 +237,6 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if ((is_int($userValue) || is_float($userValue)) && !Validator::isFiniteNumber($userValue)) {
-            $this->logger->log(Logger::DEBUG, sprintf(
-                logs::INFINITE_ATTRIBUTE_VALUE,
-                json_encode($condition),
-                $conditionName
-            ));
-            return null;
-        }
-
         if (!Validator::isFiniteNumber($conditionValue)) {
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNKNOWN_CONDITION_VALUE,
@@ -251,11 +245,20 @@ class CustomAttributeConditionEvaluator
             return null;
         }
 
-        if (!Validator::isFiniteNumber($userValue)) {
-            $this->logger->log(Logger::DEBUG, sprintf(
+        if (!(is_int($userValue) || is_float($userValue))) {
+            $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
                 gettype($userValue),
+                $conditionName
+            ));
+            return null;
+        }
+
+        if (!Validator::isFiniteNumber($userValue)) {
+            $this->logger->log(Logger::WARNING, sprintf(
+                logs::INFINITE_ATTRIBUTE_VALUE,
+                json_encode($condition),
                 $conditionName
             ));
             return null;
@@ -289,7 +292,7 @@ class CustomAttributeConditionEvaluator
         }
 
         if (!is_string($userValue)) {
-            $this->logger->log(Logger::DEBUG, sprintf(
+            $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
                 gettype($userValue),

--- a/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
+++ b/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
@@ -126,11 +126,11 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if ((is_int($userValue) || is_float($userValue)) && (abs($userValue) > pow(2, 53))) {
+        if ((is_int($userValue) || is_float($userValue)) && !Validator::isFiniteNumber($userValue)) {
             $this->logger->log(Logger::DEBUG, sprintf(
                 logs::INFINITE_ATTRIBUTE_VALUE,
                 json_encode($condition),
-                $userValue
+                $conditionName
             ));
             return null;
         }
@@ -188,11 +188,11 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if ((is_int($userValue) || is_float($userValue)) && (abs($userValue) > pow(2, 53))) {
+        if ((is_int($userValue) || is_float($userValue)) && !Validator::isFiniteNumber($userValue)) {
             $this->logger->log(Logger::DEBUG, sprintf(
                 logs::INFINITE_ATTRIBUTE_VALUE,
                 json_encode($condition),
-                $userValue
+                $conditionName
             ));
             return null;
         }
@@ -234,11 +234,11 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if ((is_int($userValue) || is_float($userValue)) && (abs($userValue) > pow(2, 53))) {
+        if ((is_int($userValue) || is_float($userValue)) && !Validator::isFiniteNumber($userValue)) {
             $this->logger->log(Logger::DEBUG, sprintf(
                 logs::INFINITE_ATTRIBUTE_VALUE,
                 json_encode($condition),
-                $userValue
+                $conditionName
             ));
             return null;
         }

--- a/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
+++ b/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
@@ -126,12 +126,25 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
+        if ((is_int($userValue) || is_float($userValue)) && (abs($userValue) > pow(2, 53))) {
+            $this->logger->log(Logger::DEBUG, sprintf(
+                logs::INFINITE_ATTRIBUTE_VALUE,
+                json_encode($condition),
+                $userValue
+            ));
+            return null;
+        }
+
         if (!$this->isValueValidForExactConditions($conditionValue)) {
+            $this->logger->log(Logger::WARNING, sprintf(
+                logs::UNKNOWN_CONDITION_VALUE,
+                json_encode($condition)
+            ));
             return null;
         }
 
         if (!$this->isValueValidForExactConditions($userValue) || !Validator::areValuesSameType($conditionValue, $userValue)) {
-            $this->logger->log(Logger::WARNING, sprintf(
+            $this->logger->log(Logger::DEBUG, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
                 gettype($userValue),
@@ -175,12 +188,25 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
+        if ((is_int($userValue) || is_float($userValue)) && (abs($userValue) > pow(2, 53))) {
+            $this->logger->log(Logger::DEBUG, sprintf(
+                logs::INFINITE_ATTRIBUTE_VALUE,
+                json_encode($condition),
+                $userValue
+            ));
+            return null;
+        }
+
         if (!Validator::isFiniteNumber($conditionValue)) {
+            $this->logger->log(Logger::WARNING, sprintf(
+                logs::UNKNOWN_CONDITION_VALUE,
+                json_encode($condition)
+            ));
             return null;
         }
 
         if (!Validator::isFiniteNumber($userValue)) {
-            $this->logger->log(Logger::WARNING, sprintf(
+            $this->logger->log(Logger::DEBUG, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
                 gettype($userValue),
@@ -208,12 +234,25 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
+        if ((is_int($userValue) || is_float($userValue)) && (abs($userValue) > pow(2, 53))) {
+            $this->logger->log(Logger::DEBUG, sprintf(
+                logs::INFINITE_ATTRIBUTE_VALUE,
+                json_encode($condition),
+                $userValue
+            ));
+            return null;
+        }
+
         if (!Validator::isFiniteNumber($conditionValue)) {
+            $this->logger->log(Logger::WARNING, sprintf(
+                logs::UNKNOWN_CONDITION_VALUE,
+                json_encode($condition)
+            ));
             return null;
         }
 
         if (!Validator::isFiniteNumber($userValue)) {
-            $this->logger->log(Logger::WARNING, sprintf(
+            $this->logger->log(Logger::DEBUG, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
                 gettype($userValue),
@@ -242,11 +281,15 @@ class CustomAttributeConditionEvaluator
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
         if (!is_string($conditionValue)) {
+            $this->logger->log(Logger::WARNING, sprintf(
+                logs::UNKNOWN_CONDITION_VALUE,
+                json_encode($condition)
+            ));
             return null;
         }
 
         if (!is_string($userValue)) {
-            $this->logger->log(Logger::WARNING, sprintf(
+            $this->logger->log(Logger::DEBUG, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
                 gettype($userValue),

--- a/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
+++ b/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
@@ -348,12 +348,10 @@ class CustomAttributeConditionEvaluator
                     $conditionName
                 ));
                 return null;
-            } else {
-                $userValue = $this->userAttributes[$conditionName];
             }
 
-            if ($userValue === null) {
-                $this->logger->log(Logger::WARNING, sprintf(
+            if (!isset($this->userAttributes[$conditionName])) {
+                $this->logger->log(Logger::DEBUG, sprintf(
                     logs::NULL_ATTRIBUTE_VALUE,
                     json_encode($leafCondition),
                     $conditionName

--- a/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
+++ b/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
@@ -130,23 +130,12 @@ class CustomAttributeConditionEvaluator
             return null;
         }
 
-        if(!$this->isValueValidForExactConditions($userValue)) {
+        if(!$this->isValueValidForExactConditions($userValue) || !Validator::areValuesSameType($conditionValue, $userValue)) {
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
-                $conditionName,
-                json_encode($userValue)
-            ));
-            return null;
-        }
-
-        if(!Validator::areValuesSameType($conditionValue, $userValue)) {
-            $this->logger->log(Logger::DEBUG, sprintf(
-                logs::MISMATCH_TYPE,
-                json_encode($condition),
-                $conditionName,
                 gettype($userValue),
-                gettype($conditionValue)
+                $conditionName
             ));
             return null;
         }
@@ -194,8 +183,8 @@ class CustomAttributeConditionEvaluator
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
-                $conditionName,
-                json_encode($userValue)
+                gettype($userValue),
+                $conditionName
             ));
             return null;
         }
@@ -227,8 +216,8 @@ class CustomAttributeConditionEvaluator
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
-                $conditionName,
-                json_encode($userValue)
+                gettype($userValue),
+                $conditionName
             ));
             return null;
         }
@@ -260,8 +249,8 @@ class CustomAttributeConditionEvaluator
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
-                $conditionName,
-                json_encode($userValue)
+                gettype($userValue),
+                $conditionName
             ));
             return null;
         }
@@ -304,15 +293,27 @@ class CustomAttributeConditionEvaluator
         }
 
         $conditionName = $leafCondition['name'];
-        $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if($userValue === null and $leafCondition['match'] !== self::EXISTS_MATCH_TYPE) {
-            $this->logger->log(Logger::DEBUG, sprintf(
-                logs::MISSING_ATTRIBUTE_VALUE,
-                json_encode($leafCondition),
-                $conditionName
-            ));
-            return null;
+        if($leafCondition['match'] !== self::EXISTS_MATCH_TYPE) {
+            if(!array_key_exists($conditionName, $this->userAttributes)) {
+                $this->logger->log(Logger::DEBUG, sprintf(
+                    logs::MISSING_ATTRIBUTE_VALUE,
+                    json_encode($leafCondition),
+                    $conditionName
+                ));
+                return null;
+            }else{
+                $userValue = $this->userAttributes[$conditionName];
+            }
+
+            if($userValue === null) {
+                $this->logger->log(Logger::WARNING, sprintf(
+                    logs::NULL_ATTRIBUTE_VALUE,
+                    json_encode($leafCondition),
+                    $conditionName
+                ));
+                return null;
+            }
         }
 
         $evaluatorForMatch = $this->getEvaluatorByMatchType($conditionMatch);

--- a/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
+++ b/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
@@ -56,7 +56,7 @@ class CustomAttributeConditionEvaluator
     protected function setNullForMissingKeys(array $leafCondition)
     {
         $keys = ['type', 'match', 'value'];
-        foreach($keys as $key) {
+        foreach ($keys as $key) {
             $leafCondition[$key] = isset($leafCondition[$key]) ? $leafCondition[$key]: null;
         }
 
@@ -102,7 +102,7 @@ class CustomAttributeConditionEvaluator
      */
     protected function isValueValidForExactConditions($value)
     {
-        if(is_string($value) || is_bool($value) || Validator::isFiniteNumber($value)) {
+        if (is_string($value) || is_bool($value) || Validator::isFiniteNumber($value)) {
             return true;
         }
 
@@ -126,11 +126,11 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if(!$this->isValueValidForExactConditions($conditionValue)) {
+        if (!$this->isValueValidForExactConditions($conditionValue)) {
             return null;
         }
 
-        if(!$this->isValueValidForExactConditions($userValue) || !Validator::areValuesSameType($conditionValue, $userValue)) {
+        if (!$this->isValueValidForExactConditions($userValue) || !Validator::areValuesSameType($conditionValue, $userValue)) {
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
@@ -175,11 +175,11 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if(!Validator::isFiniteNumber($conditionValue)) {
+        if (!Validator::isFiniteNumber($conditionValue)) {
             return null;
         }
 
-        if(!Validator::isFiniteNumber($userValue)) {
+        if (!Validator::isFiniteNumber($userValue)) {
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
@@ -208,11 +208,11 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if(!Validator::isFiniteNumber($conditionValue)) {
+        if (!Validator::isFiniteNumber($conditionValue)) {
             return null;
         }
 
-        if(!Validator::isFiniteNumber($userValue)) {
+        if (!Validator::isFiniteNumber($userValue)) {
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
@@ -241,11 +241,11 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if(!is_string($conditionValue)) {
+        if (!is_string($conditionValue)) {
             return null;
         }
 
-        if(!is_string($userValue)) {
+        if (!is_string($userValue)) {
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNEXPECTED_TYPE,
                 json_encode($condition),
@@ -270,7 +270,7 @@ class CustomAttributeConditionEvaluator
     {
         $leafCondition = $this->setNullForMissingKeys($leafCondition);
 
-        if($leafCondition['type'] !== self::CUSTOM_ATTRIBUTE_CONDITION_TYPE) {
+        if ($leafCondition['type'] !== self::CUSTOM_ATTRIBUTE_CONDITION_TYPE) {
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNKNOWN_CONDITION_TYPE,
                 json_encode($leafCondition)
@@ -278,13 +278,13 @@ class CustomAttributeConditionEvaluator
             return null;
         }
 
-        if(($leafCondition['match']) === null) {
+        if (($leafCondition['match']) === null) {
             $conditionMatch = self::EXACT_MATCH_TYPE;
         } else {
             $conditionMatch = $leafCondition['match'];
         }
 
-        if(!in_array($conditionMatch, $this->getMatchTypes())) {
+        if (!in_array($conditionMatch, $this->getMatchTypes())) {
             $this->logger->log(Logger::WARNING, sprintf(
                 logs::UNKNOWN_MATCH_TYPE,
                 json_encode($leafCondition)
@@ -294,19 +294,19 @@ class CustomAttributeConditionEvaluator
 
         $conditionName = $leafCondition['name'];
 
-        if($leafCondition['match'] !== self::EXISTS_MATCH_TYPE) {
-            if(!array_key_exists($conditionName, $this->userAttributes)) {
+        if ($leafCondition['match'] !== self::EXISTS_MATCH_TYPE) {
+            if (!array_key_exists($conditionName, $this->userAttributes)) {
                 $this->logger->log(Logger::DEBUG, sprintf(
                     logs::MISSING_ATTRIBUTE_VALUE,
                     json_encode($leafCondition),
                     $conditionName
                 ));
                 return null;
-            }else{
+            } else {
                 $userValue = $this->userAttributes[$conditionName];
             }
 
-            if($userValue === null) {
+            if ($userValue === null) {
                 $this->logger->log(Logger::WARNING, sprintf(
                     logs::NULL_ATTRIBUTE_VALUE,
                     json_encode($leafCondition),

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -146,20 +146,20 @@ class Validator
             $audienceConditions = $experiment->getAudienceIds();
         }
 
-        // Return true if experiment is not targeted to any audience.
-        if (empty($audienceConditions)) {
-            $logger->log(Logger::INFO, sprintf(
-                AudienceEvaluationLogs::NO_AUDIENCE_ATTACHED,
-                $experiment->getKey()
-            ));
-            return true;
-        }
-
         $logger->log(Logger::DEBUG, sprintf(
-            AudienceEvaluationLogs::EVALUATING_AUDIENCES,
+            AudienceEvaluationLogs::EVALUATING_AUDIENCES_COMBINED,
             $experiment->getKey(),
             json_encode($audienceConditions)
         ));
+
+        // Return true if experiment is not targeted to any audience.
+        if (empty($audienceConditions)) {
+            $logger->log(Logger::INFO, sprintf(
+                AudienceEvaluationLogs::AUDIENCE_EVALUATION_RESULT_COMBINED,
+                $experiment->getKey(), 'True'
+            ));
+            return true;
+        }
 
         if ($userAttributes === null) {
             $userAttributes = [];
@@ -177,16 +177,16 @@ class Validator
             }
             
             $logger->log(Logger::DEBUG, sprintf(
-                AudienceEvaluationLogs::EVALUATING_AUDIENCE_WITH_CONDITIONS,
+                AudienceEvaluationLogs::EVALUATING_AUDIENCE,
                 $audienceId,
                 json_encode($audience->getConditionsList())
             ));
 
             $conditionTreeEvaluator = new ConditionTreeEvaluator();
             $result = $conditionTreeEvaluator->evaluate($audience->getConditionsList(), $evaluateCustomAttr);
-            $resultStr = $result === null ? 'UNKNOWN' : ucfirst(var_export($result, true));
+            $resultStr = $result === null ? 'UNKNOWN' : strtoupper(var_export($result, true));
 
-            $logger->log(Logger::DEBUG, sprintf(
+            $logger->log(Logger::INFO, sprintf(
                 AudienceEvaluationLogs::AUDIENCE_EVALUATION_RESULT,
                 $audienceId,
                 $resultStr

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -62,11 +62,11 @@ class Validator
      */
     public static function areAttributesValid($attributes)
     {
-        if(!is_array($attributes)){
+        if (!is_array($attributes)) {
             return false;
         }
 
-        if (empty($attributes)){
+        if (empty($attributes)) {
             return true;
         }
         // At least one key string to be an associative array.
@@ -149,8 +149,8 @@ class Validator
         // Return true if experiment is not targeted to any audience.
         if (empty($audienceConditions)) {
             $logger->log(Logger::INFO, sprintf(
-                  AudienceEvaluationLogs::NO_AUDIENCE_ATTACHED,
-                  $experiment->getKey()
+                AudienceEvaluationLogs::NO_AUDIENCE_ATTACHED,
+                $experiment->getKey()
             ));
             return true;
         }
@@ -166,11 +166,11 @@ class Validator
         }
 
         $customAttrCondEval = new CustomAttributeConditionEvaluator($userAttributes, $logger);
-        $evaluateCustomAttr = function($leafCondition) use ($customAttrCondEval) {
+        $evaluateCustomAttr = function ($leafCondition) use ($customAttrCondEval) {
             return $customAttrCondEval->evaluate($leafCondition);
         };
 
-        $evaluateAudience = function($audienceId) use ($config, $evaluateCustomAttr, $logger) {
+        $evaluateAudience = function ($audienceId) use ($config, $evaluateCustomAttr, $logger) {
             $audience = $config->getAudience($audienceId);
             $logger->log(Logger::DEBUG, sprintf(
                 AudienceEvaluationLogs::EVALUATING_AUDIENCE_WITH_CONDITIONS,
@@ -267,8 +267,8 @@ class Validator
         $secondValType = gettype($secondVal);
         $numberTypes = array('double', 'integer');
 
-        if(in_array($firstValType, $numberTypes) && in_array($secondValType, $numberTypes)) {
-            return True;
+        if (in_array($firstValType, $numberTypes) && in_array($secondValType, $numberTypes)) {
+            return true;
         }
 
         return $firstValType == $secondValType;
@@ -281,7 +281,7 @@ class Validator
      */
     public static function doesArrayContainOnlyStringKeys($arr)
     {
-        if(!is_array($arr) || empty($arr)) {
+        if (!is_array($arr) || empty($arr)) {
             return false;
         }
 

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -157,7 +157,7 @@ class Validator
             $logger->log(Logger::INFO, sprintf(
                 AudienceEvaluationLogs::AUDIENCE_EVALUATION_RESULT_COMBINED,
                 $experiment->getKey(),
-                'True'
+                'TRUE'
             ));
             return true;
         }

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -172,6 +172,10 @@ class Validator
 
         $evaluateAudience = function ($audienceId) use ($config, $evaluateCustomAttr, $logger) {
             $audience = $config->getAudience($audienceId);
+            if ($audience === null) {
+                return null;
+            }
+            
             $logger->log(Logger::DEBUG, sprintf(
                 AudienceEvaluationLogs::EVALUATING_AUDIENCE_WITH_CONDITIONS,
                 $audienceId,

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -161,11 +161,6 @@ class Validator
             json_encode($audienceConditions)
         ));
 
-        $logger->log(Logger::DEBUG, sprintf(
-            AudienceEvaluationLogs::USER_ATTRIBUTES,
-            json_encode($userAttributes)
-        ));
-
         if ($userAttributes === null) {
             $userAttributes = [];
         }
@@ -185,12 +180,12 @@ class Validator
 
             $conditionTreeEvaluator = new ConditionTreeEvaluator();
             $result = $conditionTreeEvaluator->evaluate($audience->getConditionsList(), $evaluateCustomAttr);
-            $resultLog = $result === null ? 'UNKNOWN' : ucfirst(var_export($result, true));
+            $resultStr = $result === null ? 'UNKNOWN' : ucfirst(var_export($result, true));
 
             $logger->log(Logger::DEBUG, sprintf(
                 AudienceEvaluationLogs::AUDIENCE_EVALUATION_RESULT,
                 $audienceId,
-                $resultLog
+                $resultStr
             ));
 
             return $result;
@@ -258,12 +253,12 @@ class Validator
     }
 
     /**
-     * Method to verify that both values belong to same type. 
+     * Method to verify that both values belong to same type.
      * Float/Double and Integer are considered similar.
-     * 
+     *
      * @param  mixed  $firstVal
      * @param  mixed  $secondVal
-     * 
+     *
      * @return bool   True if values belong to similar types. Otherwise, False.
      */
     public static function areValuesSameType($firstVal, $secondVal)

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -135,7 +135,7 @@ class Validator
      * @param $config ProjectConfig Configuration for the project.
      * @param $experiment Experiment Entity representing the experiment.
      * @param $userAttributes array Attributes of the user.
-     *  @param $logger LoggerInterface.
+     * @param $logger LoggerInterface.
      *
      * @return boolean Representing whether user meets audience conditions to be in experiment or not.
      */
@@ -156,7 +156,8 @@ class Validator
         if (empty($audienceConditions)) {
             $logger->log(Logger::INFO, sprintf(
                 AudienceEvaluationLogs::AUDIENCE_EVALUATION_RESULT_COMBINED,
-                $experiment->getKey(), 'True'
+                $experiment->getKey(),
+                'True'
             ));
             return true;
         }
@@ -202,7 +203,7 @@ class Validator
         $logger->log(Logger::INFO, sprintf(
             AudienceEvaluationLogs::AUDIENCE_EVALUATION_RESULT_COMBINED,
             $experiment->getKey(),
-            ucfirst(var_export($evalResult, true))
+            strtoupper(var_export($evalResult, true))
         ));
 
         return $evalResult;

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -62,8 +62,8 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $this->collectedLogs = [];
-        $this->collectLogsForAssertion = function($a, $b) {
-           $this->collectedLogs[] = array($a,$b);
+        $this->collectLogsForAssertion = function ($a, $b) {
+            $this->collectedLogs[] = array($a,$b);
         };
 
         $this->config = new ProjectConfig(DATAFILE, $this->loggerMock, new NoOpErrorHandler());
@@ -1068,7 +1068,8 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->willReturn(null);
 
         $this->assertNull(
-            $this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', $user_attributes));
+            $this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', $user_attributes)
+        );
     }
 
     // ============== END of tests - when the user qualifies for targeting rule (audience match) ======================

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
@@ -48,9 +48,10 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                         ->method('log')
-                        ->with($logLevel,
+                        ->with(
+                            $logLevel,
                             "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"regex\"}\" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK."
-                          );
+                        );
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -72,9 +73,10 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                         ->method('log')
-                        ->with($logLevel,
+                        ->with(
+                            $logLevel,
                             "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"sdk_version\",\"match\":\"exact\"}\" uses an unknown condition type. You may need to upgrade to anewer release of the Optimizely SDK."
-                          );
+                        );
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
@@ -50,7 +50,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
                         ->method('log')
                         ->with(
                             $logLevel,
-                            "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"regex\"}\" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK."
+                            "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"regex\"} uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK."
                         );
 
         $customAttrConditionEvaluator->evaluate($conditionList);
@@ -75,7 +75,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
                         ->method('log')
                         ->with(
                             $logLevel,
-                            "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"sdk_version\",\"match\":\"exact\"}\" uses an unknown condition type. You may need to upgrade to anewer release of the Optimizely SDK."
+                            "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"sdk_version\",\"match\":\"exact\"} uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK."
                         );
 
         $customAttrConditionEvaluator->evaluate($conditionList);
@@ -100,7 +100,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
             ->method('log')
             ->with(
                 $logLevel,
-                "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":[],\"type\":\"custom_attribute\",\"match\":\"exact\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."
+                "Audience condition {\"name\":\"favorite_constellation\",\"value\":[],\"type\":\"custom_attribute\",\"match\":\"exact\"} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."
             );
 
         $customAttrConditionEvaluator->evaluate($conditionList);
@@ -130,7 +130,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testExactUserValueNull()
     {
-        $logLevel = Logger::WARNING;
+        $logLevel = Logger::DEBUG;
         $conditionList = [
           'name' => 'favorite_constellation',
           'value' => 'Lacerta',
@@ -145,7 +145,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"}\" evaluated to UNKNOWN because a null value was passed for user attribute \"favorite_constellation\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated to UNKNOWN because a null value was passed for user attribute \"favorite_constellation\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -167,7 +167,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":[],\"type\":\"custom_attribute\",\"match\":\"gt\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":[],\"type\":\"custom_attribute\",\"match\":\"gt\"} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -196,7 +196,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testGreaterThanUserValueNull()
     {
-        $logLevel = Logger::WARNING;
+        $logLevel = Logger::DEBUG;
         $conditionList = [
           'name' => 'meters_travelled',
           'value' => 48,
@@ -211,7 +211,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"gt\"}\" evaluated to UNKNOWN because a null value was passed for user attribute \"meters_travelled\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated to UNKNOWN because a null value was passed for user attribute \"meters_travelled\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -233,7 +233,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":[],\"type\":\"custom_attribute\",\"match\":\"lt\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":[],\"type\":\"custom_attribute\",\"match\":\"lt\"} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -262,7 +262,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testLessThanUserValueNull()
     {
-        $logLevel = Logger::WARNING;
+        $logLevel = Logger::DEBUG;
         $conditionList = [
           'name' => 'meters_travelled',
           'value' => 48,
@@ -277,7 +277,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"lt\"}\" evaluated to UNKNOWN because a null value was passed for user attribute \"meters_travelled\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated to UNKNOWN because a null value was passed for user attribute \"meters_travelled\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -299,7 +299,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition \"{\"name\":\"headline_text\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"substring\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+            ->with($logLevel, "Audience condition {\"name\":\"headline_text\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"substring\"} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -328,7 +328,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testSubstringUserValueNull()
     {
-        $logLevel = Logger::WARNING;
+        $logLevel = Logger::DEBUG;
         $conditionList = [
           'name' => 'headline_text',
           'value' => 'buy now',
@@ -343,14 +343,13 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition \"{\"name\":\"headline_text\",\"value\":\"buy now\",\"type\":\"custom_attribute\",\"match\":\"substring\"}\" evaluated to UNKNOWN because a null value was passed for user attribute \"headline_text\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"headline_text\",\"value\":\"buy now\",\"type\":\"custom_attribute\",\"match\":\"substring\"} evaluated to UNKNOWN because a null value was passed for user attribute \"headline_text\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
 
     public function testExistsUserValueMissing()
     {
-        $logLevel = Logger::WARNING;
         $conditionList = [
           'name' => 'input_value',
           'value' => null,
@@ -386,7 +385,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated to UNKNOWN for user attribute \"favorite_constellation\" is not in the range [-2^53, +2^53].");
+            ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated to UNKNOWN because the number value for user attribute \"favorite_constellation\" is not in the range [-2^53, +2^53].");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -430,7 +429,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated to UNKNOWN for user attribute \"meters_travelled\" is not in the range [-2^53, +2^53].");
+            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated to UNKNOWN because the number value for user attribute \"meters_travelled\" is not in the range [-2^53, +2^53].");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -474,7 +473,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated to UNKNOWN for user attribute \"meters_travelled\" is not in the range [-2^53, +2^53].");
+            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated to UNKNOWN because the number value for user attribute \"meters_travelled\" is not in the range [-2^53, +2^53].");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
@@ -49,7 +49,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $this->loggerMock->expects($this->once())
                         ->method('log')
                         ->with($logLevel,
-                            "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"regex\"}\" uses an unknown match type."
+                            "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"regex\"}\" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK."
                           );
 
         $customAttrConditionEvaluator->evaluate($conditionList);
@@ -73,7 +73,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $this->loggerMock->expects($this->once())
                         ->method('log')
                         ->with($logLevel,
-                            "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"sdk_version\",\"match\":\"exact\"}\" has an unknown condition type."
+                            "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"sdk_version\",\"match\":\"exact\"}\" uses an unknown condition type. You may need to upgrade to anewer release of the Optimizely SDK."
                           );
 
         $customAttrConditionEvaluator->evaluate($conditionList);
@@ -96,7 +96,29 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated as UNKNOWN because no value was passed for user attribute \"favorite_constellation\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated to UNKNOWN because no value was passed for user attribute \"favorite_constellation\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testExactUserValueNull()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'favorite_constellation',
+          'value' => 'Lacerta',
+          'type' => 'custom_attribute',
+          'match' => 'exact'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['favorite_constellation' => null],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"}\" evaluated to UNKNOWN because a null value was passed for user attribute \"favorite_constellation\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -118,7 +140,29 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated as UNKNOWN because no value was passed for user attribute \"meters_travelled\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated to UNKNOWN because no value was passed for user attribute \"meters_travelled\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testGreaterThanUserValueNull()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'meters_travelled',
+          'value' => 48,
+          'type' => 'custom_attribute',
+          'match' => 'gt'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['meters_travelled' => null],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"gt\"}\" evaluated to UNKNOWN because a null value was passed for user attribute \"meters_travelled\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -140,7 +184,29 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated as UNKNOWN because no value was passed for user attribute \"meters_travelled\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated to UNKNOWN because no value was passed for user attribute \"meters_travelled\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testLessThanUserValueNull()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'meters_travelled',
+          'value' => 48,
+          'type' => 'custom_attribute',
+          'match' => 'lt'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['meters_travelled' => null],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"lt\"}\" evaluated to UNKNOWN because a null value was passed for user attribute \"meters_travelled\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -162,7 +228,29 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition {\"name\":\"headline_text\",\"value\":\"buy now\",\"type\":\"custom_attribute\",\"match\":\"substring\"} evaluated as UNKNOWN because no value was passed for user attribute \"headline_text\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"headline_text\",\"value\":\"buy now\",\"type\":\"custom_attribute\",\"match\":\"substring\"} evaluated to UNKNOWN because no value was passed for user attribute \"headline_text\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testSubstringUserValueNull()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'headline_text',
+          'value' => 'buy now',
+          'type' => 'custom_attribute',
+          'match' => 'substring'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['headline_text' => null],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition \"{\"name\":\"headline_text\",\"value\":\"buy now\",\"type\":\"custom_attribute\",\"match\":\"substring\"}\" evaluated to UNKNOWN because a null value was passed for user attribute \"headline_text\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -205,7 +293,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated as UNKNOWN because the value for user attribute \"favorite_constellation\" is inapplicable: \"[]\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated to UNKNOWN because a value of type \"array\" was passed for user attribute \"favorite_constellation\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -227,7 +315,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated as UNKNOWN because the value for user attribute \"meters_travelled\" is inapplicable: \"\"48\"\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated to UNKNOWN because a value of type \"string\" was passed for user attribute \"meters_travelled\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -249,7 +337,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated as UNKNOWN because the value for user attribute \"meters_travelled\" is inapplicable: \"true\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated to UNKNOWN because a value of type \"boolean\" was passed for user attribute \"meters_travelled\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -271,14 +359,14 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition {\"name\":\"headline_text\",\"value\":\"buy now\",\"type\":\"custom_attribute\",\"match\":\"substring\"} evaluated as UNKNOWN because the value for user attribute \"headline_text\" is inapplicable: \"1234\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"headline_text\",\"value\":\"buy now\",\"type\":\"custom_attribute\",\"match\":\"substring\"} evaluated to UNKNOWN because a value of type \"integer\" was passed for user attribute \"headline_text\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
 
     public function testExactUserValueTypeMismatch()
     {
-        $logLevel = Logger::DEBUG;
+        $logLevel = Logger::WARNING;
         $conditionList = [
           'name' => 'favorite_constellation',
           'value' => 'Lacerta',
@@ -293,7 +381,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
                          ->method('log')
-                         ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated as UNKNOWN because the value for user attribute \"favorite_constellation\" is \"integer\" while expected is \"string\".");
+                         ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated to UNKNOWN because a value of type \"integer\" was passed for user attribute \"favorite_constellation\".");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
@@ -86,7 +86,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $logLevel = Logger::WARNING;
         $conditionList = [
             'name' => 'favorite_constellation',
-            'value' => pow(2, 53) + 1,
+            'value' => [],
             'type' => 'custom_attribute',
             'match' => 'exact'
         ];
@@ -100,7 +100,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
             ->method('log')
             ->with(
                 $logLevel,
-                "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":9007199254740993,\"type\":\"custom_attribute\",\"match\":\"exact\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."
+                "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":[],\"type\":\"custom_attribute\",\"match\":\"exact\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."
             );
 
         $customAttrConditionEvaluator->evaluate($conditionList);
@@ -155,7 +155,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $logLevel = Logger::WARNING;
         $conditionList = [
             'name' => 'meters_travelled',
-            'value' => pow(2, 53) + 1,
+            'value' => [],
             'type' => 'custom_attribute',
             'match' => 'gt'
         ];
@@ -167,7 +167,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":9007199254740993,\"type\":\"custom_attribute\",\"match\":\"gt\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+            ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":[],\"type\":\"custom_attribute\",\"match\":\"gt\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -221,7 +221,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $logLevel = Logger::WARNING;
         $conditionList = [
             'name' => 'meters_travelled',
-            'value' => pow(2, 53) + 1,
+            'value' => [],
             'type' => 'custom_attribute',
             'match' => 'lt'
         ];
@@ -233,7 +233,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":9007199254740993,\"type\":\"custom_attribute\",\"match\":\"lt\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+            ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":[],\"type\":\"custom_attribute\",\"match\":\"lt\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -371,7 +371,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testExactUserValueInfinite()
     {
-        $logLevel = Logger::DEBUG;
+        $logLevel = Logger::WARNING;
         $conditionList = [
             'name' => 'favorite_constellation',
             'value' => 900,
@@ -380,7 +380,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         ];
 
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['favorite_constellation' => pow(2, 53) + 1],
+            ['favorite_constellation' => INF],
             $this->loggerMock
         );
 
@@ -393,7 +393,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testExactUserValueUnexpectedType()
     {
-        $logLevel = Logger::DEBUG;
+        $logLevel = Logger::WARNING;
         $conditionList = [
           'name' => 'favorite_constellation',
           'value' => 'Lacerta',
@@ -415,7 +415,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testGreaterThanUserValueInfinite()
     {
-        $logLevel = Logger::DEBUG;
+        $logLevel = Logger::WARNING;
         $conditionList = [
             'name' => 'meters_travelled',
             'value' => 900,
@@ -424,7 +424,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         ];
 
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => pow(2, 53) + 1],
+            ['meters_travelled' => INF],
             $this->loggerMock
         );
 
@@ -437,7 +437,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testGreaterThanUserValueUnexpectedType()
     {
-        $logLevel = Logger::DEBUG;
+        $logLevel = Logger::WARNING;
         $conditionList = [
           'name' => 'meters_travelled',
           'value' => 48,
@@ -459,7 +459,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testLessThanUserValueInfinite()
     {
-        $logLevel = Logger::DEBUG;
+        $logLevel = Logger::WARNING;
         $conditionList = [
             'name' => 'meters_travelled',
             'value' => 900,
@@ -468,7 +468,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         ];
 
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => pow(2, 53) + 1],
+            ['meters_travelled' => INF],
             $this->loggerMock
         );
 
@@ -481,7 +481,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testLessThanUserValueUnexpectedType()
     {
-        $logLevel = Logger::DEBUG;
+        $logLevel = Logger::WARNING;
         $conditionList = [
           'name' => 'meters_travelled',
           'value' => 48,
@@ -501,9 +501,9 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
 
-    public function testSubstringnUserValueUnexpectedType()
+    public function testSubstringUserValueUnexpectedType()
     {
-        $logLevel = Logger::DEBUG;
+        $logLevel = Logger::WARNING;
         $conditionList = [
           'name' => 'headline_text',
           'value' => 'buy now',
@@ -525,7 +525,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testExactUserValueTypeMismatch()
     {
-        $logLevel = Logger::DEBUG;
+        $logLevel = Logger::WARNING;
         $conditionList = [
           'name' => 'favorite_constellation',
           'value' => 'Lacerta',

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
@@ -386,7 +386,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated to UNKNOWN for user attribute \"9007199254740993\" is not in the range [-2^53, +2^53].");
+            ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated to UNKNOWN for user attribute \"favorite_constellation\" is not in the range [-2^53, +2^53].");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -430,7 +430,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated to UNKNOWN for user attribute \"9007199254740993\" is not in the range [-2^53, +2^53].");
+            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated to UNKNOWN for user attribute \"meters_travelled\" is not in the range [-2^53, +2^53].");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -474,7 +474,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated to UNKNOWN for user attribute \"9007199254740993\" is not in the range [-2^53, +2^53].");
+            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated to UNKNOWN for user attribute \"meters_travelled\" is not in the range [-2^53, +2^53].");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
@@ -81,6 +81,31 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
 
+    public function testExactConditionValueUnknown()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+            'name' => 'favorite_constellation',
+            'value' => pow(2, 53) + 1,
+            'type' => 'custom_attribute',
+            'match' => 'exact'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['favorite_constellation'=> 9000],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+            ->method('log')
+            ->with(
+                $logLevel,
+                "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":9007199254740993,\"type\":\"custom_attribute\",\"match\":\"exact\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."
+            );
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
     public function testExactUserValueMissing()
     {
         $logLevel = Logger::DEBUG;
@@ -121,6 +146,28 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $this->loggerMock->expects($this->once())
                          ->method('log')
                          ->with($logLevel, "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"}\" evaluated to UNKNOWN because a null value was passed for user attribute \"favorite_constellation\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testGreaterThanConditionValueUnknown()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+            'name' => 'meters_travelled',
+            'value' => pow(2, 53) + 1,
+            'type' => 'custom_attribute',
+            'match' => 'gt'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['meters_travelled'=> 9000],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+            ->method('log')
+            ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":9007199254740993,\"type\":\"custom_attribute\",\"match\":\"gt\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -169,6 +216,28 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
 
+    public function testLessThanConditionValueUnknown()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+            'name' => 'meters_travelled',
+            'value' => pow(2, 53) + 1,
+            'type' => 'custom_attribute',
+            'match' => 'lt'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['meters_travelled'=> 48],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+            ->method('log')
+            ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":9007199254740993,\"type\":\"custom_attribute\",\"match\":\"lt\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
     public function testLessThanUserValueMissing()
     {
         $logLevel = Logger::DEBUG;
@@ -209,6 +278,28 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $this->loggerMock->expects($this->once())
                          ->method('log')
                          ->with($logLevel, "Audience condition \"{\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"lt\"}\" evaluated to UNKNOWN because a null value was passed for user attribute \"meters_travelled\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testSubstringConditionValueUnknown()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+            'name' => 'headline_text',
+            'value' => 900,
+            'type' => 'custom_attribute',
+            'match' => 'substring'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['headline_text'=> 'buy now'],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+            ->method('log')
+            ->with($logLevel, "Audience condition \"{\"name\":\"headline_text\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"substring\"}\" has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
 
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
@@ -278,9 +369,31 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
 
+    public function testExactUserValueInfinite()
+    {
+        $logLevel = Logger::DEBUG;
+        $conditionList = [
+            'name' => 'favorite_constellation',
+            'value' => 900,
+            'type' => 'custom_attribute',
+            'match' => 'exact'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['favorite_constellation' => pow(2, 53) + 1],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+            ->method('log')
+            ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated to UNKNOWN for user attribute \"9007199254740993\" is not in the range [-2^53, +2^53].");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
     public function testExactUserValueUnexpectedType()
     {
-        $logLevel = Logger::WARNING;
+        $logLevel = Logger::DEBUG;
         $conditionList = [
           'name' => 'favorite_constellation',
           'value' => 'Lacerta',
@@ -300,9 +413,31 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
 
+    public function testGreaterThanUserValueInfinite()
+    {
+        $logLevel = Logger::DEBUG;
+        $conditionList = [
+            'name' => 'meters_travelled',
+            'value' => 900,
+            'type' => 'custom_attribute',
+            'match' => 'gt'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['meters_travelled' => pow(2, 53) + 1],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+            ->method('log')
+            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated to UNKNOWN for user attribute \"9007199254740993\" is not in the range [-2^53, +2^53].");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
     public function testGreaterThanUserValueUnexpectedType()
     {
-        $logLevel = Logger::WARNING;
+        $logLevel = Logger::DEBUG;
         $conditionList = [
           'name' => 'meters_travelled',
           'value' => 48,
@@ -322,9 +457,31 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
         $customAttrConditionEvaluator->evaluate($conditionList);
     }
 
+    public function testLessThanUserValueInfinite()
+    {
+        $logLevel = Logger::DEBUG;
+        $conditionList = [
+            'name' => 'meters_travelled',
+            'value' => 900,
+            'type' => 'custom_attribute',
+            'match' => 'lt'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['meters_travelled' => pow(2, 53) + 1],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+            ->method('log')
+            ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":900,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated to UNKNOWN for user attribute \"9007199254740993\" is not in the range [-2^53, +2^53].");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
     public function testLessThanUserValueUnexpectedType()
     {
-        $logLevel = Logger::WARNING;
+        $logLevel = Logger::DEBUG;
         $conditionList = [
           'name' => 'meters_travelled',
           'value' => 48,
@@ -346,7 +503,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testSubstringnUserValueUnexpectedType()
     {
-        $logLevel = Logger::WARNING;
+        $logLevel = Logger::DEBUG;
         $conditionList = [
           'name' => 'headline_text',
           'value' => 'buy now',
@@ -368,7 +525,7 @@ class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_Te
 
     public function testExactUserValueTypeMismatch()
     {
-        $logLevel = Logger::WARNING;
+        $logLevel = Logger::DEBUG;
         $conditionList = [
           'name' => 'favorite_constellation',
           'value' => 'Lacerta',

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Copyright 2019, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Optimizely\Tests;
+
+use Monolog\Logger;
+use Optimizely\Entity\Audience;
+use Optimizely\Enums\AudienceEvaluationLogs;
+use Optimizely\Utils\CustomAttributeConditionEvaluator;
+
+class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
+            ->setMethods(array('log'))
+            ->getMock();
+    }
+
+    public function testEvaluateMatchTypeInvalid()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'favorite_constellation',
+          'value' => 'Lacerta',
+          'type' => 'custom_attribute',
+          'match' => 'regex'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            [],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                        ->method('log')
+                        ->with($logLevel,
+                            "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"regex\"}\" uses an unknown match type."
+                          );
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testEvaluateConditionTypeInvalid()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'favorite_constellation',
+          'value' => 'Lacerta',
+          'type' => 'sdk_version',
+          'match' => 'exact'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            [],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                        ->method('log')
+                        ->with($logLevel,
+                            "Audience condition \"{\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"sdk_version\",\"match\":\"exact\"}\" has an unknown condition type."
+                          );
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testExactUserValueMissing()
+    {
+        $logLevel = Logger::DEBUG;
+        $conditionList = [
+          'name' => 'favorite_constellation',
+          'value' => 'Lacerta',
+          'type' => 'custom_attribute',
+          'match' => 'exact'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            [],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated as UNKNOWN because no value was passed for user attribute \"favorite_constellation\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testGreaterThanUserValueMissing()
+    {
+        $logLevel = Logger::DEBUG;
+        $conditionList = [
+          'name' => 'meters_travelled',
+          'value' => 48,
+          'type' => 'custom_attribute',
+          'match' => 'gt'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            [],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated as UNKNOWN because no value was passed for user attribute \"meters_travelled\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testLessThanUserValueMissing()
+    {
+        $logLevel = Logger::DEBUG;
+        $conditionList = [
+          'name' => 'meters_travelled',
+          'value' => 48,
+          'type' => 'custom_attribute',
+          'match' => 'lt'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            [],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated as UNKNOWN because no value was passed for user attribute \"meters_travelled\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testSubstringUserValueMissing()
+    {
+        $logLevel = Logger::DEBUG;
+        $conditionList = [
+          'name' => 'headline_text',
+          'value' => 'buy now',
+          'type' => 'custom_attribute',
+          'match' => 'substring'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            [],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition {\"name\":\"headline_text\",\"value\":\"buy now\",\"type\":\"custom_attribute\",\"match\":\"substring\"} evaluated as UNKNOWN because no value was passed for user attribute \"headline_text\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testExistsUserValueMissing()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'input_value',
+          'value' => null,
+          'type' => 'custom_attribute',
+          'match' => 'exists'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            [],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->never())
+                         ->method('log');
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testExactUserValueUnexpectedType()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'favorite_constellation',
+          'value' => 'Lacerta',
+          'type' => 'custom_attribute',
+          'match' => 'exact'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['favorite_constellation' => []],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated as UNKNOWN because the value for user attribute \"favorite_constellation\" is inapplicable: \"[]\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testGreaterThanUserValueUnexpectedType()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'meters_travelled',
+          'value' => 48,
+          'type' => 'custom_attribute',
+          'match' => 'gt'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['meters_travelled' => '48'],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"gt\"} evaluated as UNKNOWN because the value for user attribute \"meters_travelled\" is inapplicable: \"\"48\"\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testLessThanUserValueUnexpectedType()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'meters_travelled',
+          'value' => 48,
+          'type' => 'custom_attribute',
+          'match' => 'lt'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['meters_travelled' => true],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition {\"name\":\"meters_travelled\",\"value\":48,\"type\":\"custom_attribute\",\"match\":\"lt\"} evaluated as UNKNOWN because the value for user attribute \"meters_travelled\" is inapplicable: \"true\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testSubstringnUserValueUnexpectedType()
+    {
+        $logLevel = Logger::WARNING;
+        $conditionList = [
+          'name' => 'headline_text',
+          'value' => 'buy now',
+          'type' => 'custom_attribute',
+          'match' => 'substring'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['headline_text' => 1234],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition {\"name\":\"headline_text\",\"value\":\"buy now\",\"type\":\"custom_attribute\",\"match\":\"substring\"} evaluated as UNKNOWN because the value for user attribute \"headline_text\" is inapplicable: \"1234\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+
+    public function testExactUserValueTypeMismatch()
+    {
+        $logLevel = Logger::DEBUG;
+        $conditionList = [
+          'name' => 'favorite_constellation',
+          'value' => 'Lacerta',
+          'type' => 'custom_attribute',
+          'match' => 'exact'
+        ];
+
+        $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
+            ['favorite_constellation' => 5],
+            $this->loggerMock
+        );
+
+        $this->loggerMock->expects($this->once())
+                         ->method('log')
+                         ->with($logLevel, "Audience condition {\"name\":\"favorite_constellation\",\"value\":\"Lacerta\",\"type\":\"custom_attribute\",\"match\":\"exact\"} evaluated as UNKNOWN because the value for user attribute \"favorite_constellation\" is \"integer\" while expected is \"string\".");
+
+        $customAttrConditionEvaluator->evaluate($conditionList);
+    }
+}

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018, Optimizely
+ * Copyright 2018-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,10 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
+            ->setMethods(array('log'))
+            ->getMock();
+
         $this->browserConditionSafari = [
             'type' => 'custom_attribute',
             'name' => 'browser_type',
@@ -112,7 +116,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testEvaluateReturnsTrueWhenAttrsPassAudienceCondition()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['browser_type' => 'safari']
+            ['browser_type' => 'safari'],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -125,7 +130,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testEvaluateReturnsFalseWhenAttrsFailAudienceConditions()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['browser_type' => 'chrome']
+            ['browser_type' => 'chrome'],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -145,7 +151,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
         ];
 
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            $userAttributes
+            $userAttributes,
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -176,7 +183,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testEvaluateReturnsNullForInvalidMatchProperty()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['weird_condition' => 'hi']
+            ['weird_condition' => 'hi'],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -195,7 +203,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testEvaluateAssumesExactWhenConditionMatchPropertyIsNull()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['favorite_constellation' => 'Lacerta']
+            ['favorite_constellation' => 'Lacerta'],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -213,7 +222,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testEvaluateReturnsNullWhenConditionHasInvalidTypeProperty()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['weird_condition' => 'hi']
+            ['weird_condition' => 'hi'],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -231,7 +241,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExistsReturnsFalseWhenNoUserProvidedValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            []
+            [],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -244,7 +255,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExistsReturnsFalseWhenUserProvidedValueIsNull()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['input_value' => null]
+            ['input_value' => null],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -257,7 +269,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExistsReturnsTrueWhenUserProvidedValueIsString()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['input_value' => 'hi']
+            ['input_value' => 'hi'],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -270,7 +283,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExistsReturnsTrueWhenUserProvidedValueIsNumber()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['input_value' => 10]
+            ['input_value' => 10],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -280,7 +294,9 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
         );
 
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['input_value' => 10.0]
+
+            ['input_value' => 10.0],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -294,7 +310,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExistsReturnsTrueWhenUserProvidedValueIsBoolean()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['input_value' => false]
+            ['input_value' => false],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -307,7 +324,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactStringReturnsTrueWhenAttrsEqualToConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['favorite_constellation' => 'Lacerta']
+            ['favorite_constellation' => 'Lacerta'],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -320,7 +338,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactStringReturnsFalseWhenAttrsNotEqualToConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['favorite_constellation' => 'The Big Dipper']
+            ['favorite_constellation' => 'The Big Dipper'],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -333,7 +352,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactStringReturnsNullWhenAttrsIsDifferentTypeFromConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['favorite_constellation' => false]
+            ['favorite_constellation' => false],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -346,7 +366,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactStringReturnsNullWhenNoUserProvidedValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            []
+            [],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -359,7 +380,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactIntReturnsTrueWhenAttrsEqualToConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['lasers_count' => 9000]
+            ['lasers_count' => 9000],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -372,7 +394,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactFloatReturnsTrueWhenAttrsEqualToConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['lasers_count' => 9000.0]
+            ['lasers_count' => 9000.0],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -385,7 +408,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactIntReturnsFalseWhenAttrsNotEqualToConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['lasers_count' => 8000]
+            ['lasers_count' => 8000],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -398,7 +422,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactFloatReturnsFalseWhenAttrsNotEqualToConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['lasers_count' => 8000.0]
+            ['lasers_count' => 8000.0],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -411,7 +436,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactIntReturnsNullWhenAttrsIsDifferentTypeFromConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['lasers_count' => 'hi']
+            ['lasers_count' => 'hi'],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -421,7 +447,9 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
         );
 
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['lasers_count' => true]
+
+            ['lasers_count' => true],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -434,7 +462,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactFloatReturnsNullWhenAttrsIsDifferentTypeFromConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-          ['lasers_count' => 'hi']
+            ['lasers_count' => 'hi'],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -444,7 +473,9 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
         );
 
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-          ['lasers_count' => true]
+
+            ['lasers_count' => true],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -457,7 +488,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactIntReturnsNullWhenNoUserProvidedValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            []
+            [],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -470,7 +502,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactFloatReturnsNullWhenNoUserProvidedValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            []
+            [],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -483,7 +516,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactBoolReturnsTrueWhenAttrsEqualToConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['did_register_user' => false]
+            ['did_register_user' => false],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -496,7 +530,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactBoolReturnsFalseWhenAttrsNotEqualToConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['did_register_user' => true]
+            ['did_register_user' => true],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -509,7 +544,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactBoolReturnsNullWhenAttrsIsDifferentTypeFromConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['did_register_user' => 0]
+            ['did_register_user' => 0],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -522,7 +558,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactBoolReturnsNullWhenWhenNoUserProvidedValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            []
+            [],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -535,7 +572,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testSubstringReturnsTrueWhenConditionValueIsSubstringOfUserValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['headline_text' => 'Limited time, buy now!']
+            ['headline_text' => 'Limited time, buy now!'],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -548,7 +586,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testSubstringReturnsFalseWhenConditionValueIsNotSubstringOfUserValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['headline_text' => 'Breaking news!']
+            ['headline_text' => 'Breaking news!'],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -561,7 +600,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testSubstringReturnsNullWhenUserProvidedvalueNotAString()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['headline_text' => 10]
+            ['headline_text' => 10],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -574,7 +614,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testSubstringReturnsNullWhenNoUserProvidedValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            []
+            [],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -587,7 +628,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testGreaterThanIntReturnsTrueWhenUserValueGreaterThanConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 48.1]
+            ['meters_travelled' => 48.1],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -595,8 +637,10 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
                   $this->gtIntCondition
             )
         );
+
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 49]
+            ['meters_travelled' => 49],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -609,7 +653,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testGreaterThanFloatReturnsTrueWhenUserValueGreaterThanConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 48.3]
+            ['meters_travelled' => 48.3],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -617,8 +662,10 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
                   $this->gtFloatCondition
             )
         );
+
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 49]
+            ['meters_travelled' => 49],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -631,7 +678,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testGreaterThanIntReturnsFalseWhenUserValueNotGreaterThanConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 47.9]
+            ['meters_travelled' => 47.9],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -639,8 +687,10 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
                   $this->gtIntCondition
             )
         );
+
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 47]
+            ['meters_travelled' => 47],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -653,7 +703,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testGreaterThanFloatReturnsFalseWhenUserValueNotGreaterThanConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 48.2]
+            ['meters_travelled' => 48.2],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -661,8 +712,10 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
                   $this->gtFloatCondition
             )
         );
+
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 48]
+            ['meters_travelled' => 48],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -675,7 +728,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testGreaterThanIntReturnsNullWhenUserValueIsNotANumber()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 'a long way']
+            ['meters_travelled' => 'a long way'],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -683,8 +737,10 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
                   $this->gtIntCondition
             )
         );
+
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => false]
+            ['meters_travelled' => false],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -697,7 +753,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testGreaterThanFloatReturnsNullWhenUserValueIsNotANumber()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 'a long way']
+            ['meters_travelled' => 'a long way'],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -705,8 +762,10 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
                   $this->gtFloatCondition
             )
         );
+
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => false]
+            ['meters_travelled' => false],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -719,7 +778,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testGreaterThanIntReturnsNullWhenNoUserProvidedValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            []
+            [],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -732,7 +792,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testGreaterThanFloatReturnsNullWhenNoUserProvidedValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            []
+            [],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -745,16 +806,19 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testLessThanIntReturnsTrueWhenUserValueLessThanConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 47.9]
+            ['meters_travelled' => 47.9],
+            $this->loggerMock
         );
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
+
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 47]
+            ['meters_travelled' => 47],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -767,7 +831,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testLessThanFloatReturnsTrueWhenUserValueLessThanConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 48.1]
+            ['meters_travelled' => 48.1],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -776,7 +841,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 48]
+            ['meters_travelled' => 48],
+            $this->loggerMock
         );
 
         $this->assertTrue(
@@ -789,7 +855,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testLessThanIntReturnsFalseWhenUserValueNotLessThanConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 48.1]
+            ['meters_travelled' => 48.1],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -798,7 +865,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 49]
+            ['meters_travelled' => 49],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -811,7 +879,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testLessThanFloatReturnsFalseWhenUserValueNotLessThanConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 48.2]
+            ['meters_travelled' => 48.2],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -820,7 +889,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 49]
+            ['meters_travelled' => 49],
+            $this->loggerMock
         );
 
         $this->assertFalse(
@@ -833,7 +903,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testLessThanIntReturnsNullWhenUserValueIsNotANumber()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 'a long way']
+            ['meters_travelled' => 'a long way'],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -843,7 +914,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
         );
 
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => false]
+            ['meters_travelled' => false],
+            $this->loggerMock
         );
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
@@ -855,7 +927,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testLessThanFloatReturnsNullWhenUserValueIsNotANumber()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => 'a long way']
+            ['meters_travelled' => 'a long way'],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -864,7 +937,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            ['meters_travelled' => false]
+            ['meters_travelled' => false],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -877,7 +951,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testLessThanIntReturnsNullWhenNoUserProvidedValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            []
+            [],
+            $this->loggerMock
         );
 
         $this->assertNull(
@@ -890,7 +965,8 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testLessThanFloatReturnsNullWhenNoUserProvidedValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-            []
+            [],
+            $this->loggerMock
         );
 
         $this->assertNull(

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
@@ -122,7 +122,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->browserConditionSafari
+                $this->browserConditionSafari
             )
         );
     }
@@ -136,7 +136,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->browserConditionSafari
+                $this->browserConditionSafari
             )
         );
     }
@@ -157,25 +157,25 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->browserConditionSafari
+                $this->browserConditionSafari
             )
         );
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->booleanCondition
+                $this->booleanCondition
             )
         );
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->integerCondition
+                $this->integerCondition
             )
         );
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->doubleCondition
+                $this->doubleCondition
             )
         );
     }
@@ -197,7 +197,6 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
                 ]
             )
         );
-
     }
 
     public function testEvaluateAssumesExactWhenConditionMatchPropertyIsNull()
@@ -304,7 +303,6 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
                 $this->existsCondition
             )
         );
-
     }
 
     public function testExistsReturnsTrueWhenUserProvidedValueIsBoolean()
@@ -330,7 +328,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactStringCondition
+                $this->exactStringCondition
             )
         );
     }
@@ -344,7 +342,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactStringCondition
+                $this->exactStringCondition
             )
         );
     }
@@ -358,7 +356,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactStringCondition
+                $this->exactStringCondition
             )
         );
     }
@@ -386,7 +384,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactIntCondition
+                $this->exactIntCondition
             )
         );
     }
@@ -400,7 +398,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactFloatCondition
+                $this->exactFloatCondition
             )
         );
     }
@@ -414,7 +412,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactIntCondition
+                $this->exactIntCondition
             )
         );
     }
@@ -428,7 +426,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactFloatCondition
+                $this->exactFloatCondition
             )
         );
     }
@@ -442,7 +440,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactIntCondition
+                $this->exactIntCondition
             )
         );
 
@@ -454,7 +452,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactIntCondition
+                $this->exactIntCondition
             )
         );
     }
@@ -467,9 +465,9 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertNull(
-          $customAttrConditionEvaluator->evaluate(
+            $customAttrConditionEvaluator->evaluate(
                 $this->exactFloatCondition
-          )
+            )
         );
 
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -479,9 +477,9 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertNull(
-          $customAttrConditionEvaluator->evaluate(
+            $customAttrConditionEvaluator->evaluate(
                 $this->exactFloatCondition
-          )
+            )
         );
     }
 
@@ -522,7 +520,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactBoolCondition
+                $this->exactBoolCondition
             )
         );
     }
@@ -536,7 +534,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactBoolCondition
+                $this->exactBoolCondition
             )
         );
     }
@@ -550,7 +548,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactBoolCondition
+                $this->exactBoolCondition
             )
         );
     }
@@ -564,7 +562,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactBoolCondition
+                $this->exactBoolCondition
             )
         );
     }
@@ -578,7 +576,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->substringCondition
+                $this->substringCondition
             )
         );
     }
@@ -592,7 +590,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->substringCondition
+                $this->substringCondition
             )
         );
     }
@@ -606,7 +604,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->substringCondition
+                $this->substringCondition
             )
         );
     }
@@ -620,7 +618,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->substringCondition
+                $this->substringCondition
             )
         );
     }
@@ -634,7 +632,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
 
@@ -645,7 +643,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
     }
@@ -659,7 +657,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
 
@@ -670,7 +668,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
     }
@@ -684,7 +682,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
 
@@ -695,7 +693,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
     }
@@ -709,7 +707,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
 
@@ -720,7 +718,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
     }
@@ -734,7 +732,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
 
@@ -745,7 +743,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
     }
@@ -759,7 +757,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
 
@@ -770,7 +768,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
     }
@@ -784,7 +782,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
     }
@@ -798,7 +796,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
     }
@@ -823,7 +821,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
     }
@@ -837,7 +835,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -847,7 +845,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
     }
@@ -861,7 +859,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -871,7 +869,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
     }
@@ -885,7 +883,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -895,7 +893,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
     }
@@ -909,7 +907,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
 
@@ -919,7 +917,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
     }
@@ -933,7 +931,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -943,7 +941,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
     }
@@ -957,7 +955,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
     }
@@ -971,7 +969,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
     }

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -54,7 +54,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
 
         $this->loggerMock->expects($this->at(1))
             ->method('log')
-            ->with(Logger::INFO, "Audiences for experiment \"test_experiment\" collectively evaluated to True.");
+            ->with(Logger::INFO, "Audiences for experiment \"test_experiment\" collectively evaluated to TRUE.");
 
         $this->assertTrue(Validator::isUserInExperiment($this->config, $experiment, [], $this->loggerMock));
     }

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -48,9 +48,13 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
         $experiment->setAudienceIds([]);
         $experiment->setAudienceConditions([]);
 
-        $this->loggerMock->expects($this->once())
+        $this->loggerMock->expects($this->at(0))
             ->method('log')
-            ->with(Logger::INFO, "No Audience attached to experiment \"test_experiment\". Evaluated to True.");
+            ->with(Logger::DEBUG, "Evaluating audiences for experiment \"test_experiment\": [].");
+
+        $this->loggerMock->expects($this->at(1))
+            ->method('log')
+            ->with(Logger::INFO, "Audiences for experiment \"test_experiment\" collectively evaluated to True.");
 
         $this->assertTrue(Validator::isUserInExperiment($this->config, $experiment, [], $this->loggerMock));
     }
@@ -71,12 +75,12 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
 
         Validator::isUserInExperiment($this->config, $experiment, $userAttributes, $this->loggerMock);
 
-        $this->assertContains([Logger::DEBUG, "Evaluating audiences for experiment \"test_experiment\": \"[\"11155\"]\"."], $this->collectedLogs);
+        $this->assertContains([Logger::DEBUG, "Evaluating audiences for experiment \"test_experiment\": [\"11155\"]."], $this->collectedLogs);
         $this->assertContains(
             [Logger::DEBUG, "Starting to evaluate audience \"11155\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"browser_type\",\"type\":\"custom_attribute\",\"value\":\"chrome\"}]]]\"."],
             $this->collectedLogs
         );
-        $this->assertContains([Logger::DEBUG, "Audience \"11155\" evaluated to UNKNOWN."], $this->collectedLogs);
+        $this->assertContains([Logger::INFO, "Audience \"11155\" evaluated to UNKNOWN."], $this->collectedLogs);
         $this->assertContains([Logger::INFO, "Audiences for experiment \"test_experiment\" collectively evaluated to False."], $this->collectedLogs);
     }
 
@@ -93,7 +97,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
         Validator::isUserInExperiment($this->typedConfig, $experiment, ["house" => "I am in Slytherin"], $this->loggerMock);
 
         $this->assertContains(
-            [Logger::DEBUG, "Evaluating audiences for experiment \"audience_combinations_experiment\": \"[\"or\",[\"or\",\"3468206642\",\"3988293898\"]]\"."],
+            [Logger::DEBUG, "Evaluating audiences for experiment \"audience_combinations_experiment\": [\"or\",[\"or\",\"3468206642\",\"3988293898\"]]."],
             $this->collectedLogs
         );
         $this->assertContains(
@@ -101,7 +105,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
             $this->collectedLogs
         );
         $this->assertContains(
-            [Logger::DEBUG, "Audience \"3468206642\" evaluated to False."],
+            [Logger::INFO, "Audience \"3468206642\" evaluated to FALSE."],
             $this->collectedLogs
         );
         $this->assertContains(
@@ -109,7 +113,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
             $this->collectedLogs
         );
         $this->assertContains(
-            [Logger::DEBUG, "Audience \"3988293898\" evaluated to True."],
+            [Logger::INFO, "Audience \"3988293898\" evaluated to TRUE."],
             $this->collectedLogs
         );
         $this->assertContains([Logger::INFO, "Audiences for experiment \"audience_combinations_experiment\" collectively evaluated to True."], $this->collectedLogs);

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Copyright 2019, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ namespace Optimizely\Tests;
+
+ use Monolog\Logger;
+ use Optimizely\ErrorHandler\NoOpErrorHandler;
+ use Optimizely\Logger\NoOpLogger;
+ use Optimizely\ProjectConfig;
+ use Optimizely\Utils\Validator;
+
+ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
+ {
+     protected function setUp()
+     {
+         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
+             ->setMethods(array('log'))
+             ->getMock();
+
+         $this->config = new ProjectConfig(DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
+
+         $this->typedConfig = new ProjectConfig(DATAFILE_WITH_TYPED_AUDIENCES, new NoOpLogger(), new NoOpErrorHandler());
+
+         $this->collectedLogs = [];
+
+         $this->collectLogsForAssertion = function($a, $b) {
+            $this->collectedLogs[] = array($a,$b);
+         };
+     }
+
+     public function testIsUserInExperimentWithNoAudience()
+     {
+         $experiment = $this->config->getExperimentFromKey('test_experiment');
+         $experiment->setAudienceIds([]);
+         $experiment->setAudienceConditions([]);
+
+         $this->loggerMock->expects($this->once())
+             ->method('log')
+             ->with(Logger::INFO, "No Audience attached to experiment \"test_experiment\". Evaluated as True.");
+
+         $this->assertTrue(Validator::isUserInExperiment($this->config, $experiment, [], $this->loggerMock));
+     }
+
+     public function testIsUserInExperimentEvaluatesAudienceIds()
+     {
+         $userAttributes = [
+            "test_attribute" => "test_value_1"
+         ];
+
+         $experiment = $this->config->getExperimentFromKey('test_experiment');
+         $experiment->setAudienceIds(['11155']);
+         $experiment->setAudienceConditions(null);
+
+         $this->loggerMock->expects($this->any())
+                          ->method('log')
+                          ->will($this->returnCallback($this->collectLogsForAssertion));
+
+        Validator::isUserInExperiment($this->config, $experiment, $userAttributes, $this->loggerMock);
+
+        $this->assertContains([Logger::DEBUG, "Evaluating audiences for experiment \"test_experiment\": \"[\"11155\"]\"."], $this->collectedLogs);
+        $this->assertContains([Logger::DEBUG, "User attributes: \"{\"test_attribute\":\"test_value_1\"}\"."], $this->collectedLogs);
+        $this->assertContains([Logger::DEBUG, "Starting to evaluate audience \"11155\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"browser_type\",\"type\":\"custom_attribute\",\"value\":\"chrome\"}]]]\"."],
+                              $this->collectedLogs
+                            );
+        $this->assertContains([Logger::DEBUG, "Audience \"11155\" evaluated as UNKNOWN."], $this->collectedLogs);
+        $this->assertContains([Logger::INFO, "Audiences for experiment \"test_experiment\" collectively evaluated as False."], $this->collectedLogs);
+     }
+
+     public function testIsUserInExperimenEvaluatesAudienceConditions()
+     {
+        $experiment = $this->typedConfig->getExperimentFromKey('audience_combinations_experiment');
+        $experiment->setAudienceIds([]);
+        $experiment->setAudienceConditions(['or', ['or', '3468206642', '3988293898']]);
+
+        $this->loggerMock->expects($this->any())
+                         ->method('log')
+                         ->will($this->returnCallback($this->collectLogsForAssertion));
+
+       Validator::isUserInExperiment($this->typedConfig, $experiment, ["house" => "I am in Slytherin"], $this->loggerMock);
+
+       $this->assertContains([Logger::DEBUG, "Evaluating audiences for experiment \"audience_combinations_experiment\": \"[\"or\",[\"or\",\"3468206642\",\"3988293898\"]]\"."],
+                              $this->collectedLogs
+                            );
+       $this->assertContains([Logger::DEBUG, "User attributes: \"{\"house\":\"I am in Slytherin\"}\"."],
+                             $this->collectedLogs
+                           );
+       $this->assertContains([Logger::DEBUG, "Starting to evaluate audience \"3468206642\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"value\":\"Gryffindor\"}]]]\"."],
+                              $this->collectedLogs
+                            );
+
+       $this->assertContains([Logger::DEBUG, "Audience \"3468206642\" evaluated as False."],
+                               $this->collectedLogs
+                             );
+       $this->assertContains([Logger::DEBUG, "Starting to evaluate audience \"3988293898\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"match\":\"substring\",\"value\":\"Slytherin\"}]]]\"."],
+                              $this->collectedLogs
+                            );
+       $this->assertContains([Logger::DEBUG, "Audience \"3988293898\" evaluated as True."],
+                             $this->collectedLogs
+                            );
+       $this->assertContains([Logger::INFO, "Audiences for experiment \"audience_combinations_experiment\" collectively evaluated as True."], $this->collectedLogs);
+     }
+ }

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -81,7 +81,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
             $this->collectedLogs
         );
         $this->assertContains([Logger::INFO, "Audience \"11155\" evaluated to UNKNOWN."], $this->collectedLogs);
-        $this->assertContains([Logger::INFO, "Audiences for experiment \"test_experiment\" collectively evaluated to False."], $this->collectedLogs);
+        $this->assertContains([Logger::INFO, "Audiences for experiment \"test_experiment\" collectively evaluated to FALSE."], $this->collectedLogs);
     }
 
     public function testIsUserInExperimenEvaluatesAudienceConditions()
@@ -116,6 +116,6 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
             [Logger::INFO, "Audience \"3988293898\" evaluated to TRUE."],
             $this->collectedLogs
         );
-        $this->assertContains([Logger::INFO, "Audiences for experiment \"audience_combinations_experiment\" collectively evaluated to True."], $this->collectedLogs);
+        $this->assertContains([Logger::INFO, "Audiences for experiment \"audience_combinations_experiment\" collectively evaluated to TRUE."], $this->collectedLogs);
     }
 }

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -50,7 +50,7 @@
 
          $this->loggerMock->expects($this->once())
              ->method('log')
-             ->with(Logger::INFO, "No Audience attached to experiment \"test_experiment\". Evaluated as True.");
+             ->with(Logger::INFO, "No Audience attached to experiment \"test_experiment\". Evaluated to True.");
 
          $this->assertTrue(Validator::isUserInExperiment($this->config, $experiment, [], $this->loggerMock));
      }
@@ -72,12 +72,12 @@
         Validator::isUserInExperiment($this->config, $experiment, $userAttributes, $this->loggerMock);
 
         $this->assertContains([Logger::DEBUG, "Evaluating audiences for experiment \"test_experiment\": \"[\"11155\"]\"."], $this->collectedLogs);
-        $this->assertContains([Logger::DEBUG, "User attributes: \"{\"test_attribute\":\"test_value_1\"}\"."], $this->collectedLogs);
-        $this->assertContains([Logger::DEBUG, "Starting to evaluate audience \"11155\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"browser_type\",\"type\":\"custom_attribute\",\"value\":\"chrome\"}]]]\"."],
+        $this->assertContains([Logger::DEBUG, "Starting to evaluate audience \"11155\" with conditions:" +
+                              " \"[\"and\",[\"or\",[\"or\",{\"name\":\"browser_type\",\"type\":\"custom_attribute\",\"value\":\"chrome\"}]]]\"."],
                               $this->collectedLogs
                             );
-        $this->assertContains([Logger::DEBUG, "Audience \"11155\" evaluated as UNKNOWN."], $this->collectedLogs);
-        $this->assertContains([Logger::INFO, "Audiences for experiment \"test_experiment\" collectively evaluated as False."], $this->collectedLogs);
+        $this->assertContains([Logger::DEBUG, "Audience \"11155\" evaluated to UNKNOWN."], $this->collectedLogs);
+        $this->assertContains([Logger::INFO, "Audiences for experiment \"test_experiment\" collectively evaluated to False."], $this->collectedLogs);
      }
 
      public function testIsUserInExperimenEvaluatesAudienceConditions()
@@ -92,25 +92,24 @@
 
        Validator::isUserInExperiment($this->typedConfig, $experiment, ["house" => "I am in Slytherin"], $this->loggerMock);
 
-       $this->assertContains([Logger::DEBUG, "Evaluating audiences for experiment \"audience_combinations_experiment\": \"[\"or\",[\"or\",\"3468206642\",\"3988293898\"]]\"."],
+       $this->assertContains([Logger::DEBUG, "Evaluating audiences for experiment \"audience_combinations_experiment\":" +
+                              " \"[\"or\",[\"or\",\"3468206642\",\"3988293898\"]]\"."],
                               $this->collectedLogs
                             );
-       $this->assertContains([Logger::DEBUG, "User attributes: \"{\"house\":\"I am in Slytherin\"}\"."],
-                             $this->collectedLogs
-                           );
-       $this->assertContains([Logger::DEBUG, "Starting to evaluate audience \"3468206642\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"value\":\"Gryffindor\"}]]]\"."],
+       $this->assertContains([Logger::DEBUG, "Starting to evaluate audience \"3468206642\" with conditions:" +
+                              " \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"value\":\"Gryffindor\"}]]]\"."],
                               $this->collectedLogs
                             );
-
-       $this->assertContains([Logger::DEBUG, "Audience \"3468206642\" evaluated as False."],
+       $this->assertContains([Logger::DEBUG, "Audience \"3468206642\" evaluated to False."],
                                $this->collectedLogs
                              );
-       $this->assertContains([Logger::DEBUG, "Starting to evaluate audience \"3988293898\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"match\":\"substring\",\"value\":\"Slytherin\"}]]]\"."],
+       $this->assertContains([Logger::DEBUG, "Starting to evaluate audience \"3988293898\" with conditions:" +
+                              " \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"match\":\"substring\",\"value\":\"Slytherin\"}]]]\"."],
                               $this->collectedLogs
                             );
-       $this->assertContains([Logger::DEBUG, "Audience \"3988293898\" evaluated as True."],
+       $this->assertContains([Logger::DEBUG, "Audience \"3988293898\" evaluated to True."],
                              $this->collectedLogs
                             );
-       $this->assertContains([Logger::INFO, "Audiences for experiment \"audience_combinations_experiment\" collectively evaluated as True."], $this->collectedLogs);
+       $this->assertContains([Logger::INFO, "Audiences for experiment \"audience_combinations_experiment\" collectively evaluated to True."], $this->collectedLogs);
      }
  }

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -73,8 +73,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains([Logger::DEBUG, "Evaluating audiences for experiment \"test_experiment\": \"[\"11155\"]\"."], $this->collectedLogs);
         $this->assertContains(
-            [Logger::DEBUG, "Starting to evaluate audience \"11155\" with conditions:" +
-                             " \"[\"and\",[\"or\",[\"or\",{\"name\":\"browser_type\",\"type\":\"custom_attribute\",\"value\":\"chrome\"}]]]\"."],
+            [Logger::DEBUG, "Starting to evaluate audience \"11155\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"browser_type\",\"type\":\"custom_attribute\",\"value\":\"chrome\"}]]]\"."],
             $this->collectedLogs
         );
         $this->assertContains([Logger::DEBUG, "Audience \"11155\" evaluated to UNKNOWN."], $this->collectedLogs);
@@ -94,13 +93,11 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
         Validator::isUserInExperiment($this->typedConfig, $experiment, ["house" => "I am in Slytherin"], $this->loggerMock);
 
         $this->assertContains(
-            [Logger::DEBUG, "Evaluating audiences for experiment \"audience_combinations_experiment\":" +
-                             " \"[\"or\",[\"or\",\"3468206642\",\"3988293898\"]]\"."],
+            [Logger::DEBUG, "Evaluating audiences for experiment \"audience_combinations_experiment\": \"[\"or\",[\"or\",\"3468206642\",\"3988293898\"]]\"."],
             $this->collectedLogs
         );
         $this->assertContains(
-            [Logger::DEBUG, "Starting to evaluate audience \"3468206642\" with conditions:" +
-                             " \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"value\":\"Gryffindor\"}]]]\"."],
+            [Logger::DEBUG, "Starting to evaluate audience \"3468206642\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"value\":\"Gryffindor\"}]]]\"."],
             $this->collectedLogs
         );
         $this->assertContains(
@@ -108,8 +105,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
             $this->collectedLogs
         );
         $this->assertContains(
-            [Logger::DEBUG, "Starting to evaluate audience \"3988293898\" with conditions:" +
-                             " \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"match\":\"substring\",\"value\":\"Slytherin\"}]]]\"."],
+            [Logger::DEBUG, "Starting to evaluate audience \"3988293898\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"match\":\"substring\",\"value\":\"Slytherin\"}]]]\"."],
             $this->collectedLogs
         );
         $this->assertContains(

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -77,7 +77,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains([Logger::DEBUG, "Evaluating audiences for experiment \"test_experiment\": [\"11155\"]."], $this->collectedLogs);
         $this->assertContains(
-            [Logger::DEBUG, "Starting to evaluate audience \"11155\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"browser_type\",\"type\":\"custom_attribute\",\"value\":\"chrome\"}]]]\"."],
+            [Logger::DEBUG, "Starting to evaluate audience \"11155\" with conditions: [\"and\",[\"or\",[\"or\",{\"name\":\"browser_type\",\"type\":\"custom_attribute\",\"value\":\"chrome\"}]]]."],
             $this->collectedLogs
         );
         $this->assertContains([Logger::INFO, "Audience \"11155\" evaluated to UNKNOWN."], $this->collectedLogs);
@@ -101,7 +101,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
             $this->collectedLogs
         );
         $this->assertContains(
-            [Logger::DEBUG, "Starting to evaluate audience \"3468206642\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"value\":\"Gryffindor\"}]]]\"."],
+            [Logger::DEBUG, "Starting to evaluate audience \"3468206642\" with conditions: [\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"value\":\"Gryffindor\"}]]]."],
             $this->collectedLogs
         );
         $this->assertContains(
@@ -109,7 +109,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
             $this->collectedLogs
         );
         $this->assertContains(
-            [Logger::DEBUG, "Starting to evaluate audience \"3988293898\" with conditions: \"[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"match\":\"substring\",\"value\":\"Slytherin\"}]]]\"."],
+            [Logger::DEBUG, "Starting to evaluate audience \"3988293898\" with conditions: [\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"match\":\"substring\",\"value\":\"Slytherin\"}]]]."],
             $this->collectedLogs
         );
         $this->assertContains(

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -344,7 +344,27 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         // Both audience Ids and audience conditions exist. Audience Ids is ignored.
         $experiment->setAudienceIds([]);
         $experiment->setAudienceConditions('7718080042');
+        
+        $this->assertTrue(
+            Validator::isUserInExperiment(
+                $config,
+                $experiment,
+                ['device_type' => 'iPhone', 'location' => 'San Francisco'],
+                $this->loggerMock
+            )
+        );
+    }
 
+    public function testIsUserInExperimentWithUnknownAudienceId()
+    {
+        $config = new ProjectConfig(DATAFILE, $this->loggerMock, new NoOpErrorHandler());
+        $experiment = $config->getExperimentFromKey('test_experiment');
+
+        // Both audience Ids and audience conditions exist. Audience Ids is ignored.
+        $experiment->setAudienceIds([]);
+        $experiment->setAudienceConditions(["or", "unknown_audience_id", "7718080042"]);
+        
+        // User qualifies for audience with ID "7718080042".
         $this->assertTrue(
             Validator::isUserInExperiment(
                 $config,

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -135,10 +135,10 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(Validator::IsFiniteNumber(INF));
         $this->assertFalse(Validator::IsFiniteNumber(-INF));
         $this->assertFalse(Validator::IsFiniteNumber(NAN));
-        $this->assertFalse(Validator::IsFiniteNumber(pow(2,53) + 1));
-        $this->assertFalse(Validator::IsFiniteNumber(-pow(2,53) - 1));
-        $this->assertFalse(Validator::IsFiniteNumber(pow(2,53) + 2.0));
-        $this->assertFalse(Validator::IsFiniteNumber(-pow(2,53) - 2.0));
+        $this->assertFalse(Validator::IsFiniteNumber(pow(2, 53) + 1));
+        $this->assertFalse(Validator::IsFiniteNumber(-pow(2, 53) - 1));
+        $this->assertFalse(Validator::IsFiniteNumber(pow(2, 53) + 2.0));
+        $this->assertFalse(Validator::IsFiniteNumber(-pow(2, 53) - 2.0));
     }
 
     public function testIsFiniteNumberWithValidValues()
@@ -147,9 +147,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Validator::IsFiniteNumber(5));
         $this->assertTrue(Validator::IsFiniteNumber(5.5));
         // float pow(2,53) + 1.0 evaluates to float pow(2,53)
-        $this->assertTrue(Validator::IsFiniteNumber(pow(2,53) + 1.0));
-        $this->assertTrue(Validator::IsFiniteNumber(-pow(2,53) - 1.0));
-        $this->assertTrue(Validator::IsFiniteNumber(pow(2,53)));
+        $this->assertTrue(Validator::IsFiniteNumber(pow(2, 53) + 1.0));
+        $this->assertTrue(Validator::IsFiniteNumber(-pow(2, 53) - 1.0));
+        $this->assertTrue(Validator::IsFiniteNumber(pow(2, 53)));
     }
 
     public function testAreEventTagsValidValidEventTags()
@@ -298,7 +298,6 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->loggerMock
             )
         );
-
     }
 
     // test that isUserInExperiment returns false when some audience is attached to experiment
@@ -478,8 +477,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     {
         // Valid values
         $this->assertTrue(Validator::doesArrayContainOnlyStringKeys(
-            ["name"=> "favorite_ice_cream", "type"=> "custom_attribute", "match"=> "exists"])
-        );
+            ["name"=> "favorite_ice_cream", "type"=> "custom_attribute", "match"=> "exists"]
+        ));
 
         // Invalid values
         $this->assertFalse(Validator::doesArrayContainOnlyStringKeys([]));

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,7 +216,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             Validator::isUserInExperiment(
                 $configMock,
                 $experiment,
-                null
+                null,
+                $this->loggerMock
             )
         );
 
@@ -224,7 +225,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             Validator::isUserInExperiment(
                 $configMock,
                 $experiment,
-                []
+                [],
+                $this->loggerMock
             )
         );
     }
@@ -236,7 +238,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             Validator::isUserInExperiment(
                 $config,
                 $config->getExperimentFromKey('test_experiment'),
-                ['device_type' => 'iPhone', 'location' => 'San Francisco']
+                ['device_type' => 'iPhone', 'location' => 'San Francisco'],
+                $this->loggerMock
             )
         );
     }
@@ -248,7 +251,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             Validator::isUserInExperiment(
                 $config,
                 $config->getExperimentFromKey('test_experiment'),
-                ['device_type' => 'Android', 'location' => 'San Francisco']
+                ['device_type' => 'Android', 'location' => 'San Francisco'],
+                $this->loggerMock
             )
         );
     }
@@ -266,7 +270,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             Validator::isUserInExperiment(
                 $config,
                 $experiment,
-                []
+                [],
+                $this->loggerMock
             )
         );
 
@@ -277,7 +282,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             Validator::isUserInExperiment(
                 $config,
                 $experiment,
-                []
+                [],
+                $this->loggerMock
             )
         );
 
@@ -288,10 +294,11 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             Validator::isUserInExperiment(
                 $config,
                 $experiment,
-                []
+                [],
+                $this->loggerMock
             )
         );
-        
+
     }
 
     // test that isUserInExperiment returns false when some audience is attached to experiment
@@ -304,12 +311,13 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         // Both audience Ids and audience conditions exist. Audience Ids is ignored.
         $experiment->setAudienceIds(['7718080042']);
         $experiment->setAudienceConditions(['11155']);
-        
+
         $this->assertFalse(
             Validator::isUserInExperiment(
                 $config,
                 $experiment,
-                ['device_type' => 'Android', 'location' => 'San Francisco']
+                ['device_type' => 'Android', 'location' => 'San Francisco'],
+                $this->loggerMock
             )
         );
 
@@ -317,12 +325,13 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $experiment = $config->getExperimentFromKey('test_experiment');
         $experiment->setAudienceIds(['11155']);
         $experiment->setAudienceConditions(null);
-        
+
         $this->assertFalse(
             Validator::isUserInExperiment(
                 $config,
                 $experiment,
-                ['device_type' => 'iPhone', 'location' => 'San Francisco']
+                ['device_type' => 'iPhone', 'location' => 'San Francisco'],
+                $this->loggerMock
             )
         );
     }
@@ -336,12 +345,13 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         // Both audience Ids and audience conditions exist. Audience Ids is ignored.
         $experiment->setAudienceIds([]);
         $experiment->setAudienceConditions('7718080042');
-        
+
         $this->assertTrue(
             Validator::isUserInExperiment(
                 $config,
                 $experiment,
-                ['device_type' => 'iPhone', 'location' => 'San Francisco']
+                ['device_type' => 'iPhone', 'location' => 'San Francisco'],
+                $this->loggerMock
             )
         );
     }
@@ -373,7 +383,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             Validator::isUserInExperiment(
                 $configMock,
                 $experiment,
-                ['device_type' => 'iPhone', 'location' => 'San Francisco']
+                ['device_type' => 'iPhone', 'location' => 'San Francisco'],
+                $this->loggerMock
             )
         );
     }
@@ -429,7 +440,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             Validator::isUserInExperiment(
                 $configMock,
                 $experiment,
-                ['should_do_it' => true, 'house' => 'foo']
+                ['should_do_it' => true, 'house' => 'foo'],
+                $this->loggerMock
             )
         );
     }


### PR DESCRIPTION
Summary
-------
This adds logging to audience evaluation. 
For now, logging is limited to issues with user passed value and not the condition value (datafile). 

## Test plan
- Updated Unit Tests in OptimizelyTest and DecisionServiceTest to assert only relevant logs. Position based logging had to be removed since isUserInExperiment is a static method and can not be mocked. 
- Added new tests for isUserInExperiment and CustomAttributeConditionEvaluator

## Issues
- OASIS-3854
