### PR TITLE
build: move icecave/parity to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
     "lastguest/murmurhash": "1.3.0",
     "guzzlehttp/guzzle": "~5.3|~6.2",
-    "monolog/monolog": "~1.21",
-    "icecave/parity": "^1.0 || ^2.0"
+    "monolog/monolog": "~1.21"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",
     "php-coveralls/php-coveralls": "v2.0.0",
-    "squizlabs/php_codesniffer": "3.*"
+    "squizlabs/php_codesniffer": "3.*",
+    "icecave/parity": "^1.0 || ^2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Summary
Icecave/Parity library is being used in unit tests. This PR moves it to dev dependencies so that this doesn't get installed when SDK is used as a library in another project. 

## Test plan
All checks pass.

## Issues

