### PR TITLE
Upgrade to monolog v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: php
 dist: trusty
 php:
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
   - '7.2'
   - '7.3'
 install: "composer install"
@@ -26,7 +22,7 @@ jobs:
   include:
     - stage: 'Linting'
       language: php
-      php: '7.0'
+      php: '7.2'
       install: 'composer require "squizlabs/php_codesniffer=*"'
       script: 'composer lint'
       after_script: skip

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
     "lastguest/murmurhash": "1.3.0",
     "guzzlehttp/guzzle": "~5.3|~6.2",
-    "monolog/monolog": "~1.21",
+    "monolog/monolog": "^2.0",
     "icecave/parity": "^1.0 || ^2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "beautify": "phpcbf"
   },
   "require": {
-    "php": ">=5.5",
+    "php": ">=7.2",
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
     "lastguest/murmurhash": "1.3.0",
     "guzzlehttp/guzzle": "~5.3|~6.2",


### PR DESCRIPTION
## Summary
- As described in #191, just bringing compatibility with Laravel 6.x & 7.x

I'm creating a new project from scratch, at least, I need to make it work.

## Test plan

Fresh Laravel project just including the SDK (no wrappers/implementations yet), it failed with dependency conflicts.

**All tests passed after monolog upgrade.**

## Issues

- Sorry, it doesn't finish the issue mentioned before, it just solve the monolog part (but still some work upgrading PHPUnit dependency + tests to make it work on PHP 7.4), anyway Laravel 7 still require PHP 7.2 / 7.3, so not a major issue yet.
