### PR TITLE
ci: Enforce Static Code Analyzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,31 +6,39 @@ php:
   - '7.1'
   - '7.2'
   - '7.3'
-before_install:
-- composer install --dev
+install: "composer install"
 addons:
   srcclr: true
 script:
 - mkdir -p build/logs
 - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-after_script:
-- vendor/bin/php-coveralls -v
+after_script: "vendor/bin/php-coveralls -v"
 
-# Integration tests need to run first to reset the PR build status to pending
+# Linting and Integration tests need to run first to reset the PR build status to pending
 stages:
+  - 'Linting'
   - 'Integration tests'
   - 'Test'
 
 jobs:
   include:
+    - stage: 'Linting'
+      language: php
+      php: '7.0'
+      install: 'composer require "squizlabs/php_codesniffer=*"'
+      script: 'composer lint'
+      after_script: skip
+      after_success: travis_terminate 0
     - stage: 'Integration tests'
+      merge_mode: replace
       env: SDK=php
+      cache: false
       language: python
-      before_install: skip
       install:
         - "pip install awscli"
       before_script:
         - "aws s3 cp s3://optimizely-travisci-artifacts/ci/trigger_fullstack-sdk-compat.sh ci/ && chmod u+x ci/trigger_fullstack-sdk-compat.sh"
       script:
         - "ci/trigger_fullstack-sdk-compat.sh"
-      after_success: skip
+      after_script: skip
+      after_success: travis_terminate 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
     - stage: 'Linting'
       language: php
       php: '7.0'
-      install: 'composer global require "squizlabs/php_codesniffer=*"'
+      install: 'composer require "squizlabs/php_codesniffer=*"'
       script: 'composer lint'
       after_script: skip
       after_success: travis_terminate 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
     - stage: 'Linting'
       language: php
       php: '7.0'
-      install: 'composer require "squizlabs/php_codesniffer=*"'
+      install: 'composer global require "squizlabs/php_codesniffer=*"'
       script: 'composer lint'
       after_script: skip
       after_success: travis_terminate 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 after_script: "vendor/bin/php-coveralls -v"
 
-# Linting and Integration tests need to run first to reset the PR build status to pending
+# Linting and integration tests need to run first to reset the PR build status to pending
 stages:
   - 'Linting'
   - 'Integration tests'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,11 @@ We welcome contributions and feedback! All contributors must sign our [Contribut
 
 * **All code must have test coverage.** We use PHPUnit. Changes in functionality should have accompanying unit tests. Bug fixes should have accompanying regression tests.
 * Tests are located in `tests` with one file per class.
+* Lint your code with PHP CodeSniffer before submitting.
+
+## Style
+We enforce [PSR-2](https://www.php-fig.org/psr/psr-2/) rules with some minor [deviations](phpcs.xml). Run linter by executing `composer lint` and autocorrect lint errors by executing `composer beautify`.
+
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,11 @@
       "email": "developers@optimizely.com"
     }
   ],
+  "scripts": {
+        "test": "phpunit",
+        "lint": "phpcs",
+        "beautify": "phpcbf"
+  },
   "require": {
     "php": ">=5.5",
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
@@ -19,7 +24,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",
-    "php-coveralls/php-coveralls": "v2.0.0"
+    "php-coveralls/php-coveralls": "v2.0.0",
+    "squizlabs/php_codesniffer": "3.*"
   },
   "autoload": {
     "psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="OptimizelyPSR2">
+  <!-- description for custom ruleset -->
+  <description>A custom coding standard for Optimizely PHP-SDK based on PSR2</description>
+
+  <!-- If no files or directories are specified on commandline, these files will be sniffed -->
+  <file>./src</file>
+  <file>./tests</file>
+
+  <!-- Exclude patterns for files to be excluded from sniffing -->
+  <!-- <exclude-pattern>./tests/EventTests/*</exclude-pattern> -->
+
+  <!-- Embed command line arguments in config file. -->
+  <arg name="tab-width" value="4"/>
+
+  <!-- To exclude any rule sniff, get sniff name by running phpcs with -s switch -->
+  <rule ref="PSR2">
+    <exclude name="Generic.Files.LineLength.TooLong"/>
+    <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
+    <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses"/>
+    <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
+  </rule >
+</ruleset>

--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,9 +90,9 @@ class Bucketer
 
         /* murmurhash3_int returns both positive and negative integers for PHP x86 versions
         it returns negative integers when it tries to create 2^32 integers while PHP doesn't support
-        unsigned integers and can store integers only upto 2^31. 
+        unsigned integers and can store integers only upto 2^31.
         Observing generated hashcodes and their corresponding bucket values after normalization
-        indicates that a negative bucket number on x86 is exactly 10,000 less than it's 
+        indicates that a negative bucket number on x86 is exactly 10,000 less than it's
         corresponding bucket number on x64. Hence we can safely add 10,000 to a negative number to
         make it consistent across both of the PHP variants. */
         

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2018, Optimizely Inc and Contributors
+ * Copyright 2017-2019, Optimizely Inc and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,8 +93,8 @@ class DecisionService
     {
         $bucketingIdKey = ControlAttributes::BUCKETING_ID;
 
-        if (isset($userAttributes[$bucketingIdKey])){
-            if (is_string($userAttributes[$bucketingIdKey])){
+        if (isset($userAttributes[$bucketingIdKey])) {
+            if (is_string($userAttributes[$bucketingIdKey])) {
                 return $userAttributes[$bucketingIdKey];
             }
             $this->_logger->log(Logger::WARNING, 'Bucketing ID attribute is not a string. Defaulted to user ID.');
@@ -308,7 +308,7 @@ class DecisionService
             break;
         }
         // Evaluate Everyone Else Rule / Last Rule now
-        $experiment = $rolloutRules[sizeof($rolloutRules)-1];        
+        $experiment = $rolloutRules[sizeof($rolloutRules)-1];
         
         // Evaluate if user meets the audience condition of Everyone Else Rule / Last Rule now
         if (!Validator::isUserInExperiment($this->_projectConfig, $experiment, $userAttributes)) {

--- a/src/Optimizely/Entity/Experiment.php
+++ b/src/Optimizely/Entity/Experiment.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016, 2018, Optimizely
+ * Copyright 2016, 2018-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ class Experiment
 
     /**
      * @var array/string Single audience ID the experiment is attached to or
-     *                   hierarchical conditions array of audience IDs related by AND/OR/NOT operators. 
+     *                   hierarchical conditions array of audience IDs related by AND/OR/NOT operators.
      */
     private $_audienceConditions;
 

--- a/src/Optimizely/Entity/FeatureVariable.php
+++ b/src/Optimizely/Entity/FeatureVariable.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017,2019, Optimizely
+ * Copyright 2017, 2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Entity/FeatureVariable.php
+++ b/src/Optimizely/Entity/FeatureVariable.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017, Optimizely
+ * Copyright 2017,2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ class FeatureVariable
     private $_defaultValue;
 
 
-    public function __construct($id =null, $key = null, $type = null, $defaultValue = null)
+    public function __construct($id = null, $key = null, $type = null, $defaultValue = null)
     {
         $this->_id = $id;
         $this->_key = $key;

--- a/src/Optimizely/Entity/Variation.php
+++ b/src/Optimizely/Entity/Variation.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ class Variation
     }
 
     /**
-     * @param  string Variable ID
+     * @param string Variable ID
      *
      * @return VariableUsage Variable usage instance corresponding to given variable ID
      */

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ class EventBuilder
             ANONYMIZE_IP => $config->getAnonymizeIP()
         ];
 
-        if(!is_null($attributes)) {
+        if (!is_null($attributes)) {
             foreach ($attributes as $attributeKey => $attributeValue) {
                 // Omit attributes that are not supported by the log endpoint.
                 if (Validator::isAttributeValid($attributeKey, $attributeValue)) {
@@ -184,15 +184,13 @@ class EventBuilder
         $decisions = [];
 
         foreach ($experimentVariationMap as $experimentId => $variationId) {
-            
-            
             $experiment = $config->getExperimentFromId($experimentId);
             $eventEntity = $config->getEvent($eventKey);
 
-            $decision = [                
+            $decision = [
                 CAMPAIGN_ID => $experiment->getLayerId(),
                 EXPERIMENT_ID => $experiment->getId(),
-                VARIATION_ID => $variationId                
+                VARIATION_ID => $variationId
             ];
             $decisions [] = $decision;
         }
@@ -201,7 +199,7 @@ class EventBuilder
             ENTITY_ID => $eventEntity->getId(),
             TIMESTAMP => time()*1000,
             UUID => GeneratorUtils::getRandomUuid(),
-            KEY => $eventKey            
+            KEY => $eventKey
         ];
 
         if (!is_null($eventTags)) {
@@ -215,9 +213,9 @@ class EventBuilder
                 $eventDict[EventTagUtils::NUMERIC_EVENT_METRIC_NAME] = $eventValue;
             }
 
-            if(count($eventTags) > 0) {
+            if (count($eventTags) > 0) {
                 $eventDict['tags'] = $eventTags;
-            }            
+            }
         }
 
         $singleSnapshot[DECISIONS] = $decisions;

--- a/src/Optimizely/Event/Builder/Params.php
+++ b/src/Optimizely/Event/Builder/Params.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ define('CLIENT_VERSION', 'client_version');
 define('CUSTOM_ATTRIBUTE_FEATURE_TYPE', 'custom');
 define('DECISIONS', 'decisions');
 define('ENTITY_ID', 'entity_id');
-define('EVENTS', 'events');;
+define('EVENTS', 'events');
 define('EXPERIMENT_ID', 'experiment_id');
 define('KEY', 'key');
 define('PROJECT_ID', 'project_id');

--- a/src/Optimizely/Logger/DefaultLogger.php
+++ b/src/Optimizely/Logger/DefaultLogger.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016,2018-2019 Optimizely
+ * Copyright 2016, 2018-2019 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Logger/DefaultLogger.php
+++ b/src/Optimizely/Logger/DefaultLogger.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016,2018 Optimizely
+ * Copyright 2016,2018-2019 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ class DefaultLogger implements LoggerInterface
     /**
      * DefaultLogger constructor.
      *
-     * @param int $minLevel Minimum level of messages to be logged.
-     * @param string $stream The PHP stream to log output.
+     * @param int    $minLevel Minimum level of messages to be logged.
+     * @param string $stream   The PHP stream to log output.
      */
     public function __construct($minLevel = Logger::INFO, $stream = "stdout")
     {

--- a/src/Optimizely/Notification/NotificationCenter.php
+++ b/src/Optimizely/Notification/NotificationCenter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2018, Optimizely Inc and Contributors
+ * Copyright 2017-2019, Optimizely Inc and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ class NotificationCenter
     /**
      * Adds a notification callback for a notification type to the notification center
      *
-     * @param string $notification_type     One of the constants defined in NotificationType
+     * @param string   $notification_type     One of the constants defined in NotificationType
      * @param callable $notification_callback A valid PHP callback
      *
      * @return null  Given invalid notification type/callback
@@ -122,12 +122,13 @@ class NotificationCenter
      *
      * @deprecated Use 'clearNotificationListeners' instead.
      */
-    public function clearNotifications($notification_type){
-      $this->_logger->log(
-        Logger::WARNING,
-        "'clearNotifications' is deprecated. Call 'clearNotificationListeners' instead."
-      );
-      $this->clearNotificationListeners($notification_type);
+    public function clearNotifications($notification_type)
+    {
+        $this->_logger->log(
+            Logger::WARNING,
+            "'clearNotifications' is deprecated. Call 'clearNotificationListeners' instead."
+        );
+        $this->clearNotificationListeners($notification_type);
     }
 
     /**
@@ -152,12 +153,13 @@ class NotificationCenter
      *
      * @deprecated Use 'clearAllNotificationListeners' instead.
      */
-    public function cleanAllNotifications(){
-      $this->_logger->log(
-        Logger::WARNING,
-        "'cleanAllNotifications' is deprecated. Call 'clearAllNotificationListeners' instead."
-      );
-      $this->clearAllNotificationListeners();
+    public function cleanAllNotifications()
+    {
+        $this->_logger->log(
+            Logger::WARNING,
+            "'cleanAllNotifications' is deprecated. Call 'clearAllNotificationListeners' instead."
+        );
+        $this->clearAllNotificationListeners();
     }
 
     /**

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,10 +230,10 @@ class Optimizely
     }
 
     /**
-     * @param  string Experiment key
-     * @param  string Variation key
-     * @param  string User ID
-     * @param  array Associative array of user attributes
+     * @param string Experiment key
+     * @param string Variation key
+     * @param string User ID
+     * @param array Associative array of user attributes
      */
     protected function sendImpressionEvent($experimentKey, $variationKey, $userId, $attributes)
     {
@@ -302,7 +302,7 @@ class Optimizely
                 self::EXPERIMENT_KEY =>$experimentKey,
                 self::USER_ID => $userId
             ]
-        	)
+        )
         ) {
             return null;
         }
@@ -338,7 +338,7 @@ class Optimizely
                 self::EVENT_KEY =>$eventKey,
                 self::USER_ID => $userId
             ]
-        	)
+        )
         ) {
             return null;
         }
@@ -435,7 +435,7 @@ class Optimizely
                 self::EXPERIMENT_KEY =>$experimentKey,
                 self::USER_ID => $userId
             ]
-        	)
+        )
         ) {
             return null;
         }
@@ -475,7 +475,8 @@ class Optimizely
                 self::EXPERIMENT_KEY =>$experimentKey,
                 self::USER_ID => $userId
             ]
-        )) {
+        )
+        ) {
             return false;
         }
         return $this->_config->setForcedVariation($experimentKey, $userId, $variationKey);
@@ -496,7 +497,8 @@ class Optimizely
                 self::EXPERIMENT_KEY =>$experimentKey,
                 self::USER_ID => $userId
             ]
-        )) {
+        )
+        ) {
             return null;
         }
 
@@ -530,7 +532,7 @@ class Optimizely
                 self::FEATURE_FLAG_KEY =>$featureFlagKey,
                 self::USER_ID => $userId
             ]
-            )
+        )
         ) {
             return false;
         }
@@ -585,7 +587,7 @@ class Optimizely
             [
                 self::USER_ID => $userId
             ]
-            )
+        )
         ) {
             return $enabledFeatureKeys;
         }
@@ -630,7 +632,7 @@ class Optimizely
                 self::VARIABLE_KEY => $variableKey,
                 self::USER_ID => $userId
             ]
-            )
+        )
         ) {
             return null;
         }
@@ -804,14 +806,14 @@ class Optimizely
     }
 
     /**
-    * Calls Validator::validateNonEmptyString for each value in array
-    * Logs for each invalid value
-    *
-    * @param array values to validate
-    * @param logger
-    *
-    * @return bool True if all of the values are valid, False otherwise
-    */
+     * Calls Validator::validateNonEmptyString for each value in array
+     * Logs for each invalid value
+     *
+     * @param array values to validate
+     * @param logger
+     *
+     * @return bool True if all of the values are valid, False otherwise
+     */
     protected function validateInputs(array $values, $logLevel = Logger::ERROR)
     {
         $isValid = true;

--- a/src/Optimizely/ProjectConfig.php
+++ b/src/Optimizely/ProjectConfig.php
@@ -196,7 +196,7 @@ class ProjectConfig
         $this->_logger = $logger;
         $this->_errorHandler = $errorHandler;
         $this->_version = $config['version'];
-        if(!in_array($this->_version, $supportedVersions)){
+        if (!in_array($this->_version, $supportedVersions)) {
             throw new InvalidDatafileVersionException(
                 "This version of the PHP SDK does not support the given datafile version: {$this->_version}."
             );
@@ -256,7 +256,7 @@ class ProjectConfig
         }
 
         // Conditions in typedAudiences are not expected to be string-encoded so they don't need
-        // to be decoded unlike audiences. 
+        // to be decoded unlike audiences.
         foreach (array_values($typedAudienceIdMap) as $typedAudience) {
             $typedAudience->setConditionsList($typedAudience->getConditions());
         }
@@ -402,7 +402,7 @@ class ProjectConfig
     }
 
     /**
-     * @param  String $featureKey Key of the feature flag
+     * @param String $featureKey Key of the feature flag
      *
      * @return FeatureFlag Entity corresponding to the key.
      */
@@ -418,7 +418,7 @@ class ProjectConfig
     }
 
     /**
-     * @param  String $rolloutId
+     * @param String $rolloutId
      *
      * @return Rollout
      */
@@ -577,8 +577,6 @@ class ProjectConfig
 
         $this->_logger->log(
             Logger::ERROR,
-   
-
             sprintf(
                 'No variable key "%s" defined in datafile for feature flag "%s".',
                 $variableKey,

--- a/src/Optimizely/Utils/ConditionTreeEvaluator.php
+++ b/src/Optimizely/Utils/ConditionTreeEvaluator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018, Optimizely
+ * Copyright 2018-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ class ConditionTreeEvaluator
 
     /**
      * Returns an array of supported operators.
-     * 
+     *
      * @return array List of operators.
      */
     protected function getOperators()
@@ -35,9 +35,9 @@ class ConditionTreeEvaluator
 
     /**
      * Returns corresponding evaluator method name for the given operator.
-     * 
-     * @param  mixed  $operator  Operator to get relevant evaluator method. 
-     * 
+     *
+     * @param mixed $operator Operator to get relevant evaluator method.
+     *
      * @return string Corresponding method to the given operator.
      */
     protected function getEvaluatorByOperatorType($operator)
@@ -53,9 +53,9 @@ class ConditionTreeEvaluator
     /**
      * Evaluates an array of conditions as if the evaluator had been applied
      * to each entry and the results AND-ed together.
-     * 
-     * @param array     $conditions  Audience conditions list.
-     * @param callable  $leafEvaluator Method to evaluate leaf condition. 
+     *
+     * @param array    $conditions    Audience conditions list.
+     * @param callable $leafEvaluator Method to evaluate leaf condition.
      *
      * @return null|boolean True if all the operands evaluate to true.
      *                      False if a single operand evaluates to false.
@@ -67,11 +67,11 @@ class ConditionTreeEvaluator
         foreach ($conditions as $condition) {
             $result = $this->evaluate($condition, $leafEvaluator);
             
-            if($result === false) {
+            if ($result === false) {
                 return false;
             }
 
-            if($result === null) {
+            if ($result === null) {
                 $sawNullResult = true;
             }
         }
@@ -82,9 +82,9 @@ class ConditionTreeEvaluator
     /**
      * Evaluates an array of conditions as if the evaluator had been applied
      * to each entry and the results OR-ed together.
-     * 
-     * @param array     $conditions  Audience conditions list.
-     * @param callable  $leafEvaluator Method to evaluate leaf condition. 
+     *
+     * @param array    $conditions    Audience conditions list.
+     * @param callable $leafEvaluator Method to evaluate leaf condition.
      *
      * @return null|boolean True if any operand evaluates to true.
      *                    False if all operands evaluate to false.
@@ -96,11 +96,11 @@ class ConditionTreeEvaluator
         foreach ($conditions as $condition) {
             $result = $this->evaluate($condition, $leafEvaluator);
 
-            if($result === true) {
+            if ($result === true) {
                 return true;
             }
 
-            if($result === null) {
+            if ($result === null) {
                 $sawNullResult = true;
             }
         }
@@ -111,9 +111,9 @@ class ConditionTreeEvaluator
     /**
      * Evaluates an array of conditions as if the evaluator had been applied
      * to a single entry and NOT was applied to the result.
-     * 
-     * @param array     $conditions  Audience conditions list.
-     * @param callable  $leafEvaluator Method to evaluate leaf condition. 
+     *
+     * @param array    $conditions    Audience conditions list.
+     * @param callable $leafEvaluator Method to evaluate leaf condition.
      *
      * @return null|boolean True if the operand evaluates to false.
      *                      False if the operand evaluates to true.
@@ -132,8 +132,8 @@ class ConditionTreeEvaluator
     /**
      * Function to evaluate audience conditions against user's attributes.
      *
-     * @param array     $conditions Nested array of and/or/not conditions representing the audience conditions.
-     * @param callable  $leafEvaluator Method to evaluate leaf condition. 
+     * @param array    $conditions    Nested array of and/or/not conditions representing the audience conditions.
+     * @param callable $leafEvaluator Method to evaluate leaf condition.
      *
      * @return null|boolean Result of evaluating the conditions using the operator rules.
      *                      and the leaf evaluator. Null if conditions couldn't be evaluated.
@@ -141,14 +141,13 @@ class ConditionTreeEvaluator
     public function evaluate($conditions, callable $leafEvaluator)
     {
         // When parsing audiences tree the leaf node is a string representing an audience ID.
-        // When parsing conditions of a single audience the leaf node is an associative array with all keys of type string. 
+        // When parsing conditions of a single audience the leaf node is an associative array with all keys of type string.
         if (is_string($conditions) || Validator::doesArrayContainOnlyStringKeys($conditions)) {
-            
             $leafCondition = $conditions;
             return $leafEvaluator($leafCondition);
         }
             
-        if(in_array($conditions[0], $this->getOperators())) {
+        if (in_array($conditions[0], $this->getOperators())) {
             $operator = array_shift($conditions);
         } else {
             $operator = self::OR_OPERATOR;

--- a/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
+++ b/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018, Optimizely
+ * Copyright 2018-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,12 +31,12 @@ class CustomAttributeConditionEvaluator
 
     /**
      * @var UserAttributes
-    */
+     */
     protected $userAttributes;
 
     /**
      * CustomAttributeConditionEvaluator constructor
-     * 
+     *
      * @param array $userAttributes Associative array of user attributes to values.
      */
     public function __construct(array $userAttributes)
@@ -46,13 +46,13 @@ class CustomAttributeConditionEvaluator
 
     /**
      * Sets null for missing keys in a leaf condition.
-     * 
+     *
      * @param array $leafCondition The leaf condition node of an audience.
      */
     protected function setNullForMissingKeys(array $leafCondition)
     {
         $keys = ['type', 'match', 'value'];
-        foreach($keys as $key) {
+        foreach ($keys as $key) {
             $leafCondition[$key] = isset($leafCondition[$key]) ? $leafCondition[$key]: null;
         }
 
@@ -61,7 +61,7 @@ class CustomAttributeConditionEvaluator
 
     /**
      * Gets the supported match types for condition evaluation.
-     * 
+     *
      * @return array List of supported match types.
      */
     protected function getMatchTypes()
@@ -72,9 +72,9 @@ class CustomAttributeConditionEvaluator
 
     /**
      * Gets the evaluator method name for the given match type.
-     * 
-     * @param  string $matchType Match type for which to get evaluator. 
-     * 
+     *
+     * @param string $matchType Match type for which to get evaluator.
+     *
      * @return string Corresponding evaluator method name.
      */
     protected function getEvaluatorByMatchType($matchType)
@@ -91,14 +91,14 @@ class CustomAttributeConditionEvaluator
 
     /**
      * Checks if the given input is a valid value for exact condition evaluation.
-     * 
-     * @param  $value Input to check.
-     * 
+     *
+     * @param $value Input to check.
+     *
      * @return boolean true if given input is a string/boolean/finite number, false otherwise.
      */
     protected function isValueValidForExactConditions($value)
     {
-        if(is_string($value) || is_bool($value) || Validator::isFiniteNumber($value)) {
+        if (is_string($value) || is_bool($value) || Validator::isFiniteNumber($value)) {
             return true;
         }
 
@@ -107,9 +107,9 @@ class CustomAttributeConditionEvaluator
 
     /**
      * Evaluate the given exact match condition for the given user attributes.
-     * 
-     * @param  object $condition
-     * 
+     *
+     * @param object $condition
+     *
      * @return null|boolean true if the user attribute value is equal (===) to the condition value,
      *                      false if the user attribute value is not equal (!==) to the condition value,
      *                      null if the condition value or user attribute value has an invalid type, or
@@ -122,26 +122,27 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if(!$this->isValueValidForExactConditions($userValue) ||
-            !$this->isValueValidForExactConditions($conditionValue) ||
-            !Validator::areValuesSameType($conditionValue, $userValue)) {
+        if (!$this->isValueValidForExactConditions($userValue)
+            || !$this->isValueValidForExactConditions($conditionValue)
+            || !Validator::areValuesSameType($conditionValue, $userValue)
+        ) {
                 return null;
-            }
+        }
 
         return $conditionValue == $userValue;
     }
 
     /**
      * Evaluate the given exists match condition for the given user attributes.
-     * 
-     * @param  object $condition
-     * 
+     *
+     * @param object $condition
+     *
      * @return null|boolean true if both:
      *                           1) the user attributes have a value for the given condition, and
      *                           2) the user attribute value is not null.
      *                      false otherwise.
      */
-    protected function existsEvaluator($condition) 
+    protected function existsEvaluator($condition)
     {
         $conditionName = $condition['name'];
         return isset($this->userAttributes[$conditionName]);
@@ -149,9 +150,9 @@ class CustomAttributeConditionEvaluator
 
     /**
      * Evaluate the given greater than match condition for the given user attributes.
-     * 
-     * @param  object $condition
-     * 
+     *
+     * @param object $condition
+     *
      * @return boolean true if the user attribute value is greater than the condition value,
      *                 false if the user attribute value is less than or equal to the condition value,
      *                 null if the condition value isn't a number or the user attribute value
@@ -163,7 +164,7 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if(!Validator::isFiniteNumber($userValue) || !Validator::isFiniteNumber($conditionValue)) {
+        if (!Validator::isFiniteNumber($userValue) || !Validator::isFiniteNumber($conditionValue)) {
             return null;
         }
 
@@ -172,9 +173,9 @@ class CustomAttributeConditionEvaluator
 
     /**
      * Evaluate the given less than match condition for the given user attributes.
-     * 
-     * @param  object $condition
-     * 
+     *
+     * @param object $condition
+     *
      * @return boolean true if the user attribute value is less than the condition value,
      *                 false if the user attribute value is greater than or equal to the condition value,
      *                 null if the condition value isn't a number or the user attribute value
@@ -186,7 +187,7 @@ class CustomAttributeConditionEvaluator
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if(!Validator::isFiniteNumber($userValue) || !Validator::isFiniteNumber($conditionValue)) {
+        if (!Validator::isFiniteNumber($userValue) || !Validator::isFiniteNumber($conditionValue)) {
             return null;
         }
 
@@ -194,22 +195,22 @@ class CustomAttributeConditionEvaluator
     }
 
      /**
-     * Evaluate the given substring than match condition for the given user attributes.
-     * 
-     * @param  object $condition
-     * 
-     * @return boolean true if the condition value is a substring of the user attribute value,
-     *                 false if the condition value is not a substring of the user attribute value,
-     *                 null if the condition value isn't a string or the user attribute value
-     *                 isn't a string.
-     */
+      * Evaluate the given substring than match condition for the given user attributes.
+      *
+      * @param object $condition
+      *
+      * @return boolean true if the condition value is a substring of the user attribute value,
+      *                 false if the condition value is not a substring of the user attribute value,
+      *                 null if the condition value isn't a string or the user attribute value
+      *                 isn't a string.
+      */
     protected function substringEvaluator($condition)
     {
         $conditionName = $condition['name'];
         $conditionValue = $condition['value'];
         $userValue = isset($this->userAttributes[$conditionName]) ? $this->userAttributes[$conditionName]: null;
 
-        if(!is_string($userValue) || !is_string($conditionValue)) {
+        if (!is_string($userValue) || !is_string($conditionValue)) {
             return null;
         }
 
@@ -219,26 +220,26 @@ class CustomAttributeConditionEvaluator
     /**
      * Function to evaluate audience conditions against user's attributes.
      *
-     * @param array $leafCondition  Condition to be evaluated. 
+     * @param array $leafCondition Condition to be evaluated.
      *
-     * @return null|boolean true/false if the given user attributes match/don't match the given conditions, 
+     * @return null|boolean true/false if the given user attributes match/don't match the given conditions,
      * null if the given user attributes and conditions can't be evaluated.
      */
     public function evaluate($leafCondition)
     {
         $leafCondition = $this->setNullForMissingKeys($leafCondition);
 
-        if($leafCondition['type'] !== self::CUSTOM_ATTRIBUTE_CONDITION_TYPE) {
+        if ($leafCondition['type'] !== self::CUSTOM_ATTRIBUTE_CONDITION_TYPE) {
             return null;
         }
 
-        if(($leafCondition['match']) === null) {
+        if (($leafCondition['match']) === null) {
             $conditionMatch = self::EXACT_MATCH_TYPE;
         } else {
             $conditionMatch = $leafCondition['match'];
         }
 
-        if(!in_array($conditionMatch, $this->getMatchTypes())) {
+        if (!in_array($conditionMatch, $this->getMatchTypes())) {
             return null;
         }
 

--- a/src/Optimizely/Utils/EventTagUtils.php
+++ b/src/Optimizely/Utils/EventTagUtils.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2018, Optimizely
+ * Copyright 2017-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ class EventTagUtils
      * Grab the numeric event value from the event tags. "value" is a reserved keyword.
      * The value of 'value' can be a float or a numeric string
      *
-     * @param  $eventTags array Representing metadata associated with the event.
+     * @param $eventTags array Representing metadata associated with the event.
      * @param $logger instance of LoggerInterface
      *
      * @return float value of 'value' or null

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -61,11 +61,11 @@ class Validator
      */
     public static function areAttributesValid($attributes)
     {
-        if(!is_array($attributes)){
+        if (!is_array($attributes)) {
             return false;
         }
 
-        if (empty($attributes)){
+        if (empty($attributes)) {
             return true;
         }
         // At least one key string to be an associative array.
@@ -86,7 +86,7 @@ class Validator
        
         if (is_nan($value) || is_infinite($value)) {
             return false;
-        }        
+        }
 
         if (abs($value) > pow(2, 53)) {
             return false;
@@ -154,11 +154,11 @@ class Validator
         }
 
         $customAttrCondEval = new CustomAttributeConditionEvaluator($userAttributes);
-        $evaluateCustomAttr = function($leafCondition) use ($customAttrCondEval) {
+        $evaluateCustomAttr = function ($leafCondition) use ($customAttrCondEval) {
             return $customAttrCondEval->evaluate($leafCondition);
         };
 
-        $evaluateAudience = function($audienceId) use ($config, $evaluateCustomAttr) {
+        $evaluateAudience = function ($audienceId) use ($config, $evaluateCustomAttr) {
             $conditionTreeEvaluator = new ConditionTreeEvaluator();
 
             $audience = $config->getAudience($audienceId);
@@ -224,12 +224,12 @@ class Validator
     }
 
     /**
-     * Method to verify that both values belong to same type. 
+     * Method to verify that both values belong to same type.
      * Float/Double and Integer are considered similar.
-     * 
-     * @param  mixed  $firstVal
-     * @param  mixed  $secondVal
-     * 
+     *
+     * @param mixed $firstVal
+     * @param mixed $secondVal
+     *
      * @return bool   True if values belong to similar types. Otherwise, False.
      */
     public static function areValuesSameType($firstVal, $secondVal)
@@ -238,8 +238,8 @@ class Validator
         $secondValType = gettype($secondVal);
         $numberTypes = array('double', 'integer');
 
-        if(in_array($firstValType, $numberTypes) && in_array($secondValType, $numberTypes)) {
-            return True;
+        if (in_array($firstValType, $numberTypes) && in_array($secondValType, $numberTypes)) {
+            return true;
         }
 
         return $firstValType == $secondValType;
@@ -247,12 +247,13 @@ class Validator
 
     /**
      * Returns true only if given input is an array with all of it's keys of type string.
+     *
      * @param  mixed $arr
      * @return bool  True if array contains all string keys. Otherwise, false.
      */
     public static function doesArrayContainOnlyStringKeys($arr)
     {
-        if(!is_array($arr) || empty($arr)) {
+        if (!is_array($arr) || empty($arr)) {
             return false;
         }
 

--- a/src/Optimizely/Utils/VariableTypeUtils.php
+++ b/src/Optimizely/Utils/VariableTypeUtils.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017, Optimizely
+ * Copyright 2017, 2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,21 +33,21 @@ class VariableTypeUtils
         $return_value = null;
 
         switch ($variableType) {
-        case FeatureVariable::BOOLEAN_TYPE:
-            $return_value = strtolower($value) == "true";
-            break;
+            case FeatureVariable::BOOLEAN_TYPE:
+                $return_value = strtolower($value) == "true";
+                break;
 
-        case FeatureVariable::INTEGER_TYPE:
-            if (ctype_digit($value)) {
-                $return_value = (int) $value;
-            }
-            break;
+            case FeatureVariable::INTEGER_TYPE:
+                if (ctype_digit($value)) {
+                    $return_value = (int) $value;
+                }
+                break;
 
-        case FeatureVariable::DOUBLE_TYPE:
-            if (is_numeric($value)) {
-                $return_value = (float) $value;
-            }
-            break;
+            case FeatureVariable::DOUBLE_TYPE:
+                if (is_numeric($value)) {
+                    $return_value = (float) $value;
+                }
+                break;
         }
 
         if (is_null($return_value) && $logger) {

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2018, Optimizely
+ * Copyright 2017-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1070,7 +1070,8 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->method('log');
 
         $this->assertNull(
-            $this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', $user_attributes));
+            $this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', $user_attributes)
+        );
     }
 
     // ============== END of tests - when the user qualifies for targeting rule (audience match) ======================
@@ -1171,7 +1172,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->with(
                 Logger::DEBUG,
                 "User 'user_1' did not meet the audience conditions to be in rollout rule '{$experiment2->getKey()}'."
-        );    
+            );
 
         $this->assertNull($this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', $user_attributes));
     }

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,28 +142,33 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateImpressionEventWithAttributesNoValue()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
             [
                 'entity_id' => '7723280020',
                 'key' => 'device_type',
                 'type' => 'custom',
                 'value' => 'iPhone',
-            ],[
+            ],
+            [
                 'entity_id' => '7723340007',
                 'key' => 'boolean_key',
                 'type' => 'custom',
                 'value' => true
-            ],[
+            ],
+            [
                 'entity_id' => '7723340008',
                 'key' => 'double_key',
                 'type' => 'custom',
                 'value' => 5.5
-            ],[
+            ],
+            [
                 'entity_id' => '7723340009',
                 'key' => 'integer_key',
                 'type' => 'custom',
                 'value' => 5
-            ]);
+            ]
+        );
 
         $this->expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
@@ -196,12 +201,14 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateImpressionEventWithFalseAttributesNoValue()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
-          [ 'entity_id' => '7723280020',
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
+            [ 'entity_id' => '7723280020',
             'key' => 'device_type',
             'type' => 'custom',
             'value' => 'false',
-          ]);
+            ]
+        );
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
@@ -231,12 +238,14 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateImpressionEventWithZeroAttributesNoValue()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
-          [ 'entity_id' => '7723280020',
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
+            [ 'entity_id' => '7723280020',
             'key' => 'device_type',
             'type' => 'custom',
             'value' => 0,
-          ]);
+            ]
+        );
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
@@ -292,8 +301,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
     
     public function testCreateImpressionEventWithUserAgentWhenBotFilteringIsEnabled()
     {
-        $this->expectedEventParams['visitors'][0]['attributes'] = 
-          [[ 
+        $this->expectedEventParams['visitors'][0]['attributes'] =
+          [[
             'entity_id' => '$opt_user_agent',
             'key' => '$opt_user_agent',
             'type' => 'custom',
@@ -329,13 +338,15 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateImpressionEventWithInvalidAttributeTypes()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
             [
                 'entity_id' => '7723280020',
                 'key' => 'device_type',
                 'type' => 'custom',
                 'value' => 'iPhone',
-            ],[
+            ],
+            [
                 'entity_id' => '7723340008',
                 'key' => 'double_key',
                 'type' => 'custom',
@@ -371,8 +382,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateImpressionEventWithUserAgentWhenBotFilteringIsDisabled()
     {
-        $this->expectedEventParams['visitors'][0]['attributes'] = 
-          [[ 
+        $this->expectedEventParams['visitors'][0]['attributes'] =
+          [[
             'entity_id' => '$opt_user_agent',
             'key' => '$opt_user_agent',
             'type' => 'custom',
@@ -418,8 +429,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateImpressionEventWithUserAgentWhenBotFilteringIsNull()
     {
-        $this->expectedEventParams['visitors'][0]['attributes'] = 
-          [[ 
+        $this->expectedEventParams['visitors'][0]['attributes'] =
+          [[
             'entity_id' => '$opt_user_agent',
             'key' => '$opt_user_agent',
             'type' => 'custom',
@@ -457,7 +468,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->fakeParamsToReconcile($logEvent);
         $result = $this->areLogEventsEqual($this->expectedLogEvent, $logEvent);
         $this->assertTrue($result[0], $result[1]);
-    }    
+    }
 
     public function testCreateConversionEventNoAttributesNoValue()
     {
@@ -490,12 +501,14 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateConversionEventWithAttributesNoValue()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
-          [ 'entity_id' => '7723280020',
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
+            [ 'entity_id' => '7723280020',
             'key' => 'device_type',
             'type' => 'custom',
             'value' => 'iPhone',
-          ]);
+            ]
+        );
 
         $this->expectedEventParams['visitors'][0]['snapshots'][0]['events'][0] =
           [
@@ -607,12 +620,14 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateConversionEventWithAttributesWithValue()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
-          [ 'entity_id' => '7723280020',
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
+            [ 'entity_id' => '7723280020',
             'key' => 'device_type',
             'type' => 'custom',
             'value' => 'iPhone',
-          ]);
+            ]
+        );
 
         $this->expectedEventParams['visitors'][0]['snapshots'][0]['events'][0] =
            [
@@ -661,12 +676,14 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateConversionEventWithAttributesWithNumericTag()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
-          [ 'entity_id' => '7723280020',
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
+            [ 'entity_id' => '7723280020',
             'key' => 'device_type',
             'type' => 'custom',
             'value' => 'iPhone',
-          ]);
+            ]
+        );
 
         $this->expectedEventParams['visitors'][0]['snapshots'][0]['events'][0] =
            [
@@ -752,18 +769,21 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
     // (since this custom attribute entity is not generated by GAE)
     public function testCreateImpressionEventWithBucketingIDAttribute()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
-          [
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
+            [
             'entity_id' => '7723280020',
             'key' => 'device_type',
             'type' => 'custom',
             'value' => 'iPhone'
-          ],[
+            ],
+            [
             'entity_id' => '$opt_bucketing_id',
             'key' => '$opt_bucketing_id',
             'type' => 'custom',
             'value' => 'variation'
-          ]);
+            ]
+        );
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
@@ -793,18 +813,21 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateConversionEventWithBucketingIDAttribute()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
-          [
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
+            [
             'entity_id' => '7723280020',
             'key' => 'device_type',
             'type' => 'custom',
             'value' => 'iPhone',
-          ],[
+            ],
+            [
             'entity_id' => '$opt_bucketing_id',
             'key' => '$opt_bucketing_id',
             'type' => 'custom',
             'value' => 'variation',
-          ]);
+            ]
+        );
 
         $this->expectedEventParams['visitors'][0]['snapshots'][0]['events'][0] =
            [
@@ -844,12 +867,14 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateConversionEventWithUserAgentAttribute()
     {
-       array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
-          [ 'entity_id' => '$opt_user_agent',
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
+            [ 'entity_id' => '$opt_user_agent',
             'key' => '$opt_user_agent',
             'type' => 'custom',
             'value' => 'Firefox',
-          ]);
+            ]
+        );
 
         $this->expectedEventParams['visitors'][0]['snapshots'][0]['events'][0] =
           [
@@ -885,12 +910,12 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testCreateConversionEventWhenEventUsedInMultipleExp()
-    {  
+    {
         $eventTags = [
             'revenue' => 4200,
             'value' => 1.234,
             'non-revenue' => 'abc'
-        ];      
+        ];
         $this->expectedEventParams['visitors'][0]['snapshots'][0]['decisions'][] = [
             'campaign_id' => '4',
             'experiment_id' => '122230',
@@ -903,22 +928,25 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'uuid' => $this->uuid,
             'key' => 'multi_exp_event',
             'revenue' => 4200,
-            'value' => 1.234,                    
-            'tags' => $eventTags,                        
+            'value' => 1.234,
+            'tags' => $eventTags,
         ];
         
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],  
-            [                 
+        array_unshift(
+            $this->expectedEventParams['visitors'][0]['attributes'],
+            [
                 'entity_id' => '7723280020',
                 'key' => 'device_type',
                 'type' => 'custom',
                 'value' => 'iPhone'
-            ],[
+            ],
+            [
                 'entity_id' => '7723340004',
                 'key' => 'location',
                 'type' => 'custom',
                 'value' => 'SF'
-            ]);
+            ]
+        );
         
         $decisions = [
             '7716830082' => '7721010009',
@@ -930,23 +958,22 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         ];
 
         $logEvent = $this->eventBuilder->createConversionEvent(
-                $this->config,
-                'multi_exp_event',
-                $decisions,
-                $this->testUserId,
-                $userAttributes,
-                $eventTags
-            );
+            $this->config,
+            'multi_exp_event',
+            $decisions,
+            $this->testUserId,
+            $userAttributes,
+            $eventTags
+        );
         $expectedLogEvent = new LogEvent(
-                $this->expectedEventUrl,
-                $this->expectedEventParams,
-                $this->expectedEventHttpVerb,
-                $this->expectedEventHeaders
+            $this->expectedEventUrl,
+            $this->expectedEventParams,
+            $this->expectedEventHttpVerb,
+            $this->expectedEventHeaders
         );
             
         $logEvent = $this->fakeParamsToReconcile($logEvent);
         $result = $this->areLogEventsEqual($expectedLogEvent, $logEvent);
         $this->assertTrue($result[0], $result[1]);
-            
     }
 }

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -869,10 +869,11 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
     {
         array_unshift(
             $this->expectedEventParams['visitors'][0]['attributes'],
-            [ 'entity_id' => '$opt_user_agent',
-            'key' => '$opt_user_agent',
-            'type' => 'custom',
-            'value' => 'Firefox',
+            [ 
+                'entity_id' => '$opt_user_agent',
+                'key' => '$opt_user_agent',
+                'type' => 'custom',
+                'value' => 'Firefox',
             ]
         );
 

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -869,7 +869,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
     {
         array_unshift(
             $this->expectedEventParams['visitors'][0]['attributes'],
-            [ 
+            [
                 'entity_id' => '$opt_user_agent',
                 'key' => '$opt_user_agent',
                 'type' => 'custom',

--- a/tests/LoggerTests/NoOpLoggerTest.php
+++ b/tests/LoggerTests/NoOpLoggerTest.php
@@ -14,11 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+namespace Optimizely\Tests;
 
 use Monolog\Logger;
 use Optimizely\Logger\NoOpLogger;
 
-class NoOpLoggerTest extends PHPUnit_Framework_TestCase
+class NoOpLoggerTest extends \PHPUnit_Framework_TestCase
 {
     public function testNoOpLogger()
     {

--- a/tests/NotificationTests/NotificationCenterTest.php
+++ b/tests/NotificationTests/NotificationCenterTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2018, Optimizely
+ * Copyright 2017-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -240,7 +240,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
     {
         // Note: anonymous methods sent with the same body will be re-added.
         // Only variable and object methods can be checked for duplication
-        
+
         $functionToSend = function () {
         };
         $this->notificationCenterObj->clearAllNotificationListeners();
@@ -276,7 +276,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
             2,
             $this->notificationCenterObj->addNotificationListener(NotificationType::TRACK, $functionToSend)
         );
-        
+
         /////////////////////////////////////////////////////////////////////////
         // ===== verify that an object method with same body isn't re-added ===== //
         /////////////////////////////////////////////////////////////////////////
@@ -368,7 +368,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
         /////////////////////////////////////////////////////////////////////
         // === Verify that callback is removed for a valid notification ID //
         /////////////////////////////////////////////////////////////////////
-        
+
         $valid_id = 3;
         $this->loggerMock->expects($this->at(0))
             ->method('log')
@@ -410,33 +410,33 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
     public function testClearNotificationsAndVerifyThatClearNotificationListenersWithArgsIsCalled()
     {
       # Mock NotificationCenter
-      $this->notificationCenterMock = $this->getMockBuilder(NotificationCenter::class)
+        $this->notificationCenterMock = $this->getMockBuilder(NotificationCenter::class)
         ->setConstructorArgs(array($this->loggerMock, $this->errorHandlerMock))
         ->setMethods(array('clearNotificationListeners'))
         ->getMock();
 
       # Log deprecation message
-      $this->loggerMock->expects($this->at(0))
+        $this->loggerMock->expects($this->at(0))
         ->method('log')
         ->with(
-          Logger::WARNING,
-          sprintf("'clearNotifications' is deprecated. Call 'clearNotificationListeners' instead.")
+            Logger::WARNING,
+            sprintf("'clearNotifications' is deprecated. Call 'clearNotificationListeners' instead.")
         );
 
-      $this->notificationCenterMock->expects($this->once())
+        $this->notificationCenterMock->expects($this->once())
         ->method('clearNotificationListeners')
         ->with(
-          NotificationType::ACTIVATE
+            NotificationType::ACTIVATE
         );
 
-      $this->notificationCenterMock->clearNotifications(NotificationType::ACTIVATE);
+        $this->notificationCenterMock->clearNotifications(NotificationType::ACTIVATE);
     }
 
     public function testClearNotificationListeners()
     {
         // ensure that notifications length is zero for each notification type
         $this->notificationCenterObj->clearAllNotificationListeners();
-        
+
         // add a callback for multiple notification types
         $this->notificationCenterObj->addNotificationListener(
             NotificationType::ACTIVATE,
@@ -499,7 +499,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
         ///////////////////////////////////////////////////////////////////////////////////////
         // === Verify that all notifications are removed given a valid notification type === //
         ///////////////////////////////////////////////////////////////////////////////////////
-         
+
         $this->loggerMock->expects($this->at(0))
             ->method('log')
             ->with(
@@ -607,34 +607,34 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
     public function testCleanAllNotificationsAndVerifyThatClearAllNotificationListenersIsCalled()
     {
       # Mock NotificationCenter
-      $this->notificationCenterMock = $this->getMockBuilder(NotificationCenter::class)
+        $this->notificationCenterMock = $this->getMockBuilder(NotificationCenter::class)
         ->setConstructorArgs(array($this->loggerMock, $this->errorHandlerMock))
         ->setMethods(array('clearAllNotificationListeners'))
         ->getMock();
 
       # Log deprecation message
-      $this->loggerMock->expects($this->at(0))
+        $this->loggerMock->expects($this->at(0))
         ->method('log')
         ->with(
-          Logger::WARNING,
-          sprintf("'cleanAllNotifications' is deprecated. Call 'clearAllNotificationListeners' instead.")
+            Logger::WARNING,
+            sprintf("'cleanAllNotifications' is deprecated. Call 'clearAllNotificationListeners' instead.")
         );
 
-      $this->notificationCenterMock->expects($this->once())
+        $this->notificationCenterMock->expects($this->once())
         ->method('clearAllNotificationListeners');
 
-      $this->notificationCenterMock->cleanAllNotifications();
+        $this->notificationCenterMock->cleanAllNotifications();
     }
 
     public function testSendNotificationsGivenLessThanExpectedNumberOfArguments()
     {
         $clientObj = new FireNotificationTester;
         $this->notificationCenterObj->clearAllNotificationListeners();
-        
+
         // add a notification callback with arguments
         $this->notificationCenterObj->addNotificationListener(
             NotificationType::ACTIVATE,
-            array($clientObj, 'decision_callback_with_args')
+            array($clientObj, 'decisionCallbackWithArgs')
         );
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -654,7 +654,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
     public function testSendNotificationsAndVerifyThatAllCallbacksWithoutArgsAreCalled()
     {
         $clientMock = $this->getMockBuilder(FireNotificationTester::class)
-            ->setMethods(array('decision_callback_no_args', 'decision_callback_no_args_2', 'track_callback_no_args'))
+            ->setMethods(array('decisionCallbackNoArgs', 'decisionCallbackNoArgs2', 'trackCallbackNoArgs'))
             ->getMock();
 
         $this->notificationCenterObj->clearAllNotificationListeners();
@@ -662,15 +662,15 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
         //add notification callbacks
         $this->notificationCenterObj->addNotificationListener(
             NotificationType::ACTIVATE,
-            array($clientMock, 'decision_callback_no_args')
+            array($clientMock, 'decisionCallbackNoArgs')
         );
         $this->notificationCenterObj->addNotificationListener(
             NotificationType::ACTIVATE,
-            array($clientMock, 'decision_callback_no_args_2')
+            array($clientMock, 'decisionCallbackNoArgs2')
         );
         $this->notificationCenterObj->addNotificationListener(
             NotificationType::TRACK,
-            array($clientMock, 'track_callback_no_args')
+            array($clientMock, 'trackCallbackNoArgs')
         );
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -678,26 +678,26 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         $clientMock->expects($this->exactly(1))
-            ->method('decision_callback_no_args');
+            ->method('decisionCallbackNoArgs');
         $clientMock->expects($this->exactly(1))
-            ->method('decision_callback_no_args_2');
+            ->method('decisionCallbackNoArgs2');
 
         $clientMock->expects($this->never())
-            ->method('track_callback_no_args');
+            ->method('trackCallbackNoArgs');
 
         $this->notificationCenterObj->sendNotifications(NotificationType::ACTIVATE);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // === Verify that none of the callbacks are called given an invalid NotificationType === //
         ////////////////////////////////////////////////////////////////////////////////////////////
-        
-        $clientMock->expects($this->never())
-            ->method('decision_callback_no_args');
-        $clientMock->expects($this->never())
-            ->method('decision_callback_no_args_2');
 
         $clientMock->expects($this->never())
-            ->method('track_callback_no_args');
+            ->method('decisionCallbackNoArgs');
+        $clientMock->expects($this->never())
+            ->method('decisionCallbackNoArgs2');
+
+        $clientMock->expects($this->never())
+            ->method('trackCallbackNoArgs');
 
         $this->notificationCenterObj->sendNotifications("abacada");
     }
@@ -705,7 +705,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
     public function testSendNotificationsAndVerifyThatAllCallbacksWithArgsAreCalled()
     {
         $clientMock = $this->getMockBuilder(FireNotificationTester::class)
-            ->setMethods(array('decision_callback_with_args', 'decision_callback_with_args_2', 'track_callback_no_args'))
+            ->setMethods(array('decisionCallbackWithArgs', 'decisionCallbackWithArgs2', 'trackCallbackNoArgs'))
             ->getMock();
 
         $this->notificationCenterObj->clearAllNotificationListeners();
@@ -713,15 +713,15 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
         //add notification callbacks with args
         $this->notificationCenterObj->addNotificationListener(
             NotificationType::ACTIVATE,
-            array($clientMock, 'decision_callback_with_args')
+            array($clientMock, 'decisionCallbackWithArgs')
         );
         $this->notificationCenterObj->addNotificationListener(
             NotificationType::ACTIVATE,
-            array($clientMock, 'decision_callback_with_args_2')
+            array($clientMock, 'decisionCallbackWithArgs2')
         );
         $this->notificationCenterObj->addNotificationListener(
             NotificationType::TRACK,
-            array($clientMock, 'track_callback_no_args')
+            array($clientMock, 'trackCallbackNoArgs')
         );
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -729,7 +729,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         $clientMock->expects($this->exactly(1))
-            ->method('decision_callback_with_args')
+            ->method('decisionCallbackWithArgs')
             ->with(
                 5,
                 5.5,
@@ -739,7 +739,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
                 }
             );
         $clientMock->expects($this->exactly(1))
-            ->method('decision_callback_with_args_2')
+            ->method('decisionCallbackWithArgs2')
             ->with(
                 5,
                 5.5,
@@ -749,7 +749,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
                 }
             );
         $clientMock->expects($this->never())
-            ->method('track_callback_no_args');
+            ->method('trackCallbackNoArgs');
 
         $this->notificationCenterObj->sendNotifications(
             NotificationType::ACTIVATE,

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     const OUTPUT_STREAM = 'output';
 
     private $datafile;
+    
     private $eventBuilderMock;
     private $loggerMock;
     private $optimizelyObject;
@@ -63,7 +64,9 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $this->optimizelyObject = new Optimizely($this->datafile, null, $this->loggerMock);
         $this->optimizelyTypedAudienceObject = new Optimizely(
-            $this->typedAudiencesDataFile, null, $this->loggerMock
+            $this->typedAudiencesDataFile,
+            null,
+            $this->loggerMock
         );
 
         $this->projectConfig = new ProjectConfig($this->datafile, $this->loggerMock, new NoOpErrorHandler());
@@ -637,7 +640,6 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         //Should be included via exact match number audience with id '3468206646'
         $this->assertEquals('A', $optimizelyMock->activate('typed_audience_experiment', 'test_user', $userAttributes));
-
     }
 
     public function testActivateWithAttributesTypedAudienceMismatch()

--- a/tests/ProjectConfigTest.php
+++ b/tests/ProjectConfigTest.php
@@ -511,7 +511,9 @@ class ProjectConfigTest extends \PHPUnit_Framework_TestCase
     public function testGetAudiencePrefersTypedAudiencesOverAudiences()
     {
         $projectConfig = new ProjectConfig(
-            DATAFILE_WITH_TYPED_AUDIENCES, $this->loggerMock, $this->errorHandlerMock
+            DATAFILE_WITH_TYPED_AUDIENCES,
+            $this->loggerMock,
+            $this->errorHandlerMock
         );
 
         // test that typedAudience is returned when an audience exists with the same ID.
@@ -560,7 +562,8 @@ class ProjectConfigTest extends \PHPUnit_Framework_TestCase
     {
         $this->loggerMock->expects($this->once())
             ->method('log')
-            ->with(Logger::WARNING, 
+            ->with(
+                Logger::WARNING,
                 'Attribute $opt_xyz unexpectedly has reserved prefix $opt_; using attribute ID instead of reserved attribute name.'
             );
 
@@ -690,7 +693,7 @@ class ProjectConfigTest extends \PHPUnit_Framework_TestCase
         $variationKey = 'control';
         $variationKey2 = 'group_exp_1_var_1';
         $invalidVariationKey = 'invalid_variation';
-        
+
         $optlyObject = new Optimizely(DATAFILE, new ValidEventDispatcher(), $this->loggerMock);
         $userAttributes = [
             'device_type' => 'iPhone',

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ define(
         }
       ],
       "audienceIds": [
-        
+
       ],
       "variations": [
         {
@@ -94,7 +94,7 @@ define(
         }
       ],
       "forcedVariations": {
-        
+
       },
       "id": "7716830585"
     },
@@ -107,7 +107,7 @@ define(
       ],
       "id": "122230",
       "forcedVariations": {
-        
+
       },
       "trafficAllocation": [
         {
@@ -195,11 +195,11 @@ define(
       "status": "Running",
       "layerId": "5",
       "audienceIds": [
-        
+
       ],
       "id": "122235",
       "forcedVariations": {
-        
+
       },
       "trafficAllocation": [
         {
@@ -241,11 +241,11 @@ define(
       "status": "Running",
       "layerId": "5",
       "audienceIds": [
-        
+
       ],
       "id": "122238",
       "forcedVariations": {
-        
+
       },
       "trafficAllocation": [
         {
@@ -287,11 +287,11 @@ define(
       "status": "Running",
       "layerId": "6",
       "audienceIds": [
-        
+
       ],
       "id": "122241",
       "forcedVariations": {
-        
+
       },
       "trafficAllocation": [
         {
@@ -375,7 +375,7 @@ define(
             }
           ],
           "audienceIds": [
-            
+
           ],
           "variations": [
             {
@@ -421,7 +421,7 @@ define(
             }
           ],
           "audienceIds": [
-            
+
           ],
           "variations": [
             {
@@ -448,7 +448,7 @@ define(
             }
           ],
           "forcedVariations": {
-            
+
           },
           "id": "7718750065"
         }
@@ -522,7 +522,7 @@ define(
         "7718750065"
       ],
       "variables": [
-        
+
       ]
     },
     {
@@ -562,7 +562,7 @@ define(
       "key": "boolean_single_variable_feature",
       "rolloutId": "166660",
       "experimentIds": [
-        
+
       ],
       "variables": [
         {
@@ -633,10 +633,10 @@ define(
       "key": "empty_feature",
       "rolloutId": "",
       "experimentIds": [
-        
+
       ],
       "variables": [
-        
+
       ]
     }
   ],
@@ -706,7 +706,7 @@ define(
           "status": "Running",
           "layerId": "166660",
           "audienceIds": [
-            
+
           ],
           "variations": [
             {
@@ -746,7 +746,7 @@ define(
               "id": "177775",
               "key": "177775",
               "variables": [
-                
+
               ],
               "featureEnabled": true
             }
@@ -764,14 +764,14 @@ define(
           "status": "Running",
           "layerId": "166661",
           "audienceIds": [
-            
+
           ],
           "variations": [
             {
               "id": "177780",
               "key": "177780",
               "variables": [
-                
+
               ],
               "featureEnabled": true
             }
@@ -844,8 +844,8 @@ define(
 );
 
 define(
-  'DATAFILE_WITH_TYPED_AUDIENCES',
-  '{
+    'DATAFILE_WITH_TYPED_AUDIENCES',
+    '{
       "version": "4",
       "rollouts": [
         {
@@ -1285,23 +1285,23 @@ class OptimizelyTester extends Optimizely
 
 class FireNotificationTester
 {
-    public function decision_callback_no_args()
+    public function decisionCallbackNoArgs()
     {
     }
 
-    public function decision_callback_no_args_2()
+    public function decisionCallbackNoArgs2()
     {
     }
 
-    public function decision_callback_with_args($anInt, $aDouble, $aString, $anArray, $aFunction)
+    public function decisionCallbackWithArgs($anInt, $aDouble, $aString, $anArray, $aFunction)
     {
     }
 
-    public function decision_callback_with_args_2($anInt, $aDouble, $aString, $anArray, $aFunction)
+    public function decisionCallbackWithArgs2($anInt, $aDouble, $aString, $anArray, $aFunction)
     {
     }
 
-    public function track_callback_no_args()
+    public function trackCallbackNoArgs()
     {
     }
 }

--- a/tests/UtilsTests/ConditionTreeEvaluatorTest.php
+++ b/tests/UtilsTests/ConditionTreeEvaluatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018, Optimizely
+ * Copyright 2018-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,24 +47,28 @@ class ConditionTreeEvaluatorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Helper method to create a callback that returns passed arguments on consecutive calls.
-     * 
+     *
      * @param  mixed $a
      * @param  mixed $b
      * @param  mixed $c
-     * 
-     * @return callable 
+     *
+     * @return callable
      */
-    protected function getLeafEvaluator($a, $b = null, $c = null) {
+    protected function getLeafEvaluator($a, $b = null, $c = null)
+    {
         $numOfCalls = 0;
 
         $leafEvaluator = function ($some_arg) use (&$numOfCalls, $a, $b, $c) {
             $numOfCalls++;
-            if($numOfCalls == 1)
+            if ($numOfCalls == 1) {
                 return $a;
-            if($numOfCalls == 2)
+            }
+            if ($numOfCalls == 2) {
                 return $b;
-            if($numOfCalls == 3)
+            }
+            if ($numOfCalls == 3) {
                 return $c;
+            }
 
             return null;
         };
@@ -336,5 +340,4 @@ class ConditionTreeEvaluatorTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
-
 }

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018, Optimizely
+ * Copyright 2018-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,7 +117,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->browserConditionSafari
+                $this->browserConditionSafari
             )
         );
     }
@@ -130,7 +130,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->browserConditionSafari
+                $this->browserConditionSafari
             )
         );
     }
@@ -150,25 +150,25 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->browserConditionSafari
+                $this->browserConditionSafari
             )
         );
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->booleanCondition
+                $this->booleanCondition
             )
         );
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->integerCondition
+                $this->integerCondition
             )
         );
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->doubleCondition
+                $this->doubleCondition
             )
         );
     }
@@ -189,7 +189,6 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
                 ]
             )
         );
-
     }
 
     public function testEvaluateAssumesExactWhenConditionMatchPropertyIsNull()
@@ -288,7 +287,6 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
                 $this->existsCondition
             )
         );
-
     }
 
     public function testExistsReturnsTrueWhenUserProvidedValueIsBoolean()
@@ -312,7 +310,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactStringCondition
+                $this->exactStringCondition
             )
         );
     }
@@ -325,7 +323,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactStringCondition
+                $this->exactStringCondition
             )
         );
     }
@@ -338,7 +336,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactStringCondition
+                $this->exactStringCondition
             )
         );
     }
@@ -364,7 +362,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactIntCondition
+                $this->exactIntCondition
             )
         );
     }
@@ -377,7 +375,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactFloatCondition
+                $this->exactFloatCondition
             )
         );
     }
@@ -390,7 +388,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactIntCondition
+                $this->exactIntCondition
             )
         );
     }
@@ -403,7 +401,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactFloatCondition
+                $this->exactFloatCondition
             )
         );
     }
@@ -416,7 +414,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactIntCondition
+                $this->exactIntCondition
             )
         );
 
@@ -426,7 +424,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactIntCondition
+                $this->exactIntCondition
             )
         );
     }
@@ -434,23 +432,23 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
     public function testExactFloatReturnsNullWhenAttrsIsDifferentTypeFromConditionValue()
     {
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-          ['lasers_count' => 'hi']
+            ['lasers_count' => 'hi']
         );
 
         $this->assertNull(
-          $customAttrConditionEvaluator->evaluate(
+            $customAttrConditionEvaluator->evaluate(
                 $this->exactFloatCondition
-          )
+            )
         );
 
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
-          ['lasers_count' => true]
+            ['lasers_count' => true]
         );
 
         $this->assertNull(
-          $customAttrConditionEvaluator->evaluate(
+            $customAttrConditionEvaluator->evaluate(
                 $this->exactFloatCondition
-          )
+            )
         );
     }
 
@@ -488,7 +486,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactBoolCondition
+                $this->exactBoolCondition
             )
         );
     }
@@ -501,7 +499,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactBoolCondition
+                $this->exactBoolCondition
             )
         );
     }
@@ -514,7 +512,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactBoolCondition
+                $this->exactBoolCondition
             )
         );
     }
@@ -527,7 +525,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->exactBoolCondition
+                $this->exactBoolCondition
             )
         );
     }
@@ -540,7 +538,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->substringCondition
+                $this->substringCondition
             )
         );
     }
@@ -553,7 +551,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->substringCondition
+                $this->substringCondition
             )
         );
     }
@@ -566,7 +564,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->substringCondition
+                $this->substringCondition
             )
         );
     }
@@ -579,7 +577,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->substringCondition
+                $this->substringCondition
             )
         );
     }
@@ -592,7 +590,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -601,7 +599,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
     }
@@ -614,7 +612,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -623,7 +621,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
     }
@@ -636,7 +634,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -645,7 +643,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
     }
@@ -658,7 +656,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -667,7 +665,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
     }
@@ -680,7 +678,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -689,7 +687,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
     }
@@ -702,7 +700,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -711,7 +709,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
     }
@@ -724,7 +722,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtIntCondition
+                $this->gtIntCondition
             )
         );
     }
@@ -737,7 +735,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->gtFloatCondition
+                $this->gtFloatCondition
             )
         );
     }
@@ -750,7 +748,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -759,7 +757,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
     }
@@ -772,7 +770,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -781,7 +779,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
     }
@@ -794,7 +792,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -803,7 +801,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
     }
@@ -816,7 +814,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -825,7 +823,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
     }
@@ -838,7 +836,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
 
@@ -847,7 +845,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
     }
@@ -860,7 +858,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
         $customAttrConditionEvaluator = new CustomAttributeConditionEvaluator(
@@ -869,7 +867,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
     }
@@ -882,7 +880,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltIntCondition
+                $this->ltIntCondition
             )
         );
     }
@@ -895,7 +893,7 @@ class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(
             $customAttrConditionEvaluator->evaluate(
-                  $this->ltFloatCondition
+                $this->ltFloatCondition
             )
         );
     }

--- a/tests/UtilsTests/EventTagUtilsTest.php
+++ b/tests/UtilsTests/EventTagUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2018, Optimizely
+ * Copyright 2017-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ class EventTagUtilsTest extends \PHPUnit_Framework_TestCase
 {
     // The size of a float is platform-dependent, although a maximum of ~1.8e308 with a precision of roughly 14 decimal digits is a common value (the 64 bit IEEE format). http://php.net/manual/en/language.types.float.php
     // PHP_FLOAT_MAX - Available as of PHP7.2.0 http://php.net/manual/en/reserved.constants.php
-    const max_float = 1.8e307;
-    const min_float = -1.8e307;
+    const MAX_FLOAT = 1.8e307;
+    const MIN_FLOAT = -1.8e307;
     protected $loggerMock;
 
     protected function setUp()
@@ -174,7 +174,7 @@ class EventTagUtilsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => 'abcd'), $this->loggerMock));
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => true), $this->loggerMock));
-        $this->assertNull(EventTagUtils::getNumericValue(array('value' => array(1, 2, 3)),$this->loggerMock));
+        $this->assertNull(EventTagUtils::getNumericValue(array('value' => array(1, 2, 3)), $this->loggerMock));
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => false), $this->loggerMock));
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => array()), $this->loggerMock));
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => '1,234'), $this->loggerMock));
@@ -189,7 +189,7 @@ class EventTagUtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => floatval(NAN)), $this->loggerMock));
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => floatval(INF)), $this->loggerMock));
         $this->assertNull(EventTagUtils::getNumericValue(array('value' => floatval(-INF)), $this->loggerMock));
-        $this->assertNull(EventTagUtils::getNumericValue(array('value' => (self::max_float*10)), $this->loggerMock));
+        $this->assertNull(EventTagUtils::getNumericValue(array('value' => (self::MAX_FLOAT*10)), $this->loggerMock));
     }
 
     // Test that the correct numeric value is returned
@@ -214,13 +214,13 @@ class EventTagUtilsTest extends \PHPUnit_Framework_TestCase
 
         $this->loggerMock->expects($this->at(0))
             ->method('log')
-            ->with(Logger::INFO, "The numeric metric value ".self::max_float." will be sent to results.");
-        $this->assertSame(self::max_float, EventTagUtils::getNumericValue(array('value' => self::max_float), $this->loggerMock));
+            ->with(Logger::INFO, "The numeric metric value ".self::MAX_FLOAT." will be sent to results.");
+        $this->assertSame(self::MAX_FLOAT, EventTagUtils::getNumericValue(array('value' => self::MAX_FLOAT), $this->loggerMock));
 
         $this->loggerMock->expects($this->at(0))
             ->method('log')
-            ->with(Logger::INFO, "The numeric metric value ".self::min_float." will be sent to results.");
-        $this->assertSame(self::min_float, EventTagUtils::getNumericValue(array('value' => self::min_float), $this->loggerMock));
+            ->with(Logger::INFO, "The numeric metric value ".self::MIN_FLOAT." will be sent to results.");
+        $this->assertSame(self::MIN_FLOAT, EventTagUtils::getNumericValue(array('value' => self::MIN_FLOAT), $this->loggerMock));
 
         $this->loggerMock->expects($this->at(0))
             ->method('log')

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -135,10 +135,10 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(Validator::IsFiniteNumber(INF));
         $this->assertFalse(Validator::IsFiniteNumber(-INF));
         $this->assertFalse(Validator::IsFiniteNumber(NAN));
-        $this->assertFalse(Validator::IsFiniteNumber(pow(2,53) + 1));
-        $this->assertFalse(Validator::IsFiniteNumber(-pow(2,53) - 1));
-        $this->assertFalse(Validator::IsFiniteNumber(pow(2,53) + 2.0));
-        $this->assertFalse(Validator::IsFiniteNumber(-pow(2,53) - 2.0));
+        $this->assertFalse(Validator::IsFiniteNumber(pow(2, 53) + 1));
+        $this->assertFalse(Validator::IsFiniteNumber(-pow(2, 53) - 1));
+        $this->assertFalse(Validator::IsFiniteNumber(pow(2, 53) + 2.0));
+        $this->assertFalse(Validator::IsFiniteNumber(-pow(2, 53) - 2.0));
     }
 
     public function testIsFiniteNumberWithValidValues()
@@ -147,9 +147,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Validator::IsFiniteNumber(5));
         $this->assertTrue(Validator::IsFiniteNumber(5.5));
         // float pow(2,53) + 1.0 evaluates to float pow(2,53)
-        $this->assertTrue(Validator::IsFiniteNumber(pow(2,53) + 1.0));
-        $this->assertTrue(Validator::IsFiniteNumber(-pow(2,53) - 1.0));
-        $this->assertTrue(Validator::IsFiniteNumber(pow(2,53)));
+        $this->assertTrue(Validator::IsFiniteNumber(pow(2, 53) + 1.0));
+        $this->assertTrue(Validator::IsFiniteNumber(-pow(2, 53) - 1.0));
+        $this->assertTrue(Validator::IsFiniteNumber(pow(2, 53)));
     }
 
     public function testAreEventTagsValidValidEventTags()
@@ -291,7 +291,6 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 []
             )
         );
-        
     }
 
     // test that isUserInExperiment returns false when some audience is attached to experiment
@@ -485,8 +484,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     {
         // Valid values
         $this->assertTrue(Validator::doesArrayContainOnlyStringKeys(
-            ["name"=> "favorite_ice_cream", "type"=> "custom_attribute", "match"=> "exists"])
-        );
+            ["name"=> "favorite_ice_cream", "type"=> "custom_attribute", "match"=> "exists"]
+        ));
 
         // Invalid values
         $this->assertFalse(Validator::doesArrayContainOnlyStringKeys([]));


### PR DESCRIPTION
## Summary
* This enforces static code analyzer PHPCodeSniffer on Travis. 
* phpcs.xml - configuration file added to root which is used by default when no arguments are supplied to `phpcs`
* PHPCodeSniffer comes along with PHP Code Beautifier which auto fixes (not all) lint errors. 
* Scripts added to composer.json for easy execution of linter and autofixer. 
* Linting stage separated on Travis as the first pass before Integration Tests and Unit tests are executed.
* Enforces PSR2 standards. https://www.php-fig.org/psr/psr-2/


## Test plan

## Issues
- OASIS-4025
