### PR TITLE
refact(decisionService): Move ProjectConfig from DecisionService constructor to individual methods

### DIFF
--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -106,7 +106,7 @@ class DecisionService
      *
      * @return Variation   Variation  which the user is bucketed into.
      */
-    public function getVariation($projectConfig, Experiment $experiment, $userId, $attributes = null)
+    public function getVariation(ProjectConfig $projectConfig, Experiment $experiment, $userId, $attributes = null)
     {
         $bucketingId = $this->getBucketingId($userId, $attributes);
 
@@ -165,7 +165,7 @@ class DecisionService
      * @return Decision  if getVariationForFeatureExperiment or getVariationForFeatureRollout returns a Decision
      *         null      otherwise
      */
-    public function getVariationForFeature($projectConfig, FeatureFlag $featureFlag, $userId, $userAttributes)
+    public function getVariationForFeature(ProjectConfig $projectConfig, FeatureFlag $featureFlag, $userId, $userAttributes)
     {
         //Evaluate in this order:
         //1. Attempt to bucket user into experiment using feature flag.
@@ -206,7 +206,7 @@ class DecisionService
      * @return Decision  if a variation is returned for the user
      *         null  if feature flag is not used in any experiments or no variation is returned for the user
      */
-    public function getVariationForFeatureExperiment($projectConfig, FeatureFlag $featureFlag, $userId, $userAttributes)
+    public function getVariationForFeatureExperiment(ProjectConfig $projectConfig, FeatureFlag $featureFlag, $userId, $userAttributes)
     {
         $featureFlagKey = $featureFlag->getKey();
         $experimentIds = $featureFlag->getExperimentIds();
@@ -261,7 +261,7 @@ class DecisionService
      *               no rollout found against the rollout ID or
      *               no variation is returned for the user
      */
-    public function getVariationForFeatureRollout($projectConfig, FeatureFlag $featureFlag, $userId, $userAttributes)
+    public function getVariationForFeatureRollout(ProjectConfig $projectConfig, FeatureFlag $featureFlag, $userId, $userAttributes)
     {
         $bucketing_id = $this->getBucketingId($userId, $userAttributes);
         $featureFlagKey = $featureFlag->getKey();
@@ -333,7 +333,7 @@ class DecisionService
      *
      * @return null|Variation Representing the variation the user is forced into.
      */
-    private function getWhitelistedVariation($projectConfig, Experiment $experiment, $userId)
+    private function getWhitelistedVariation(ProjectConfig $projectConfig, Experiment $experiment, $userId)
     {
         // Check if user is whitelisted for a variation.
         $forcedVariations = $experiment->getForcedVariations();
@@ -400,7 +400,7 @@ class DecisionService
      *
      * @return null|Variation the stored variation or null if not found.
      */
-    private function getStoredVariation($projectConfig, Experiment $experiment, UserProfile $userProfile)
+    private function getStoredVariation(ProjectConfig $projectConfig, Experiment $experiment, UserProfile $userProfile)
     {
         $experimentKey = $experiment->getKey();
         $userId = $userProfile->getUserId();

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -51,12 +51,7 @@ class DecisionService
      * @var LoggerInterface
      */
     private $_logger;
-
-    /**
-     * @var ProjectConfig
-     */
-    private $_projectConfig;
-
+    
     /**
      * @var Bucketer
      */
@@ -70,13 +65,12 @@ class DecisionService
     /**
      * DecisionService constructor.
      *
-     * @param LoggerInterface $logger
-     * @param ProjectConfig   $projectConfig
+     * @param LoggerInterface       $logger
+     * @param UserProfileServiceInterface  $userProfileService
      */
-    public function __construct(LoggerInterface $logger, ProjectConfig $projectConfig, UserProfileServiceInterface $userProfileService = null)
+    public function __construct(LoggerInterface $logger, UserProfileServiceInterface $userProfileService = null)
     {
         $this->_logger = $logger;
-        $this->_projectConfig = $projectConfig;
         $this->_bucketer = new Bucketer($logger);
         $this->_userProfileService = $userProfileService;
     }
@@ -105,13 +99,14 @@ class DecisionService
     /**
      * Determine which variation to show the user.
      *
-     * @param $experiment  Experiment Experiment to get the variation for.
-     * @param $userId      string     User identifier.
-     * @param $attributes  array      Attributes of the user.
+     * @param $projectConfig    ProjectConfig   ProjectConfig instance.
+     * @param $experiment       Experiment      Experiment to get the variation for.
+     * @param $userId           string          User identifier.
+     * @param $attributes       array           Attributes of the user.
      *
      * @return Variation   Variation  which the user is bucketed into.
      */
-    public function getVariation(Experiment $experiment, $userId, $attributes = null)
+    public function getVariation($projectConfig, Experiment $experiment, $userId, $attributes = null)
     {
         $bucketingId = $this->getBucketingId($userId, $attributes);
 
@@ -121,13 +116,13 @@ class DecisionService
         }
 
         // check if a forced variation is set
-        $forcedVariation = $this->_projectConfig->getForcedVariation($experiment->getKey(), $userId);
+        $forcedVariation = $projectConfig->getForcedVariation($experiment->getKey(), $userId);
         if (!is_null($forcedVariation)) {
             return $forcedVariation;
         }
 
         // check if the user has been whitelisted
-        $variation = $this->getWhitelistedVariation($experiment, $userId);
+        $variation = $this->getWhitelistedVariation($projectConfig, $experiment, $userId);
         if (!is_null($variation)) {
             return $variation;
         }
@@ -138,14 +133,14 @@ class DecisionService
             $storedUserProfile = $this->getStoredUserProfile($userId);
             if (!is_null($storedUserProfile)) {
                 $userProfile = $storedUserProfile;
-                $variation = $this->getStoredVariation($experiment, $userProfile);
+                $variation = $this->getStoredVariation($projectConfig, $experiment, $userProfile);
                 if (!is_null($variation)) {
                     return $variation;
                 }
             }
         }
 
-        if (!Validator::isUserInExperiment($this->_projectConfig, $experiment, $attributes, $this->_logger)) {
+        if (!Validator::isUserInExperiment($projectConfig, $experiment, $attributes, $this->_logger)) {
             $this->_logger->log(
                 Logger::INFO,
                 sprintf('User "%s" does not meet conditions to be in experiment "%s".', $userId, $experiment->getKey())
@@ -153,7 +148,7 @@ class DecisionService
             return null;
         }
 
-        $variation = $this->_bucketer->bucket($this->_projectConfig, $experiment, $bucketingId, $userId);
+        $variation = $this->_bucketer->bucket($projectConfig, $experiment, $bucketingId, $userId);
         if (!is_null($variation)) {
             $this->saveVariation($experiment, $variation, $userProfile);
         }
@@ -163,26 +158,27 @@ class DecisionService
     /**
      * Get the variation the user is bucketed into for the given FeatureFlag
      *
-     * @param  FeatureFlag $featureFlag    The feature flag the user wants to access
-     * @param  string      $userId         user ID
-     * @param  array       $userAttributes user attributes
+     * @param  ProjectConfig $projectConfig  ProjectConfig instance.
+     * @param  FeatureFlag   $featureFlag    The feature flag the user wants to access
+     * @param  string        $userId         user ID
+     * @param  array         $userAttributes user attributes
      * @return Decision  if getVariationForFeatureExperiment or getVariationForFeatureRollout returns a Decision
      *         null      otherwise
      */
-    public function getVariationForFeature(FeatureFlag $featureFlag, $userId, $userAttributes)
+    public function getVariationForFeature($projectConfig, FeatureFlag $featureFlag, $userId, $userAttributes)
     {
         //Evaluate in this order:
         //1. Attempt to bucket user into experiment using feature flag.
         //2. Attempt to bucket user into rollout using the feature flag.
 
         // Check if the feature flag is under an experiment and the the user is bucketed into one of these experiments
-        $decision = $this->getVariationForFeatureExperiment($featureFlag, $userId, $userAttributes);
+        $decision = $this->getVariationForFeatureExperiment($projectConfig, $featureFlag, $userId, $userAttributes);
         if ($decision) {
             return $decision;
         }
 
         // Check if the feature flag has rollout and the user is bucketed into one of it's rules
-        $decision = $this->getVariationForFeatureRollout($featureFlag, $userId, $userAttributes);
+        $decision = $this->getVariationForFeatureRollout($projectConfig, $featureFlag, $userId, $userAttributes);
         if ($decision) {
             $this->_logger->log(
                 Logger::INFO,
@@ -203,13 +199,14 @@ class DecisionService
     /**
      * Get the variation if the user is bucketed for one of the experiments on this feature flag
      *
-     * @param  FeatureFlag $featureFlag    The feature flag the user wants to access
-     * @param  string      $userId         user id
-     * @param  array       $userAttributes user userAttributes
+     * @param  ProjectConfig $projectConfig  ProjectConfig instance.
+     * @param  FeatureFlag   $featureFlag    The feature flag the user wants to access
+     * @param  string        $userId         user id
+     * @param  array         $userAttributes user userAttributes
      * @return Decision  if a variation is returned for the user
      *         null  if feature flag is not used in any experiments or no variation is returned for the user
      */
-    public function getVariationForFeatureExperiment(FeatureFlag $featureFlag, $userId, $userAttributes)
+    public function getVariationForFeatureExperiment($projectConfig, FeatureFlag $featureFlag, $userId, $userAttributes)
     {
         $featureFlagKey = $featureFlag->getKey();
         $experimentIds = $featureFlag->getExperimentIds();
@@ -225,13 +222,13 @@ class DecisionService
 
         // Evaluate each experiment ID and return the first bucketed experiment variation
         foreach ($experimentIds as $experiment_id) {
-            $experiment = $this->_projectConfig->getExperimentFromId($experiment_id);
+            $experiment = $projectConfig->getExperimentFromId($experiment_id);
             if ($experiment && !($experiment->getKey())) {
                 // Error logged and exception thrown in ProjectConfig-getExperimentFromId
                 continue;
             }
 
-            $variation = $this->getVariation($experiment, $userId, $userAttributes);
+            $variation = $this->getVariation($projectConfig, $experiment, $userId, $userAttributes);
             if ($variation && $variation->getKey()) {
                 $this->_logger->log(
                     Logger::INFO,
@@ -255,15 +252,16 @@ class DecisionService
      * Evaluate the user for rules in priority order by seeing if the user satisfies the audience.
      * Fall back onto the everyone else rule if the user is ever excluded from a rule due to traffic allocation.
      *
-     * @param  FeatureFlag $featureFlag    The feature flag the user wants to access
-     * @param  string      $userId         user id
-     * @param  array       $userAttributes user userAttributes
+     * @param  ProjectConfig $projectConfig  ProjectConfig instance.
+     * @param  FeatureFlag   $featureFlag    The feature flag the user wants to access
+     * @param  string        $userId         user id
+     * @param  array         $userAttributes user userAttributes
      * @return Decision  if a variation is returned for the user
      *         null  if feature flag is not used in a rollout or
      *               no rollout found against the rollout ID or
      *               no variation is returned for the user
      */
-    public function getVariationForFeatureRollout(FeatureFlag $featureFlag, $userId, $userAttributes)
+    public function getVariationForFeatureRollout($projectConfig, FeatureFlag $featureFlag, $userId, $userAttributes)
     {
         $bucketing_id = $this->getBucketingId($userId, $userAttributes);
         $featureFlagKey = $featureFlag->getKey();
@@ -275,7 +273,7 @@ class DecisionService
             );
             return null;
         }
-        $rollout = $this->_projectConfig->getRolloutFromId($rollout_id);
+        $rollout = $projectConfig->getRolloutFromId($rollout_id);
         if ($rollout && !($rollout->getId())) {
             // Error logged and thrown in getRolloutFromId
             return null;
@@ -291,7 +289,7 @@ class DecisionService
             $experiment = $rolloutRules[$i];
 
             // Evaluate if user meets the audience condition of this rollout rule
-            if (!Validator::isUserInExperiment($this->_projectConfig, $experiment, $userAttributes, $this->_logger)) {
+            if (!Validator::isUserInExperiment($projectConfig, $experiment, $userAttributes, $this->_logger)) {
                 $this->_logger->log(
                     Logger::DEBUG,
                     sprintf("User '%s' did not meet the audience conditions to be in rollout rule '%s'.", $userId, $experiment->getKey())
@@ -301,7 +299,7 @@ class DecisionService
             }
 
             // Evaluate if user satisfies the traffic allocation for this rollout rule
-            $variation = $this->_bucketer->bucket($this->_projectConfig, $experiment, $bucketing_id, $userId);
+            $variation = $this->_bucketer->bucket($projectConfig, $experiment, $bucketing_id, $userId);
             if ($variation && $variation->getKey()) {
                 return new FeatureDecision($experiment, $variation, FeatureDecision::DECISION_SOURCE_ROLLOUT);
             }
@@ -311,7 +309,7 @@ class DecisionService
         $experiment = $rolloutRules[sizeof($rolloutRules)-1];
 
         // Evaluate if user meets the audience condition of Everyone Else Rule / Last Rule now
-        if (!Validator::isUserInExperiment($this->_projectConfig, $experiment, $userAttributes, $this->_logger)) {
+        if (!Validator::isUserInExperiment($projectConfig, $experiment, $userAttributes, $this->_logger)) {
             $this->_logger->log(
                 Logger::DEBUG,
                 sprintf("User '%s' did not meet the audience conditions to be in rollout rule '%s'.", $userId, $experiment->getKey())
@@ -319,7 +317,7 @@ class DecisionService
             return null;
         }
 
-        $variation = $this->_bucketer->bucket($this->_projectConfig, $experiment, $bucketing_id, $userId);
+        $variation = $this->_bucketer->bucket($projectConfig, $experiment, $bucketing_id, $userId);
         if ($variation && $variation->getKey()) {
             return new FeatureDecision($experiment, $variation, FeatureDecision::DECISION_SOURCE_ROLLOUT);
         }
@@ -329,18 +327,19 @@ class DecisionService
     /**
      * Determine variation the user has been forced into.
      *
-     * @param $experiment Experiment Experiment in which user is to be bucketed.
-     * @param $userId     string     string
+     * @param $projectConfig ProjectConfig  ProjectConfig instance.
+     * @param $experiment    Experiment     Experiment in which user is to be bucketed.
+     * @param $userId        string         string
      *
      * @return null|Variation Representing the variation the user is forced into.
      */
-    private function getWhitelistedVariation(Experiment $experiment, $userId)
+    private function getWhitelistedVariation($projectConfig, Experiment $experiment, $userId)
     {
         // Check if user is whitelisted for a variation.
         $forcedVariations = $experiment->getForcedVariations();
         if (!is_null($forcedVariations) && isset($forcedVariations[$userId])) {
             $variationKey = $forcedVariations[$userId];
-            $variation = $this->_projectConfig->getVariationFromKey($experiment->getKey(), $variationKey);
+            $variation = $projectConfig->getVariationFromKey($experiment->getKey(), $variationKey);
             if ($variationKey && !empty($variation->getKey())) {
                 $this->_logger->log(
                     Logger::INFO,
@@ -395,12 +394,13 @@ class DecisionService
     /**
      * Get the stored variation for the given experiment from the user profile.
      *
-     * @param $experiment  Experiment  The experiment for which we are getting the stored variation.
-     * @param $userProfile UserProfile The user profile from which we are getting the stored variation.
+     * @param $projectConfig ProjectConfig  ProjectConfig instance.
+     * @param $experiment    Experiment     The experiment for which we are getting the stored variation.
+     * @param $userProfile   UserProfile    The user profile from which we are getting the stored variation.
      *
      * @return null|Variation the stored variation or null if not found.
      */
-    private function getStoredVariation(Experiment $experiment, UserProfile $userProfile)
+    private function getStoredVariation($projectConfig, Experiment $experiment, UserProfile $userProfile)
     {
         $experimentKey = $experiment->getKey();
         $userId = $userProfile->getUserId();
@@ -414,7 +414,7 @@ class DecisionService
             return null;
         }
 
-        if (!$this->_projectConfig->isVariationIdValid($experimentKey, $variationId)) {
+        if (!$projectConfig->isVariationIdValid($experimentKey, $variationId)) {
             $this->_logger->log(
                 Logger::INFO,
                 sprintf(
@@ -427,7 +427,7 @@ class DecisionService
             return null;
         }
 
-        $variation = $this->_projectConfig->getVariationFromId($experimentKey, $variationId);
+        $variation = $projectConfig->getVariationFromId($experimentKey, $variationId);
         $this->_logger->log(
             Logger::INFO,
             sprintf(

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -143,7 +143,7 @@ class Optimizely
         }
 
         $this->_eventBuilder = new EventBuilder($this->_logger);
-        $this->_decisionService = new DecisionService($this->_logger, $this->_config, $userProfileService);
+        $this->_decisionService = new DecisionService($this->_logger, $userProfileService);
         $this->notificationCenter = new NotificationCenter($this->_logger, $this->_errorHandler);
     }
 
@@ -405,7 +405,7 @@ class Optimizely
             return null;
         }
 
-        $variation = $this->_decisionService->getVariation($experiment, $userId, $attributes);
+        $variation = $this->_decisionService->getVariation($this->_config, $experiment, $userId, $attributes);
         $variationKey = ($variation === null) ? null : $variation->getKey();
 
         if ($this->_config->isFeatureExperiment($experiment->getId())) {
@@ -520,7 +520,7 @@ class Optimizely
         }
 
         $featureEnabled = false;
-        $decision = $this->_decisionService->getVariationForFeature($featureFlag, $userId, $attributes);
+        $decision = $this->_decisionService->getVariationForFeature($this->_config, $featureFlag, $userId, $attributes);
         $variation = $decision->getVariation();
         if ($variation) {
             $experiment = $decision->getExperiment();
@@ -650,7 +650,7 @@ class Optimizely
         }
 
         $featureEnabled = false;
-        $decision = $this->_decisionService->getVariationForFeature($featureFlag, $userId, $attributes);
+        $decision = $this->_decisionService->getVariationForFeature($this->_config, $featureFlag, $userId, $attributes);
         $variableValue = $variable->getDefaultValue();
 
         if ($decision->getVariation() === null) {

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -78,10 +78,10 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $this->userProvideServiceMock = $this->getMockBuilder(UserProfileServiceInterface::class)
             ->getMock();
 
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config);
+        $this->decisionService = new DecisionService($this->loggerMock);
 
         $this->decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->config))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariation'))
             ->getMock();
     }
@@ -97,7 +97,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($pausedExperiment, $this->testUserId);
+        $variation = $this->decisionService->getVariation($this->config, $pausedExperiment, $this->testUserId);
 
         $this->assertNull($variation);
     }
@@ -115,7 +115,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, $this->testUserId, $this->testUserAttributes);
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $this->testUserId, $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -125,7 +125,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBucketingIdWhenBucketingIdIsNotString()
     {
-        $decisionService = new DecisionTester($this->loggerMock, $this->config, $this->userProvideServiceMock);
+        $decisionService = new DecisionTester($this->loggerMock, $this->userProvideServiceMock);
         $userAttributesWithBucketingId = [
             'device_type' => 'iPhone',
             'company' => 'Optimizely',
@@ -142,7 +142,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBucketingIdWhenBucketingIdIsNull()
     {
-        $decisionService = new DecisionTester($this->loggerMock, $this->config, $this->userProvideServiceMock);
+        $decisionService = new DecisionTester($this->loggerMock, $this->userProvideServiceMock);
         $userAttributesWithBucketingId = [
             'device_type' => 'iPhone',
             'company' => 'Optimizely',
@@ -158,7 +158,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBucketingIdWhenBucketingIdIsString()
     {
-        $decisionService = new DecisionTester($this->loggerMock, $this->config, $this->userProvideServiceMock);
+        $decisionService = new DecisionTester($this->loggerMock, $this->userProvideServiceMock);
         $userAttributesWithBucketingId = [
             'device_type' => 'iPhone',
             'company' => 'Optimizely',
@@ -174,7 +174,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBucketingIdWhenBucketingIdIsEmptyString()
     {
-        $decisionService = new DecisionTester($this->loggerMock, $this->config, $this->userProvideServiceMock);
+        $decisionService = new DecisionTester($this->loggerMock, $this->userProvideServiceMock);
         $userAttributesWithBucketingId = [
             'device_type' => 'iPhone',
             'company' => 'Optimizely',
@@ -207,7 +207,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, 'user1');
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1');
 
         $this->assertEquals(
             $expectedVariation,
@@ -244,7 +244,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, 'user1');
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1');
 
         $this->assertEquals(
             $expectedVariation,
@@ -270,7 +270,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, 'user1', $this->testUserAttributes);
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1', $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -301,7 +301,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, 'user1', $this->testUserAttributes);
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1', $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -322,7 +322,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, 'not_whitelisted_user', $this->testUserAttributes);
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, 'not_whitelisted_user', $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -341,7 +341,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, $this->testUserId); // no matching attributes
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $this->testUserId); // no matching attributes
 
         $this->assertNull($variation);
     }
@@ -374,12 +374,12 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->method('lookup')
             ->willReturn($storedUserProfile);
 
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config, $this->userProvideServiceMock);
+        $this->decisionService = new DecisionService($this->loggerMock, $this->userProvideServiceMock);
         $bucketer = new \ReflectionProperty(DecisionService::class, '_bucketer');
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, $userId);
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $userId);
         $this->assertEquals($expectedVariation, $variation);
     }
 
@@ -418,12 +418,12 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
                 )
             );
 
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config, $this->userProvideServiceMock);
+        $this->decisionService = new DecisionService($this->loggerMock, $this->userProvideServiceMock);
         $bucketer = new \ReflectionProperty(DecisionService::class, '_bucketer');
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, $userId, $this->testUserAttributes);
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -471,12 +471,12 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
                 )
             );
 
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config, $this->userProvideServiceMock);
+        $this->decisionService = new DecisionService($this->loggerMock, $this->userProvideServiceMock);
         $bucketer = new \ReflectionProperty(DecisionService::class, '_bucketer');
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, $userId, $this->testUserAttributes);
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -524,12 +524,12 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
                 )
             );
 
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config, $this->userProvideServiceMock);
+        $this->decisionService = new DecisionService($this->loggerMock, $this->userProvideServiceMock);
         $bucketer = new \ReflectionProperty(DecisionService::class, '_bucketer');
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, $userId, $this->testUserAttributes);
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -568,12 +568,12 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->method('save')
             ->with($this->throwException(new Exception()));
 
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config, $this->userProvideServiceMock);
+        $this->decisionService = new DecisionService($this->loggerMock, $this->userProvideServiceMock);
         $bucketer = new \ReflectionProperty(DecisionService::class, '_bucketer');
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($runningExperiment, $userId, $this->testUserAttributes);
+        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -679,7 +679,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->method('lookup')
             ->willReturn($storedUserProfile);
 
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config, $this->userProvideServiceMock);
+        $this->decisionService = new DecisionService($this->loggerMock, $this->userProvideServiceMock);
         $bucketer = new \ReflectionProperty(DecisionService::class, '_bucketer');
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
@@ -696,7 +696,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::DEBUG, "The feature flag 'empty_feature' is not used in any experiments.");
 
-        $this->assertNull($this->decisionService->getVariationForFeatureExperiment($featureFlag, 'user1', []));
+        $this->assertNull($this->decisionService->getVariationForFeatureExperiment($this->config, $featureFlag, 'user1', []));
     }
 
     // should return nil and log a message when the experiment is not in the datafile
@@ -718,7 +718,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
                 "The user 'user1' is not bucketed into any of the experiments using the feature 'boolean_feature'."
             );
 
-        $this->assertNull($this->decisionService->getVariationForFeatureExperiment($featureFlag, 'user1', []));
+        $this->assertNull($this->decisionService->getVariationForFeatureExperiment($this->config, $featureFlag, 'user1', []));
     }
 
     // should return nil and log when the user is not bucketed into the feature flag's experiments
@@ -739,7 +739,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
                 "The user 'user1' is not bucketed into any of the experiments using the feature 'multi_variate_feature'."
             );
         $featureFlag = $this->config->getFeatureFlagFromKey('multi_variate_feature');
-        $this->assertNull($this->decisionServiceMock->getVariationForFeatureExperiment($featureFlag, 'user1', []));
+        $this->assertNull($this->decisionServiceMock->getVariationForFeatureExperiment($this->config, $featureFlag, 'user1', []));
     }
 
     //  should return the variation when the user is bucketed into a variation for the experiment on the feature flag
@@ -764,7 +764,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $expected_decision,
-            $this->decisionServiceMock->getVariationForFeatureExperiment($featureFlag, 'user1', [])
+            $this->decisionServiceMock->getVariationForFeatureExperiment($this->config, $featureFlag, 'user1', [])
         );
     }
 
@@ -790,7 +790,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             );
         $this->assertEquals(
             $expected_decision,
-            $this->decisionServiceMock->getVariationForFeatureExperiment($featureFlag, 'user_1', [])
+            $this->decisionServiceMock->getVariationForFeatureExperiment($this->config, $featureFlag, 'user_1', [])
         );
     }
 
@@ -812,14 +812,14 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
                 Logger::INFO,
                 "The user 'user_1' is not bucketed into any of the experiments using the feature 'boolean_feature'."
             );
-        $this->assertNull($this->decisionServiceMock->getVariationForFeatureExperiment($featureFlag, 'user_1', []));
+        $this->assertNull($this->decisionServiceMock->getVariationForFeatureExperiment($this->config, $featureFlag, 'user_1', []));
     }
 
     // should return the bucketed experiment and variation
     public function testGetVariationForFeatureWhenTheUserIsBucketedIntoFeatureExperiment()
     {
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->config))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeatureExperiment'))
             ->getMock();
 
@@ -839,7 +839,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $expected_decision,
-            $decisionServiceMock->getVariationForFeature($featureFlag, 'user_1', [])
+            $decisionServiceMock->getVariationForFeature($this->config, $featureFlag, 'user_1', [])
         );
     }
 
@@ -847,7 +847,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
     public function testGetVariationForFeatureWhenBucketedToFeatureRollout()
     {
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->config))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeatureExperiment','getVariationForFeatureRollout'))
             ->getMock();
 
@@ -880,7 +880,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $expected_decision,
-            $decisionServiceMock->getVariationForFeature($featureFlag, 'user_1', [])
+            $decisionServiceMock->getVariationForFeature($this->config, $featureFlag, 'user_1', [])
         );
     }
 
@@ -888,7 +888,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
     public function testGetVariationForFeatureWhenTheUserIsNeitherBucketedIntoFeatureExperimentNorToFeatureRollout()
     {
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->config))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeatureExperiment','getVariationForFeatureRollout'))
             ->getMock();
 
@@ -916,7 +916,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             FeatureDecision::DECISION_SOURCE_ROLLOUT
         );
         $this->assertEquals(
-            $decisionServiceMock->getVariationForFeature($featureFlag, 'user_1', []),
+            $decisionServiceMock->getVariationForFeature($this->config, $featureFlag, 'user_1', []),
             $expectedDecision
         );
     }
@@ -934,7 +934,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
                 "Feature flag 'boolean_feature' is not used in a rollout."
             );
 
-        $this->assertNull($this->decisionServiceMock->getVariationForFeatureRollout($featureFlag, 'user_1', []));
+        $this->assertNull($this->decisionServiceMock->getVariationForFeatureRollout($this->config, $featureFlag, 'user_1', []));
     }
 
     // should return null
@@ -952,7 +952,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
                 'Rollout with ID "invalid_rollout_id" is not in the datafile.'
             );
 
-        $this->assertNull($this->decisionServiceMock->getVariationForFeatureRollout($featureFlag, 'user_1', []));
+        $this->assertNull($this->decisionServiceMock->getVariationForFeatureRollout($this->config, $featureFlag, 'user_1', []));
     }
 
     // should return null
@@ -964,7 +964,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->setMethods(array('getRolloutFromId'))
             ->getMock();
 
-        $this->decisionService = new DecisionService($this->loggerMock, $configMock);
+        $this->decisionService = new DecisionService($this->loggerMock);
 
         $featureFlag = $this->config->getFeatureFlagFromKey('boolean_single_variable_feature');
         $rollout_id = $featureFlag->getRolloutId();
@@ -976,7 +976,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->method('getRolloutFromId')
             ->will($this->returnValue($experiment_less_rollout));
 
-        $this->assertNull($this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', []));
+        $this->assertNull($this->decisionService->getVariationForFeatureRollout($configMock, $featureFlag, 'user_1', []));
     }
 
     // ============== when the user qualifies for targeting rule (audience match) ======================
@@ -1008,7 +1008,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $expected_decision,
-            $this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', $user_attributes)
+            $this->decisionService->getVariationForFeatureRollout($this->config, $featureFlag, 'user_1', $user_attributes)
         );
     }
 
@@ -1031,7 +1031,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         // Provide attributes such that user qualifies for audience
         $user_attributes = ["browser_type" => "chrome"];
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config);
+        $this->decisionService = new DecisionService($this->loggerMock);
         $bucketer = new \ReflectionProperty(DecisionService::class, '_bucketer');
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
@@ -1046,7 +1046,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $expected_decision,
-            $this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', $user_attributes)
+            $this->decisionService->getVariationForFeatureRollout($this->config, $featureFlag, 'user_1', $user_attributes)
         );
     }
 
@@ -1063,7 +1063,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         // Provide attributes such that user qualifies for audience
         $user_attributes = ["browser_type" => "chrome"];
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config);
+        $this->decisionService = new DecisionService($this->loggerMock);
         $bucketer = new \ReflectionProperty(DecisionService::class, '_bucketer');
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
@@ -1077,7 +1077,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->willReturn(null);
 
         $this->assertNull(
-            $this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', $user_attributes)
+            $this->decisionService->getVariationForFeatureRollout($this->config, $featureFlag, 'user_1', $user_attributes)
         );
     }
 
@@ -1105,7 +1105,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         // Provide null attributes so that user does not qualify for audience
         $user_attributes = [];
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config);
+        $this->decisionService = new DecisionService($this->loggerMock);
         $bucketer = new \ReflectionProperty(DecisionService::class, '_bucketer');
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
@@ -1121,7 +1121,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $expected_decision,
-            $this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', $user_attributes)
+            $this->decisionService->getVariationForFeatureRollout($this->config, $featureFlag, 'user_1', $user_attributes)
         );
 
         // Verify Logs
@@ -1145,7 +1145,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         // Provide null attributes so that user does not qualify for audience
         $user_attributes = [];
-        $this->decisionService = new DecisionService($this->loggerMock, $this->config);
+        $this->decisionService = new DecisionService($this->loggerMock);
         $bucketer = new \ReflectionProperty(DecisionService::class, '_bucketer');
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
@@ -1158,7 +1158,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->will($this->returnCallback($this->collectLogsForAssertion));
 
-        $this->assertNull($this->decisionService->getVariationForFeatureRollout($featureFlag, 'user_1', $user_attributes));
+        $this->assertNull($this->decisionService->getVariationForFeatureRollout($this->config, $featureFlag, 'user_1', $user_attributes));
 
         // Verify Logs
         $this->assertContains([Logger::DEBUG, "User 'user_1' did not meet the audience conditions to be in rollout rule '{$experiment0->getKey()}'."], $this->collectedLogs);

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -2353,7 +2353,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -2394,7 +2394,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -2447,7 +2447,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -2492,7 +2492,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -2553,7 +2553,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -2597,7 +2597,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -2659,7 +2659,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -2711,7 +2711,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -2770,7 +2770,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -2821,7 +2821,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -2938,7 +2938,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3108,7 +3108,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3430,7 +3430,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     {
         // should return default value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3465,7 +3465,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     {
         // should return specific value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3503,7 +3503,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     {
         // should return specific value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3542,7 +3542,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     {
         // should return specific value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3580,7 +3580,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     {
         // should return specific value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3620,7 +3620,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // should return default value
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3664,7 +3664,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     {
         // should return default value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3738,7 +3738,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3780,7 +3780,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3819,7 +3819,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -3861,7 +3861,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
 
@@ -4006,7 +4006,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     {
         // should return specific value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
         $decisionService = new \ReflectionProperty(Optimizely::class, '_decisionService');
@@ -4062,7 +4062,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         // should return specific value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
         $decisionService = new \ReflectionProperty(Optimizely::class, '_decisionService');
@@ -4117,7 +4117,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     {
         // should return specific value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
         $decisionService = new \ReflectionProperty(Optimizely::class, '_decisionService');
@@ -4169,7 +4169,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     {
         // should return specific value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
         $decisionService = new \ReflectionProperty(Optimizely::class, '_decisionService');
@@ -4222,7 +4222,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
     {
         // should return default value
         $decisionServiceMock = $this->getMockBuilder(DecisionService::class)
-            ->setConstructorArgs(array($this->loggerMock, $this->projectConfig))
+            ->setConstructorArgs(array($this->loggerMock))
             ->setMethods(array('getVariationForFeature'))
             ->getMock();
         $decisionService = new \ReflectionProperty(Optimizely::class, '_decisionService');


### PR DESCRIPTION
## Summary
- Moved ProjectConfig from DecisionService constructor to individual methods

## Test plan
- Updated unit tests.