### PR TITLE
feat: added "enabled" field to decision metadata structure

### DIFF
--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -229,7 +229,7 @@ class EventBuilder
      *
      * @return LogEvent Event object to be sent to dispatcher.
      */
-    public function createImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes, $enabled)
+    public function createImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
     {
         $eventParams = $this->getCommonParams($config, $userId, $attributes);
 

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -143,7 +143,7 @@ class EventBuilder
      *
      * @return array Hash representing parameters particular to impression event.
      */
-    private function getImpressionParams(Experiment $experiment, $variation, $flagKey, $ruleKey, $ruleType)
+    private function getImpressionParams(Experiment $experiment, $variation, $flagKey, $ruleKey, $ruleType, $enabled)
     {
         $variationKey = $variation->getKey() ? $variation->getKey() : '';
         $impressionParams = [
@@ -156,7 +156,8 @@ class EventBuilder
                         FLAG_KEY => $flagKey,
                         RULE_KEY => $ruleKey,
                         RULE_TYPE => $ruleType,
-                        VARIATION_KEY => $variationKey
+                        VARIATION_KEY => $variationKey,
+                        ENABLED => $enabled
                     ],
                 ]
             ],
@@ -228,13 +229,13 @@ class EventBuilder
      *
      * @return LogEvent Event object to be sent to dispatcher.
      */
-    public function createImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes)
+    public function createImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes, $enabled)
     {
         $eventParams = $this->getCommonParams($config, $userId, $attributes);
 
         $experiment = $config->getExperimentFromKey($experimentKey);
         $variation = $config->getVariationFromKey($experimentKey, $variationKey);
-        $impressionParams = $this->getImpressionParams($experiment, $variation, $flagKey, $ruleKey, $ruleType);
+        $impressionParams = $this->getImpressionParams($experiment, $variation, $flagKey, $ruleKey, $ruleType, $enabled);
 
         $eventParams[VISITORS][0][SNAPSHOTS][] = $impressionParams;
 

--- a/src/Optimizely/Event/Builder/Params.php
+++ b/src/Optimizely/Event/Builder/Params.php
@@ -44,3 +44,4 @@ define('FLAG_KEY', 'flag_key');
 define('RULE_KEY', 'rule_key');
 define('RULE_TYPE', 'rule_type');
 define('VARIATION_KEY', 'variation_key');
+define('ENABLED', 'enabled');

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -195,10 +195,10 @@ class Optimizely
      * @param  array         Associative array of user attributes
      * @param  DatafileProjectConfig DatafileProjectConfig instance
      */
-    protected function sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes, $enabled)
+    protected function sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
     {
         $impressionEvent = $this->_eventBuilder
-            ->createImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes, $enabled);
+            ->createImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes);
         $this->_logger->log(Logger::INFO, sprintf('Activating user "%s" in experiment "%s".', $userId, $experimentKey));
         $this->_logger->log(
             Logger::DEBUG,
@@ -274,7 +274,7 @@ class Optimizely
             return null;
         }
 
-        $this->sendImpressionEvent($config, $experimentKey, $variationKey, '', $experimentKey, FeatureDecision::DECITION_SOURCE_EXPERIMENT, $userId, $attributes, true);
+        $this->sendImpressionEvent($config, $experimentKey, $variationKey, '', $experimentKey, FeatureDecision::DECITION_SOURCE_EXPERIMENT, true, $userId, $attributes);
 
         return $variationKey;
     }
@@ -557,7 +557,7 @@ class Optimizely
 
         if ($config->getSendFlagDecisions() && ($decision->getSource() == FeatureDecision::DECISION_SOURCE_ROLLOUT || !$variation)) {
             $ruleKey = $decision->getExperiment() ? $decision->getExperiment()->getKey() : '';
-            $this->sendImpressionEvent($config, $ruleKey, $variation ? $variation->getKey() : '', $featureFlagKey, $ruleKey, $decision->getSource(), $userId, $attributes, $featureEnabled);
+            $this->sendImpressionEvent($config, $ruleKey, $variation ? $variation->getKey() : '', $featureFlagKey, $ruleKey, $decision->getSource(), $featureEnabled, $userId, $attributes);
         }
 
         if ($variation) {
@@ -569,7 +569,7 @@ class Optimizely
                     'variationKey'=> $variation->getKey()
                 );
 
-                $this->sendImpressionEvent($config, $experimentKey, $variation->getKey(), $featureFlagKey, $experimentKey, $decision->getSource(), $userId, $attributes, $featureEnabled);
+                $this->sendImpressionEvent($config, $experimentKey, $variation->getKey(), $featureFlagKey, $experimentKey, $decision->getSource(), $featureEnabled, $userId, $attributes);
             } else {
                 $this->_logger->log(Logger::INFO, "The user '{$userId}' is not being experimented on Feature Flag '{$featureFlagKey}'.");
             }

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -195,10 +195,10 @@ class Optimizely
      * @param  array         Associative array of user attributes
      * @param  DatafileProjectConfig DatafileProjectConfig instance
      */
-    protected function sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes)
+    protected function sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes, $enabled)
     {
         $impressionEvent = $this->_eventBuilder
-            ->createImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes);
+            ->createImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes, $enabled);
         $this->_logger->log(Logger::INFO, sprintf('Activating user "%s" in experiment "%s".', $userId, $experimentKey));
         $this->_logger->log(
             Logger::DEBUG,
@@ -274,7 +274,7 @@ class Optimizely
             return null;
         }
 
-        $this->sendImpressionEvent($config, $experimentKey, $variationKey, '', $experimentKey, FeatureDecision::DECITION_SOURCE_EXPERIMENT, $userId, $attributes);
+        $this->sendImpressionEvent($config, $experimentKey, $variationKey, '', $experimentKey, FeatureDecision::DECITION_SOURCE_EXPERIMENT, $userId, $attributes, true);
 
         return $variationKey;
     }
@@ -557,7 +557,7 @@ class Optimizely
 
         if ($config->getSendFlagDecisions() && ($decision->getSource() == FeatureDecision::DECISION_SOURCE_ROLLOUT || !$variation)) {
             $ruleKey = $decision->getExperiment() ? $decision->getExperiment()->getKey() : '';
-            $this->sendImpressionEvent($config, $ruleKey, $variation ? $variation->getKey() : '', $featureFlagKey, $ruleKey, $decision->getSource(), $userId, $attributes);
+            $this->sendImpressionEvent($config, $ruleKey, $variation ? $variation->getKey() : '', $featureFlagKey, $ruleKey, $decision->getSource(), $userId, $attributes, $featureEnabled);
         }
 
         if ($variation) {
@@ -569,7 +569,7 @@ class Optimizely
                     'variationKey'=> $variation->getKey()
                 );
 
-                $this->sendImpressionEvent($config, $experimentKey, $variation->getKey(), $featureFlagKey, $experimentKey, $decision->getSource(), $userId, $attributes);
+                $this->sendImpressionEvent($config, $experimentKey, $variation->getKey(), $featureFlagKey, $experimentKey, $decision->getSource(), $userId, $attributes, $featureEnabled);
             } else {
                 $this->_logger->log(Logger::INFO, "The user '{$userId}' is not being experimented on Feature Flag '{$featureFlagKey}'.");
             }

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -556,6 +556,9 @@ class Optimizely
         $variation = $decision->getVariation();
 
         if ($config->getSendFlagDecisions() && ($decision->getSource() == FeatureDecision::DECISION_SOURCE_ROLLOUT || !$variation)) {
+            if ($variation) {
+                $featureEnabled = $variation->getFeatureEnabled();
+            }
             $ruleKey = $decision->getExperiment() ? $decision->getExperiment()->getKey() : '';
             $this->sendImpressionEvent($config, $ruleKey, $variation ? $variation->getKey() : '', $featureFlagKey, $ruleKey, $decision->getSource(), $featureEnabled, $userId, $attributes);
         }

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -147,9 +147,9 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'test_experiment',
             'experiment',
+            true,
             $this->testUserId,
-            null,
-            true
+            null
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -207,9 +207,9 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'test_experiment',
             'experiment',
+            true,
             $this->testUserId,
-            $userAttributes,
-            true
+            $userAttributes
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -248,9 +248,9 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'test_experiment',
             'experiment',
+            true,
             $this->testUserId,
-            $userAttributes,
-            true
+            $userAttributes
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -290,9 +290,9 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'test_experiment',
             'experiment',
+            true,
             $this->testUserId,
-            $userAttributes,
-            true
+            $userAttributes
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -322,9 +322,9 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'test_experiment',
             'experiment',
+            true,
             $this->testUserId,
-            $userAttributes,
-            true
+            $userAttributes
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -363,9 +363,9 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'test_experiment',
             'experiment',
+            true,
             $this->testUserId,
-            $userAttributes,
-            true
+            $userAttributes
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -411,9 +411,9 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'test_experiment',
             'experiment',
+            true,
             $this->testUserId,
-            $userAttributes,
-            true
+            $userAttributes
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -462,9 +462,9 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'test_experiment',
             'experiment',
+            true,
             $this->testUserId,
-            $userAttributes,
-            true
+            $userAttributes
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -509,9 +509,9 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'test_experiment',
             'experiment',
+            true,
             $this->testUserId,
-            $userAttributes,
-            true
+            $userAttributes
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -839,9 +839,9 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'test_experiment',
             'experiment',
+            true,
             $this->testUserId,
-            $userAttributes,
-            true
+            $userAttributes
         );
 
 

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -81,7 +81,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
                                   'flag_key' => 'test_experiment',
                                   'rule_key' => 'test_experiment',
                                   'rule_type' => 'experiment',
-                                  'variation_key'=> 'variation'
+                                  'variation_key'=> 'variation',
+                                  'enabled' => true
                               ]
                             ]]
                           );
@@ -147,7 +148,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'experiment',
             $this->testUserId,
-            null
+            null,
+            true
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -206,7 +208,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'experiment',
             $this->testUserId,
-            $userAttributes
+            $userAttributes,
+            true
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -246,7 +249,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'experiment',
             $this->testUserId,
-            $userAttributes
+            $userAttributes,
+            true
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -287,7 +291,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'experiment',
             $this->testUserId,
-            $userAttributes
+            $userAttributes,
+            true
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -318,7 +323,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'experiment',
             $this->testUserId,
-            $userAttributes
+            $userAttributes,
+            true
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -358,7 +364,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'experiment',
             $this->testUserId,
-            $userAttributes
+            $userAttributes,
+            true
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -405,7 +412,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'experiment',
             $this->testUserId,
-            $userAttributes
+            $userAttributes,
+            true
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -455,7 +463,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'experiment',
             $this->testUserId,
-            $userAttributes
+            $userAttributes,
+            true
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -501,7 +510,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'experiment',
             $this->testUserId,
-            $userAttributes
+            $userAttributes,
+            true
         );
 
         $logEvent = $this->fakeParamsToReconcile($logEvent);
@@ -830,7 +840,8 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
             'test_experiment',
             'experiment',
             $this->testUserId,
-            $userAttributes
+            $userAttributes,
+            true
         );
 
 

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -392,7 +392,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment', 'variation', '', 'test_experiment', 'experiment', '', $userAttributes);
+            ->with($this->projectConfig, 'test_experiment', 'variation', '', 'test_experiment', 'experiment', true, '', $userAttributes);
 
         // Call activate
         $this->assertEquals('variation', $optimizelyMock->activate('test_experiment', '', $userAttributes));
@@ -487,7 +487,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpression is called with expected params
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', '', 'group_experiment_1', 'experiment', 'user_1', null);
+            ->with($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', '', 'group_experiment_1', 'experiment', true, 'user_1', null);
 
         // Call activate
         $this->assertSame('group_exp_1_var_2', $optimizelyMock->activate('group_experiment_1', 'user_1'));
@@ -520,7 +520,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpression is called with expected params
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', '', 'group_experiment_1', 'experiment', 'user_1', null);
+            ->with($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', '', 'group_experiment_1', 'experiment', true, 'user_1', null);
 
         // set forced variation
         $this->assertTrue($optimizelyMock->setForcedVariation($experimentKey, $userId, $variationKey), 'Set variation for paused experiment should have failed.');
@@ -581,7 +581,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment', 'control', '', 'test_experiment', 'experiment', 'test_user', $userAttributes);
+            ->with($this->projectConfig, 'test_experiment', 'control', '', 'test_experiment', 'experiment', true, 'test_user', $userAttributes);
 
         // Call activate
         $this->assertEquals('control', $optimizelyMock->activate('test_experiment', 'test_user', $userAttributes));
@@ -614,7 +614,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment', 'control', '', 'test_experiment', 'experiment', 'test_user', $userAttributes);
+            ->with($this->projectConfig, 'test_experiment', 'control', '', 'test_experiment', 'experiment', true, 'test_user', $userAttributes);
 
         // Call activate
         $this->assertEquals('control', $optimizelyMock->activate('test_experiment', 'test_user', $userAttributes));
@@ -639,7 +639,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->at(0))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfigForTypedAudience, 'typed_audience_experiment', 'A', '', 'typed_audience_experiment', 'experiment', 'test_user', $userAttributes);
+            ->with($this->projectConfigForTypedAudience, 'typed_audience_experiment', 'A', '', 'typed_audience_experiment', 'experiment', true, 'test_user', $userAttributes);
 
         // Should be included via exact match string audience with id '3468206642'
         $this->assertEquals('A', $optimizelyMock->activate('typed_audience_experiment', 'test_user', $userAttributes));
@@ -651,7 +651,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->at(0))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfigForTypedAudience, 'typed_audience_experiment', 'A', '', 'typed_audience_experiment', 'experiment', 'test_user', $userAttributes);
+            ->with($this->projectConfigForTypedAudience, 'typed_audience_experiment', 'A', '', 'typed_audience_experiment', 'experiment', true, 'test_user', $userAttributes);
 
         //Should be included via exact match number audience with id '3468206646'
         $this->assertEquals('A', $optimizelyMock->activate('typed_audience_experiment', 'test_user', $userAttributes));
@@ -691,7 +691,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called once with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfigForTypedAudience, 'audience_combinations_experiment', 'A', '', 'audience_combinations_experiment', 'experiment', 'test_user', $userAttributes);
+            ->with($this->projectConfigForTypedAudience, 'audience_combinations_experiment', 'A', '', 'audience_combinations_experiment', 'experiment', true, 'test_user', $userAttributes);
 
         // Should be included via substring match string audience with id '3988293898', and
         // exact match number audience with id '3468206646'
@@ -2554,7 +2554,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // assert that sendImpressionEvent is called with expected params
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment_double_feature', 'control', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, 'user_id', []);
+            ->with($this->projectConfig, 'test_experiment_double_feature', 'control', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, true, 'user_id', []);
 
         $this->loggerMock->expects($this->at(0))
             ->method('log')
@@ -2659,7 +2659,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment_double_feature', 'variation', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, 'user_id', []);
+            ->with($this->projectConfig, 'test_experiment_double_feature', 'variation', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, false, 'user_id', []);
 
         $this->loggerMock->expects($this->at(0))
             ->method('log')
@@ -3042,7 +3042,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // assert that sendImpressionEvent is called with expected params
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment_double_feature', 'control', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, '', []);
+            ->with($this->projectConfig, 'test_experiment_double_feature', 'control', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, true, '', []);
 
         $this->loggerMock->expects($this->at(0))
             ->method('log')
@@ -4682,9 +4682,9 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'group_experiment_1',
                 'group_experiment_1',
                 'experiment',
+                true,
                 'user_1',
-                null,
-                true
+                null
             )
             ->willReturn(
                 new LogEvent(
@@ -4735,7 +4735,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'Dispatching impression event to URL logx.optimizely.com/decision with params {"param1":"val1","param2":"val2"}.'
             );
 
-        $optlyObject->sendImpressionEvent($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', 'group_experiment_1', 'group_experiment_1', 'experiment', 'user_1', null, true);
+        $optlyObject->sendImpressionEvent($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', 'group_experiment_1', 'group_experiment_1', 'experiment', true, 'user_1', null);
     }
 
     public function testSendImpressionEventDispatchFailure()
@@ -4758,7 +4758,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::ERROR, 'Unable to dispatch impression event. Error ');
 
-        $optlyObject->sendImpressionEvent($this->projectConfig, 'test_experiment', 'control', 'test_experiment', 'test_experiment', 'experiment', 'test_user', [], true);
+        $optlyObject->sendImpressionEvent($this->projectConfig, 'test_experiment', 'control', 'test_experiment', 'test_experiment', 'experiment', true, 'test_user', []);
     }
 
     public function testSendImpressionEventWithAttributes()
@@ -4781,6 +4781,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'test_experiment',
                 'test_experiment',
                 'experiment',
+                true,
                 'test_user',
                 $userAttributes
             )
@@ -4823,7 +4824,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $optlyObject->notificationCenter = $this->notificationCenterMock;
 
-        $optlyObject->sendImpressionEvent($this->projectConfig, 'test_experiment', 'control', 'test_experiment', 'test_experiment', 'experiment', 'test_user', $userAttributes, true);
+        $optlyObject->sendImpressionEvent($this->projectConfig, 'test_experiment', 'control', 'test_experiment', 'test_experiment', 'experiment', true, 'test_user', $userAttributes);
     }
 
     /*
@@ -4999,7 +5000,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->anything(), 'rollout_1_exp_1', '177771', 'boolean_single_variable_feature', 'rollout_1_exp_1', 'rollout', 'user_id', []);
+            ->with($this->anything(), 'rollout_1_exp_1', '177771', 'boolean_single_variable_feature', 'rollout_1_exp_1', 'rollout', false, 'user_id', []);
 
         $this->assertTrue($optimizelyMock->isFeatureEnabled('boolean_single_variable_feature', 'user_id', []));
     }

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -4683,7 +4683,8 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'group_experiment_1',
                 'experiment',
                 'user_1',
-                null
+                null,
+                true
             )
             ->willReturn(
                 new LogEvent(
@@ -4734,7 +4735,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'Dispatching impression event to URL logx.optimizely.com/decision with params {"param1":"val1","param2":"val2"}.'
             );
 
-        $optlyObject->sendImpressionEvent($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', 'group_experiment_1', 'group_experiment_1', 'experiment', 'user_1', null);
+        $optlyObject->sendImpressionEvent($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', 'group_experiment_1', 'group_experiment_1', 'experiment', 'user_1', null, true);
     }
 
     public function testSendImpressionEventDispatchFailure()
@@ -4757,7 +4758,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::ERROR, 'Unable to dispatch impression event. Error ');
 
-        $optlyObject->sendImpressionEvent($this->projectConfig, 'test_experiment', 'control', 'test_experiment', 'test_experiment', 'experiment', 'test_user', []);
+        $optlyObject->sendImpressionEvent($this->projectConfig, 'test_experiment', 'control', 'test_experiment', 'test_experiment', 'experiment', 'test_user', [], true);
     }
 
     public function testSendImpressionEventWithAttributes()
@@ -4822,7 +4823,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $optlyObject->notificationCenter = $this->notificationCenterMock;
 
-        $optlyObject->sendImpressionEvent($this->projectConfig, 'test_experiment', 'control', 'test_experiment', 'test_experiment', 'experiment', 'test_user', $userAttributes);
+        $optlyObject->sendImpressionEvent($this->projectConfig, 'test_experiment', 'control', 'test_experiment', 'test_experiment', 'experiment', 'test_user', $userAttributes, true);
     }
 
     /*

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -5000,7 +5000,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->anything(), 'rollout_1_exp_1', '177771', 'boolean_single_variable_feature', 'rollout_1_exp_1', 'rollout', false, 'user_id', []);
+            ->with($this->anything(), 'rollout_1_exp_1', '177771', 'boolean_single_variable_feature', 'rollout_1_exp_1', 'rollout', true, 'user_id', []);
 
         $this->assertTrue($optimizelyMock->isFeatureEnabled('boolean_single_variable_feature', 'user_id', []));
     }

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -1694,9 +1694,9 @@ class TestBucketer extends Bucketer
  */
 class OptimizelyTester extends Optimizely
 {
-    public function sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes)
+    public function sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes, $enabled)
     {
-        parent::sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes);
+        parent::sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes, $enabled);
     }
 
     public function validateInputs(array $values, $logLevel = Logger::ERROR)

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -1694,9 +1694,9 @@ class TestBucketer extends Bucketer
  */
 class OptimizelyTester extends Optimizely
 {
-    public function sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes, $enabled)
+    public function sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
     {
-        parent::sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $userId, $attributes, $enabled);
+        parent::sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes);
     }
 
     public function validateInputs(array $values, $logLevel = Logger::ERROR)


### PR DESCRIPTION
## Summary
1. Added "enabled" field to decision metadata structure
2. Setting "enabled" to true for activate() since we check for non null variation. 

## Test Plan
1. Manuall tested thoroughly
2. Fixed existing unit tests