### PR TITLE
feat(track): Introducing easier event tracking

### DIFF
--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,8 @@ class EventBuilder
             REVISION => $config->getRevision(),
             CLIENT_ENGINE => self::SDK_TYPE,
             CLIENT_VERSION => self::SDK_VERSION,
-            ANONYMIZE_IP => $config->getAnonymizeIP()
+            ANONYMIZE_IP => $config->getAnonymizeIP(),
+            ENRICH_DECISIONS => true
         ];
 
         if(!is_null($attributes)) {
@@ -170,38 +171,21 @@ class EventBuilder
     /**
      * Helper function to get parameters specific to conversion event.
      *
-     * @param $config ProjectConfig Configuration for the project.
-     * @param $eventKey string Key representing the event.
-     * @param $experimentVariationMap array Map of experiment ID to the ID of the variation that the user is bucketed into.
+     * @param $eventEntity Event representing event entity.
      * @param $eventTags array Hash representing metadata associated with the event.
      *
      * @return array Hash representing parameters particular to conversion event.
      */
-    private function getConversionParams($config, $eventKey, $experimentVariationMap, $eventTags)
+    private function getConversionParams($eventEntity, $eventTags)
     {
         $conversionParams = [];
         $singleSnapshot = [];
-        $decisions = [];
-
-        foreach ($experimentVariationMap as $experimentId => $variationId) {
-            
-            
-            $experiment = $config->getExperimentFromId($experimentId);
-            $eventEntity = $config->getEvent($eventKey);
-
-            $decision = [                
-                CAMPAIGN_ID => $experiment->getLayerId(),
-                EXPERIMENT_ID => $experiment->getId(),
-                VARIATION_ID => $variationId                
-            ];
-            $decisions [] = $decision;
-        }
 
         $eventDict = [
             ENTITY_ID => $eventEntity->getId(),
             TIMESTAMP => time()*1000,
             UUID => GeneratorUtils::getRandomUuid(),
-            KEY => $eventKey            
+            KEY => $eventEntity->getKey()
         ];
 
         if (!is_null($eventTags)) {
@@ -217,10 +201,9 @@ class EventBuilder
 
             if(count($eventTags) > 0) {
                 $eventDict['tags'] = $eventTags;
-            }            
+            }
         }
 
-        $singleSnapshot[DECISIONS] = $decisions;
         $singleSnapshot[EVENTS] [] = $eventDict;
         $conversionParams [] = $singleSnapshot;
 
@@ -256,17 +239,17 @@ class EventBuilder
      *
      * @param $config ProjectConfig Configuration for the project.
      * @param $eventKey string Key representing the event.
-     * @param $experimentVariationMap array Map of experiment ID to the ID of the variation that the user is bucketed into.
      * @param $userId string ID of user.
      * @param $attributes array Attributes of the user.
      * @param $eventTags array Hash representing metadata associated with the event.
      *
      * @return LogEvent Event object to be sent to dispatcher.
      */
-    public function createConversionEvent($config, $eventKey, $experimentVariationMap, $userId, $attributes, $eventTags)
+    public function createConversionEvent($config, $eventKey, $userId, $attributes, $eventTags)
     {
         $eventParams = $this->getCommonParams($config, $userId, $attributes);
-        $conversionParams = $this->getConversionParams($config, $eventKey, $experimentVariationMap, $eventTags);
+        $eventEntity = $config->getEvent($eventKey);
+        $conversionParams = $this->getConversionParams($eventEntity, $eventTags);
 
         $eventParams[VISITORS][0][SNAPSHOTS] = $conversionParams;
         return new LogEvent(self::$ENDPOINT, $eventParams, self::$HTTP_VERB, self::$HTTP_HEADERS);

--- a/src/Optimizely/Event/Builder/Params.php
+++ b/src/Optimizely/Event/Builder/Params.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ define('CLIENT_ENGINE', 'client_name');
 define('CLIENT_VERSION', 'client_version');
 define('CUSTOM_ATTRIBUTE_FEATURE_TYPE', 'custom');
 define('DECISIONS', 'decisions');
+define('ENRICH_DECISIONS', 'enrich_decisions');
 define('ENTITY_ID', 'entity_id');
 define('EVENTS', 'events');;
 define('EXPERIMENT_ID', 'experiment_id');

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -313,7 +313,7 @@ class Optimizely
         $event = $this->_config->getEvent($eventKey);
 
         if (is_null($event->getKey())) {
-            $this->_logger->log(Logger::ERROR, sprintf('Not tracking user "%s" for event "%s".', $userId, $eventKey));
+            $this->_logger->log(Logger::INFO, sprintf('Not tracking user "%s" for event "%s".', $userId, $eventKey));
             return;
         }
 

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -313,7 +313,7 @@ class Optimizely
         $event = $this->_config->getEvent($eventKey);
 
         if (is_null($event->getKey())) {
-            $this->_logger->log(Logger::INFO, sprintf('Not tracking user "%s" for event "%s".', $userId, $eventKey));
+            $this->_logger->log(Logger::ERROR, sprintf('Not tracking user "%s" for event "%s".', $userId, $eventKey));
             return;
         }
 
@@ -336,36 +336,36 @@ class Optimizely
             )
         );
 
-          try {
-              $this->_eventDispatcher->dispatchEvent($conversionEvent);
-          } catch (Throwable $exception) {
-              $this->_logger->log(
-                  Logger::ERROR,
-                  sprintf(
-                      'Unable to dispatch conversion event. Error %s',
-                      $exception->getMessage()
-                  )
-              );
-          } catch (Exception $exception) {
-              $this->_logger->log(
-                  Logger::ERROR,
-                  sprintf(
-                      'Unable to dispatch conversion event. Error %s',
-                      $exception->getMessage()
-                  )
-              );
-          }
+        try {
+            $this->_eventDispatcher->dispatchEvent($conversionEvent);
+        } catch (Throwable $exception) {
+            $this->_logger->log(
+                Logger::ERROR,
+                sprintf(
+                    'Unable to dispatch conversion event. Error %s',
+                    $exception->getMessage()
+                )
+            );
+        } catch (Exception $exception) {
+            $this->_logger->log(
+                Logger::ERROR,
+                sprintf(
+                    'Unable to dispatch conversion event. Error %s',
+                    $exception->getMessage()
+                )
+            );
+        }
 
-          $this->notificationCenter->sendNotifications(
-              NotificationType::TRACK,
-              array(
-                  $eventKey,
-                  $userId,
-                  $attributes,
-                  $eventTags,
-                  $conversionEvent
-              )
-          );
+        $this->notificationCenter->sendNotifications(
+            NotificationType::TRACK,
+            array(
+                $eventKey,
+                $userId,
+                $attributes,
+                $eventTags,
+                $conversionEvent
+            )
+        );
     }
 
     /**

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,43 +193,6 @@ class Optimizely
     }
 
     /**
-     * Get the experiments that we should be tracking for the given event. A valid experiment
-     * is one that is in "Running" state and into which the user has been bucketed.
-     *
-     * @param $event string Event key representing the event which needs to be recorded.
-     * @param $user string ID for user.
-     * @param $attributes array Attributes of the user.
-     *
-     * @return Array Of objects where each object contains the ID of the experiment to track and the ID of the variation the user is bucketed into.
-     */
-    private function getValidExperimentsForEvent($event, $userId, $attributes = null)
-    {
-        $validExperiments = [];
-        foreach ($event->getExperimentIds() as $experimentId) {
-            $experiment = $this->_config->getExperimentFromId($experimentId);
-            $experimentKey = $experiment->getKey();
-            $variationKey = $this->getVariation($experimentKey, $userId, $attributes);
-
-            if (is_null($variationKey)) {
-                $this->_logger->log(
-                    Logger::INFO,
-                    sprintf(
-                        'Not tracking user "%s" for experiment "%s".',
-                        $userId,
-                        $experimentKey
-                    )
-                );
-                continue;
-            }
-
-            $variation = $this->_config->getVariationFromKey($experimentKey, $variationKey);
-            $validExperiments[$experimentId] = $variation->getId();
-        }
-
-        return $validExperiments;
-    }
-
-    /**
      * @param  string Experiment key
      * @param  string Variation key
      * @param  string User ID
@@ -354,64 +317,55 @@ class Optimizely
             return;
         }
 
-        // Filter out experiments that are not running or when user(s) do not meet conditions.
-        $experimentVariationMap = $this->getValidExperimentsForEvent($event, $userId, $attributes);
-        if (!empty($experimentVariationMap)) {
-            $conversionEvent = $this->_eventBuilder
-                ->createConversionEvent(
-                    $this->_config,
-                    $eventKey,
-                    $experimentVariationMap,
-                    $userId,
-                    $attributes,
-                    $eventTags
-                );
-            $this->_logger->log(Logger::INFO, sprintf('Tracking event "%s" for user "%s".', $eventKey, $userId));
-            $this->_logger->log(
-                Logger::DEBUG,
-                sprintf(
-                    'Dispatching conversion event to URL %s with params %s.',
-                    $conversionEvent->getUrl(),
-                    json_encode($conversionEvent->getParams())
-                )
+        $conversionEvent = $this->_eventBuilder
+            ->createConversionEvent(
+                $this->_config,
+                $eventKey,
+                $userId,
+                $attributes,
+                $eventTags
             );
+        
+        $this->_logger->log(Logger::INFO, sprintf('Tracking event "%s" for user "%s".', $eventKey, $userId));
+        $this->_logger->log(
+            Logger::DEBUG,
+            sprintf(
+                'Dispatching conversion event to URL %s with params %s.',
+                $conversionEvent->getUrl(),
+                json_encode($conversionEvent->getParams())
+            )
+        );
 
-            try {
-                $this->_eventDispatcher->dispatchEvent($conversionEvent);
-            } catch (Throwable $exception) {
-                $this->_logger->log(
-                    Logger::ERROR,
-                    sprintf(
-                        'Unable to dispatch conversion event. Error %s',
-                        $exception->getMessage()
-                    )
-                );
-            } catch (Exception $exception) {
-                $this->_logger->log(
-                    Logger::ERROR,
-                    sprintf(
-                        'Unable to dispatch conversion event. Error %s',
-                        $exception->getMessage()
-                    )
-                );
-            }
+          try {
+              $this->_eventDispatcher->dispatchEvent($conversionEvent);
+          } catch (Throwable $exception) {
+              $this->_logger->log(
+                  Logger::ERROR,
+                  sprintf(
+                      'Unable to dispatch conversion event. Error %s',
+                      $exception->getMessage()
+                  )
+              );
+          } catch (Exception $exception) {
+              $this->_logger->log(
+                  Logger::ERROR,
+                  sprintf(
+                      'Unable to dispatch conversion event. Error %s',
+                      $exception->getMessage()
+                  )
+              );
+          }
 
-            $this->notificationCenter->sendNotifications(
-                NotificationType::TRACK,
-                array(
-                    $eventKey,
-                    $userId,
-                    $attributes,
-                    $eventTags,
-                    $conversionEvent
-                )
-            );
-        } else {
-            $this->_logger->log(
-                Logger::INFO,
-                sprintf('There are no valid experiments for event "%s" to track.', $eventKey)
-            );
-        }
+          $this->notificationCenter->sendNotifications(
+              NotificationType::TRACK,
+              array(
+                  $eventKey,
+                  $userId,
+                  $attributes,
+                  $eventTags,
+                  $conversionEvent
+              )
+          );
     }
 
     /**

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2018, Optimizely
+ * Copyright 2016-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,11 +51,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
                 'project_id' => '7720880029',
                 'visitors'=> [[
                   'snapshots'=> [[
-                    'decisions'=> [[
-                      'campaign_id'=> '7719770039',
-                      'experiment_id'=> '7716830082',
-                      'variation_id'=> '7721010009'
-                    ]],
                     'events'=> [[
                       'entity_id'=> '7719770039',
                       'timestamp'=> $this->timestamp,
@@ -75,7 +70,18 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
                 'client_name' => 'php-sdk',
                 'client_version' => '2.2.1',
                 'anonymize_ip'=> false,
+                'enrich_decisions' => true,
             ];
+
+        $decisions = array('decisions' => [[
+                              'campaign_id'=> '7719770039',
+                              'experiment_id'=> '7716830082',
+                              'variation_id'=> '7721010009'
+                            ]]
+                          );
+        $this->expectedImpressionEventParams = $this->expectedEventParams;
+        $this->expectedImpressionEventParams['visitors'][0]['snapshots'][0] = $decisions +
+                                                                    $this->expectedImpressionEventParams['visitors'][0]['snapshots'][0];
         $this->expectedEventHttpVerb = 'POST';
         $this->expectedEventHeaders = ['Content-Type' => 'application/json'];
     }
@@ -122,7 +128,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
-            $this->expectedEventParams,
+            $this->expectedImpressionEventParams,
             $this->expectedEventHttpVerb,
             $this->expectedEventHeaders
         );
@@ -142,7 +148,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateImpressionEventWithAttributesNoValue()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
+        array_unshift($this->expectedImpressionEventParams['visitors'][0]['attributes'],
             [
                 'entity_id' => '7723280020',
                 'key' => 'device_type',
@@ -167,7 +173,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
-            $this->expectedEventParams,
+            $this->expectedImpressionEventParams,
             $this->expectedEventHttpVerb,
             $this->expectedEventHeaders
         );
@@ -196,7 +202,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateImpressionEventWithFalseAttributesNoValue()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
+        array_unshift($this->expectedImpressionEventParams['visitors'][0]['attributes'],
           [ 'entity_id' => '7723280020',
             'key' => 'device_type',
             'type' => 'custom',
@@ -205,7 +211,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
-            $this->expectedEventParams,
+            $this->expectedImpressionEventParams,
             $this->expectedEventHttpVerb,
             $this->expectedEventHeaders
         );
@@ -231,7 +237,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateImpressionEventWithZeroAttributesNoValue()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
+        array_unshift($this->expectedImpressionEventParams['visitors'][0]['attributes'],
           [ 'entity_id' => '7723280020',
             'key' => 'device_type',
             'type' => 'custom',
@@ -240,7 +246,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
-            $this->expectedEventParams,
+            $this->expectedImpressionEventParams,
             $this->expectedEventHttpVerb,
             $this->expectedEventHeaders
         );
@@ -269,7 +275,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
-            $this->expectedEventParams,
+            $this->expectedImpressionEventParams,
             $this->expectedEventHttpVerb,
             $this->expectedEventHeaders
         );
@@ -289,11 +295,11 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $result = $this->areLogEventsEqual($expectedLogEvent, $logEvent);
         $this->assertTrue($result[0], $result[1]);
     }
-    
+
     public function testCreateImpressionEventWithUserAgentWhenBotFilteringIsEnabled()
     {
-        $this->expectedEventParams['visitors'][0]['attributes'] = 
-          [[ 
+        $this->expectedImpressionEventParams['visitors'][0]['attributes'] =
+          [[
             'entity_id' => '$opt_user_agent',
             'key' => '$opt_user_agent',
             'type' => 'custom',
@@ -306,7 +312,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
-            $this->expectedEventParams,
+            $this->expectedImpressionEventParams,
             $this->expectedEventHttpVerb,
             $this->expectedEventHeaders
         );
@@ -329,7 +335,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateImpressionEventWithInvalidAttributeTypes()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
+        array_unshift($this->expectedImpressionEventParams['visitors'][0]['attributes'],
             [
                 'entity_id' => '7723280020',
                 'key' => 'device_type',
@@ -345,7 +351,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
-            $this->expectedEventParams,
+            $this->expectedImpressionEventParams,
             $this->expectedEventHttpVerb,
             $this->expectedEventHeaders
         );
@@ -371,8 +377,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateImpressionEventWithUserAgentWhenBotFilteringIsDisabled()
     {
-        $this->expectedEventParams['visitors'][0]['attributes'] = 
-          [[ 
+        $this->expectedImpressionEventParams['visitors'][0]['attributes'] =
+          [[
             'entity_id' => '$opt_user_agent',
             'key' => '$opt_user_agent',
             'type' => 'custom',
@@ -385,7 +391,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
-            $this->expectedEventParams,
+            $this->expectedImpressionEventParams,
             $this->expectedEventHttpVerb,
             $this->expectedEventHeaders
         );
@@ -418,8 +424,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateImpressionEventWithUserAgentWhenBotFilteringIsNull()
     {
-        $this->expectedEventParams['visitors'][0]['attributes'] = 
-          [[ 
+        $this->expectedImpressionEventParams['visitors'][0]['attributes'] =
+          [[
             'entity_id' => '$opt_user_agent',
             'key' => '$opt_user_agent',
             'type' => 'custom',
@@ -428,7 +434,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
-            $this->expectedEventParams,
+            $this->expectedImpressionEventParams,
             $this->expectedEventHttpVerb,
             $this->expectedEventHeaders
         );
@@ -457,7 +463,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->fakeParamsToReconcile($logEvent);
         $result = $this->areLogEventsEqual($this->expectedLogEvent, $logEvent);
         $this->assertTrue($result[0], $result[1]);
-    }    
+    }
 
     public function testCreateConversionEventNoAttributesNoValue()
     {
@@ -478,7 +484,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->eventBuilder->createConversionEvent(
             $this->config,
             'purchase',
-            ['7716830082' => '7721010009'],
             $this->testUserId,
             null,
             null
@@ -504,7 +509,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'uuid'=> $this->uuid,
             'key'=> 'purchase'
           ];
-        $this->expectedEventParams['visitors'][0]['snapshots'][0]['decisions'][0]['variation_id'] = '7722370027';
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
@@ -520,7 +524,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->eventBuilder->createConversionEvent(
             $this->config,
             'purchase',
-            ['7716830082' => '7722370027'],
             $this->testUserId,
             $userAttributes,
             null
@@ -541,7 +544,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'uuid'=> $this->uuid,
             'key'=> 'purchase'
           ];
-        $this->expectedEventParams['visitors'][0]['snapshots'][0]['decisions'][0]['variation_id'] = '7722370027';
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
@@ -556,7 +558,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->eventBuilder->createConversionEvent(
             $this->config,
             'purchase',
-            ['7716830082' => '7722370027'],
             $this->testUserId,
             $userAttributes,
             null
@@ -583,8 +584,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             ]
            ];
 
-        $this->expectedEventParams['visitors'][0]['snapshots'][0]['decisions'][0]['variation_id'] = '7722370027';
-
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
             $this->expectedEventParams,
@@ -594,7 +593,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->eventBuilder->createConversionEvent(
             $this->config,
             'purchase',
-            ['7716830082' => '7722370027'],
             $this->testUserId,
             null,
             array('revenue' => 42,'value'=> '13.37',)
@@ -628,7 +626,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
               'value' => '13.37'
             ]
            ];
-        $this->expectedEventParams['visitors'][0]['snapshots'][0]['decisions'][0]['variation_id'] = '7722370027';
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
@@ -644,7 +641,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->eventBuilder->createConversionEvent(
             $this->config,
             'purchase',
-            ['7716830082' => '7722370027'],
             $this->testUserId,
             $userAttributes,
             array(
@@ -679,7 +675,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
               'value' => '13.37'
             ]
            ];
-        $this->expectedEventParams['visitors'][0]['snapshots'][0]['decisions'][0]['variation_id'] = '7722370027';
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
@@ -694,7 +689,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->eventBuilder->createConversionEvent(
             $this->config,
             'purchase',
-            ['7716830082' => '7722370027'],
             $this->testUserId,
             $userAttributes,
             array(
@@ -721,7 +715,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
               'value' => 'invalid value'
             ]
            ];
-        $this->expectedEventParams['visitors'][0]['snapshots'][0]['decisions'][0]['variation_id'] = '7722370027';
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
@@ -733,7 +726,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->eventBuilder->createConversionEvent(
             $this->config,
             'purchase',
-            ['7716830082' => '7722370027'],
             $this->testUserId,
             null,
             array(
@@ -752,7 +744,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
     // (since this custom attribute entity is not generated by GAE)
     public function testCreateImpressionEventWithBucketingIDAttribute()
     {
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
+        array_unshift($this->expectedImpressionEventParams['visitors'][0]['attributes'],
           [
             'entity_id' => '7723280020',
             'key' => 'device_type',
@@ -767,7 +759,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
-            $this->expectedEventParams,
+            $this->expectedImpressionEventParams,
             $this->expectedEventHttpVerb,
             $this->expectedEventHeaders
         );
@@ -813,7 +805,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'uuid'=> $this->uuid,
             'key'=> 'purchase'
            ];
-        $this->expectedEventParams['visitors'][0]['snapshots'][0]['decisions'][0]['variation_id'] = '7722370027';
 
         $expectedLogEvent = new LogEvent(
             $this->expectedEventUrl,
@@ -831,7 +822,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->eventBuilder->createConversionEvent(
             $this->config,
             'purchase',
-            ['7716830082' => '7722370027'],
             $this->testUserId,
             $userAttributes,
             null
@@ -851,50 +841,43 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'value' => 'Firefox',
           ]);
 
-        $this->expectedEventParams['visitors'][0]['snapshots'][0]['events'][0] =
-          [
-            'entity_id'=> '7718020063',
-            'timestamp'=> $this->timestamp,
-            'uuid'=> $this->uuid,
-            'key'=> 'purchase'
-          ];
-        $this->expectedEventParams['visitors'][0]['snapshots'][0]['decisions'][0]['variation_id'] = '7722370027';
-
-        $expectedLogEvent = new LogEvent(
-            $this->expectedEventUrl,
-            $this->expectedEventParams,
-            $this->expectedEventHttpVerb,
-            $this->expectedEventHeaders
-        );
-
-        $userAttributes = [
-            '$opt_user_agent' => 'Firefox'
+      $this->expectedEventParams['visitors'][0]['snapshots'][0]['events'][0] =
+        [
+          'entity_id'=> '7718020063',
+          'timestamp'=> $this->timestamp,
+          'uuid'=> $this->uuid,
+          'key'=> 'purchase'
         ];
-        $logEvent = $this->eventBuilder->createConversionEvent(
-            $this->config,
-            'purchase',
-            ['7716830082' => '7722370027'],
-            $this->testUserId,
-            $userAttributes,
-            null
-        );
 
-        $logEvent = $this->fakeParamsToReconcile($logEvent);
-        $result = $this->areLogEventsEqual($expectedLogEvent, $logEvent);
-        $this->assertTrue($result[0], $result[1]);
+      $expectedLogEvent = new LogEvent(
+          $this->expectedEventUrl,
+          $this->expectedEventParams,
+          $this->expectedEventHttpVerb,
+          $this->expectedEventHeaders
+      );
+
+      $userAttributes = [
+          '$opt_user_agent' => 'Firefox'
+      ];
+      $logEvent = $this->eventBuilder->createConversionEvent(
+          $this->config,
+          'purchase',
+          $this->testUserId,
+          $userAttributes,
+          null
+      );
+
+      $logEvent = $this->fakeParamsToReconcile($logEvent);
+      $result = $this->areLogEventsEqual($expectedLogEvent, $logEvent);
+      $this->assertTrue($result[0], $result[1]);
     }
 
     public function testCreateConversionEventWhenEventUsedInMultipleExp()
-    {  
+    {
         $eventTags = [
             'revenue' => 4200,
             'value' => 1.234,
             'non-revenue' => 'abc'
-        ];      
-        $this->expectedEventParams['visitors'][0]['snapshots'][0]['decisions'][] = [
-            'campaign_id' => '4',
-            'experiment_id' => '122230',
-            'variation_id' => '122234'
         ];
 
         $this->expectedEventParams['visitors'][0]['snapshots'][0]['events'][0] = [
@@ -903,12 +886,12 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'uuid' => $this->uuid,
             'key' => 'multi_exp_event',
             'revenue' => 4200,
-            'value' => 1.234,                    
-            'tags' => $eventTags,                        
+            'value' => 1.234,
+            'tags' => $eventTags,
         ];
-        
-        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],  
-            [                 
+
+        array_unshift($this->expectedEventParams['visitors'][0]['attributes'],
+            [
                 'entity_id' => '7723280020',
                 'key' => 'device_type',
                 'type' => 'custom',
@@ -919,11 +902,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
                 'type' => 'custom',
                 'value' => 'SF'
             ]);
-        
-        $decisions = [
-            '7716830082' => '7721010009',
-            '122230' => '122234'
-        ];
+
         $userAttributes = [
             'device_type' => 'iPhone',
             'location' => 'SF'
@@ -932,7 +911,6 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $logEvent = $this->eventBuilder->createConversionEvent(
                 $this->config,
                 'multi_exp_event',
-                $decisions,
                 $this->testUserId,
                 $userAttributes,
                 $eventTags
@@ -943,10 +921,10 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
                 $this->expectedEventHttpVerb,
                 $this->expectedEventHeaders
         );
-            
+
         $logEvent = $this->fakeParamsToReconcile($logEvent);
         $result = $this->areLogEventsEqual($expectedLogEvent, $logEvent);
         $this->assertTrue($result[0], $result[1]);
-            
+
     }
 }

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1142,7 +1142,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $this->loggerMock->expects($this->at(1))
             ->method('log')
-            ->with(Logger::ERROR, 'Not tracking user "test_user" for event "unknown_key".');
+            ->with(Logger::INFO, 'Not tracking user "test_user" for event "unknown_key".');
 
         $this->optimizelyObject->track('unknown_key', 'test_user');
     }

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1142,7 +1142,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $this->loggerMock->expects($this->at(1))
             ->method('log')
-            ->with(Logger::INFO, 'Not tracking user "test_user" for event "unknown_key".');
+            ->with(Logger::ERROR, 'Not tracking user "test_user" for event "unknown_key".');
 
         $this->optimizelyObject->track('unknown_key', 'test_user');
     }

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1142,7 +1142,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $this->loggerMock->expects($this->at(1))
             ->method('log')
-            ->with(Logger::ERROR, 'Not tracking user "test_user" for event "unknown_key".');
+            ->with(Logger::INFO, 'Not tracking user "test_user" for event "unknown_key".');
 
         $this->optimizelyObject->track('unknown_key', 'test_user');
     }
@@ -1766,110 +1766,6 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 $arrayParam
             );
         $optlyObject->notificationCenter = $this->notificationCenterMock;
-
-        $eventBuilder = new \ReflectionProperty(Optimizely::class, '_eventBuilder');
-        $eventBuilder->setAccessible(true);
-        $eventBuilder->setValue($optlyObject, $this->eventBuilderMock);
-
-        // Should be excluded - exact match boolean audience with id '3468206643' does not match,
-        // so the overall conditions fail
-        $optlyObject->track('user_signed_up', 'test_user', $userAttributes, array('revenue' => 42));
-    }
-
-    public function testTrackWithAttributesTypedAudienceMatch()
-    {
-        $userAttributes = [
-            'house' => 'Welcome to Slytherin!'
-        ];
-
-        $this->eventBuilderMock->expects($this->once())
-            ->method('createConversionEvent')
-            ->with(
-                $this->projectConfigForTypedAudience,
-                'item_bought',
-                [
-                    '11564051718' => '11617170975',
-                    '1323241597' => '1423767503'
-                ],
-                'test_user',
-                $userAttributes,
-                array('revenue' => 42)
-            )
-            ->willReturn(new LogEvent('logx.optimizely.com/track', ['param1' => 'val1'], 'POST', []));
-
-        $optlyObject = new Optimizely($this->typedAudiencesDataFile, new ValidEventDispatcher(), $this->loggerMock);
-
-        $eventBuilder = new \ReflectionProperty(Optimizely::class, '_eventBuilder');
-        $eventBuilder->setAccessible(true);
-        $eventBuilder->setValue($optlyObject, $this->eventBuilderMock);
-
-        // Should be included via substring match string audience with id '3988293898'
-        $optlyObject->track('item_bought', 'test_user', $userAttributes, array('revenue' => 42));
-    }
-
-    public function testTrackWithAttributesTypedAudienceMismatch()
-    {
-        $userAttributes = [
-            'house' => 'Hufflepuff!'
-        ];
-
-        $this->eventBuilderMock->expects($this->never())
-            ->method('createConversionEvent');
-
-        $optlyObject = new Optimizely($this->typedAudiencesDataFile, new ValidEventDispatcher(), $this->loggerMock);
-
-        $eventBuilder = new \ReflectionProperty(Optimizely::class, '_eventBuilder');
-        $eventBuilder->setAccessible(true);
-        $eventBuilder->setValue($optlyObject, $this->eventBuilderMock);
-
-        // Call track
-        $optlyObject->track('item_bought', 'test_user', $userAttributes, array('revenue' => 42));
-    }
-
-    public function testTrackWithAttributesComplexAudienceMatch()
-    {
-        $userAttributes = [
-            'house' => 'Gryffindor',
-            'should_do_it' => true
-        ];
-
-        $this->eventBuilderMock->expects($this->once())
-            ->method('createConversionEvent')
-            ->with(
-                $this->projectConfigForTypedAudience,
-                'user_signed_up',
-                [
-                    '1323241598' => '1423767504',
-                    '1323241599' => '1423767505'
-                ],
-                'test_user',
-                $userAttributes,
-                array('revenue' => 42)
-            )
-            ->willReturn(new LogEvent('logx.optimizely.com/track', ['param1' => 'val1'], 'POST', []));
-
-        $optlyObject = new Optimizely($this->typedAudiencesDataFile, new ValidEventDispatcher(), $this->loggerMock);
-
-        $eventBuilder = new \ReflectionProperty(Optimizely::class, '_eventBuilder');
-        $eventBuilder->setAccessible(true);
-        $eventBuilder->setValue($optlyObject, $this->eventBuilderMock);
-
-        // Should be included via exact match string audience with id '3468206642', and
-        // exact match boolean audience with id '3468206643'
-        $optlyObject->track('user_signed_up', 'test_user', $userAttributes, array('revenue' => 42));
-    }
-
-    public function testTrackWithAttributesComplexAudienceMismatch()
-    {
-        $userAttributes = [
-            'house' => 'Gryffindor',
-            'should_do_it' => false
-        ];
-
-        $this->eventBuilderMock->expects($this->never())
-            ->method('createConversionEvent');
-
-        $optlyObject = new Optimizely($this->typedAudiencesDataFile, new ValidEventDispatcher(), $this->loggerMock);
 
         $eventBuilder = new \ReflectionProperty(Optimizely::class, '_eventBuilder');
         $eventBuilder->setAccessible(true);


### PR DESCRIPTION
## Summary
- Impression/Conversion events now have a 'enrich_decisions' boolean property set to true.
- conversion events now do not have the decision property in visitor snapshots. 
- Conversion event is now sent solely if the event key corresponds to a valid event in the data file. Number of experiments attached to the event, or status of experiment, or the bucketing does not make a difference. 

## Test plan
- Unit Tests updated
- Additional Unit Test added for paused experiment.
- Tested Compat Suite Tests for EET locally and via Travis on custom triggered build. 

## Issues
- OASIS-4030
