### PR TITLE
build: Update guzzle package version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=5.5",
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
     "lastguest/murmurhash": "1.3.0",
-    "guzzlehttp/guzzle": "~5.3|~6.2",
+    "guzzlehttp/guzzle": "~6.2",
     "monolog/monolog": "~1.21"
   },
   "require-dev": {


### PR DESCRIPTION
## Summary
All of the PHP versions that we support work well with Guzzle 6.2+. Our code is not compatible with Guzzle 5.3. Removed this from composer.json

## Test plan
All checks should pass.
