### PR TITLE
Allow notification center to be passed in to Optimizely

### DIFF
--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -111,6 +111,8 @@ class Optimizely
      * @param $errorHandler ErrorHandlerInterface
      * @param $skipJsonValidation boolean representing whether JSON schema validation needs to be performed.
      * @param $userProfileService UserProfileServiceInterface
+     * @param $configManager ProjectConfigManagerInterface provides ProjectConfig through getConfig method.
+     * @param $notificationCenter NotificationCenter
      */
     public function __construct(
         $datafile,
@@ -119,7 +121,8 @@ class Optimizely
         ErrorHandlerInterface $errorHandler = null,
         $skipJsonValidation = false,
         UserProfileServiceInterface $userProfileService = null,
-        ProjectConfigManagerInterface $configManager = null
+        ProjectConfigManagerInterface $configManager = null,
+        NotificationCenter $notificationCenter = null
     ) {
         $this->_isValid = true;
         $this->_eventDispatcher = $eventDispatcher ?: new DefaultEventDispatcher();
@@ -127,12 +130,8 @@ class Optimizely
         $this->_errorHandler = $errorHandler ?: new NoOpErrorHandler();
         $this->_eventBuilder = new EventBuilder($this->_logger);
         $this->_decisionService = new DecisionService($this->_logger, $userProfileService);
-        $this->notificationCenter = new NotificationCenter($this->_logger, $this->_errorHandler);
-        $this->_projectConfigManager = $configManager;
-
-        if ($this->_projectConfigManager === null) {
-            $this->_projectConfigManager = new StaticProjectConfigManager($datafile, $skipJsonValidation, $this->_logger, $this->_errorHandler);
-        }
+        $this->notificationCenter = $notificationCenter ?: new NotificationCenter($this->_logger, $this->_errorHandler);
+        $this->_projectConfigManager = $configManager ?: new StaticProjectConfigManager($datafile, $skipJsonValidation, $this->_logger, $this->_errorHandler);
     }
 
     /**
@@ -148,7 +147,7 @@ class Optimizely
     /**
      * Helper function to validate user inputs into the API methods.
      *
-     * @param $userId string ID for user.
+     * @param $attributes array Associative array of user attributes
      * @param $eventTags array Hash representing metadata associated with an event.
      *
      * @return boolean Representing whether all user inputs are valid.

--- a/src/Optimizely/ProjectConfigManager/HTTPProjectConfigManager.php
+++ b/src/Optimizely/ProjectConfigManager/HTTPProjectConfigManager.php
@@ -22,7 +22,9 @@ use GuzzleHttp\Client as HttpClient;
 use Monolog\Logger;
 use Optimizely\Config\DatafileProjectConfig;
 use Optimizely\Enums\ProjectConfigManagerConstants;
+use Optimizely\ErrorHandler\ErrorHandlerInterface;
 use Optimizely\ErrorHandler\NoOpErrorHandler;
+use Optimizely\Logger\LoggerInterface;
 use Optimizely\Logger\NoOpLogger;
 use Optimizely\Notification\NotificationCenter;
 use Optimizely\Notification\NotificationType;
@@ -77,17 +79,14 @@ class HTTPProjectConfigManager implements ProjectConfigManagerInterface
         $fetchOnInit = true,
         $datafile = null,
         $skipJsonValidation = false,
-        $logger = null,
-        $errorHandler = null,
-        $notificationCenter = null
+        LoggerInterface $logger = null,
+        ErrorHandlerInterface $errorHandler = null,
+        NotificationCenter $notificationCenter = null
     ) {
         $this->_skipJsonValidation = $skipJsonValidation;
         $this->_logger = $logger ?: new NoOpLogger();
         $this->_errorHandler = $errorHandler ?: new NoOpErrorHandler();
-        $this->_notificationCenter = $notificationCenter;
-        if (!($this->_notificationCenter instanceof NotificationCenter)) {
-            $this->_notificationCenter = new NotificationCenter($this->_logger, $this->_errorHandler);
-        }
+        $this->_notificationCenter = $notificationCenter ?: new NotificationCenter($this->_logger, $this->_errorHandler);
         $this->httpClient = new HttpClient();
         $this->_url = $this->getUrl($sdkKey, $url, $urlTemplate);
 


### PR DESCRIPTION
Current setup ends up in project config manager having its own notification center and Optimizely class having its own center. This change allows us to declare a notification center and share it between the two in order to accurately set up and use listeners.