### PR TITLE
feat(Decide): Add Decide API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - '7.0'
   - '7.1'
   - '7.2'
-  - '7.3'
+  - '7.3.24' # revert it back to 7.3 once 7.3.25 latest build gets fixed.
 install: "composer install"
 script:
 - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",
-    "php-coveralls/php-coveralls": "v2.0.0",
+    "php-coveralls/php-coveralls": "v2.3.0",
     "squizlabs/php_codesniffer": "3.*",
     "icecave/parity": "^1.0 || ^2.0"
   },

--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -109,6 +109,7 @@ class Bucketer
      * @param $userId string ID for user.
      * @param $parentId mixed ID representing Experiment or Group.
      * @param $trafficAllocations array Traffic allocations for variation or experiment.
+     * @param $decideReasons array Evaluation Logs.
      *
      * @return string ID representing experiment or variation.
      */
@@ -138,6 +139,7 @@ class Bucketer
      * @param $experiment Experiment Experiment or Rollout rule in which user is to be bucketed.
      * @param $bucketingId string A customer-assigned value used to create the key for the murmur hash.
      * @param $userId string User identifier.
+     * @param $decideReasons array Evaluation Logs.
      *
      * @return Variation Variation which will be shown to the user.
      */

--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -112,7 +112,7 @@ class Bucketer
      *
      * @return string ID representing experiment or variation.
      */
-    private function findBucket($bucketingId, $userId, $parentId, $trafficAllocations, &$decideReasons = null)
+    private function findBucket($bucketingId, $userId, $parentId, $trafficAllocations, &$decideReasons = [])
     {
         // Generate the bucketing key based on combination of user ID and experiment ID or group ID.
         $bucketingKey = $bucketingId.$parentId;
@@ -141,7 +141,7 @@ class Bucketer
      *
      * @return Variation Variation which will be shown to the user.
      */
-    public function bucket(ProjectConfigInterface $config, Experiment $experiment, $bucketingId, $userId, &$decideReasons = null)
+    public function bucket(ProjectConfigInterface $config, Experiment $experiment, $bucketingId, $userId, &$decideReasons = [])
     {
         if (is_null($experiment->getKey())) {
             return null;

--- a/src/Optimizely/Decide/OptimizelyDecideOption.php
+++ b/src/Optimizely/Decide/OptimizelyDecideOption.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2020, Optimizely
+ * Copyright 2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Decide/OptimizelyDecideOption.php
+++ b/src/Optimizely/Decide/OptimizelyDecideOption.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019-2020 Optimizely
+ * Copyright 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 
-namespace Optimizely\Enums;
+namespace Optimizely\Decide;
 
-class DecisionNotificationTypes
+class OptimizelyDecideOption
 {
-    const AB_TEST = "ab-test";
-    const FEATURE = "feature";
-    const FEATURE_TEST = "feature-test";
-    const FEATURE_VARIABLE = "feature-variable";
-    const FLAG = "flag";
-    const ALL_FEATURE_VARIABLES = "all-feature-variables";
+    const DISABLE_DECISION_EVENT = 'DISABLE_DECISION_EVENT';
+    const ENABLED_FLAGS_ONLY = 'ENABLED_FLAGS_ONLY';
+    const IGNORE_USER_PROFILE_SERVICE = 'IGNORE_USER_PROFILE_SERVICE';
+    const INCLUDE_REASONS = 'INCLUDE_REASONS';
+    const EXCLUDE_VARIABLES = 'EXCLUDE_VARIABLES';
 }

--- a/src/Optimizely/Decide/OptimizelyDecision.php
+++ b/src/Optimizely/Decide/OptimizelyDecision.php
@@ -28,15 +28,22 @@ class OptimizelyDecision
     private $reasons;
     
     
-    public function __construct($variationKey, $enabled, $variables, $ruleKey, $flagKey, $userContext, $reasons)
-    {
+    public function __construct(
+        $variationKey = null,
+        $enabled = null,
+        $variables = null,
+        $ruleKey = null,
+        $flagKey = null,
+        $userContext = null,
+        $reasons = null
+    ) {
         $this->variationKey = $variationKey;
-        $this->enabled = $enabled;
-        $this->variables = $variables;
+        $this->enabled = $enabled === null ? false : $enabled;
+        $this->variables = $variables === null ? [] : $variables;
         $this->ruleKey = $ruleKey;
         $this->flagKey = $flagKey;
         $this->userContext = $userContext;
-        $this->reasons = $reasons;
+        $this->reasons = $reasons === null ? [] : $reasons;
     }
 
     public function jsonSerialize()

--- a/src/Optimizely/Decide/OptimizelyDecision.php
+++ b/src/Optimizely/Decide/OptimizelyDecision.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2020, Optimizely
+ * Copyright 2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Decide/OptimizelyDecision.php
+++ b/src/Optimizely/Decide/OptimizelyDecision.php
@@ -17,7 +17,7 @@
 
 namespace Optimizely\Decide;
 
-class OptimizelyDecision
+class OptimizelyDecision implements \JsonSerializable
 {
     private $variationKey;
     private $enabled;
@@ -44,6 +44,41 @@ class OptimizelyDecision
         $this->flagKey = $flagKey;
         $this->userContext = $userContext;
         $this->reasons = $reasons === null ? [] : $reasons;
+    }
+
+    public function getVariationKey()
+    {
+        return $this->variationKey;
+    }
+
+    public function getEnabled()
+    {
+        return $this->enabled;
+    }
+
+    public function getVariables()
+    {
+        return $this->variables;
+    }
+
+    public function getRuleKey()
+    {
+        return $this->ruleKey;
+    }
+
+    public function getFlagKey()
+    {
+        return $this->flagKey;
+    }
+
+    public function getUserContext()
+    {
+        return $this->userContext;
+    }
+
+    public function getReasons()
+    {
+        return $this->reasons;
     }
 
     public function jsonSerialize()

--- a/src/Optimizely/Decide/OptimizelyDecision.php
+++ b/src/Optimizely/Decide/OptimizelyDecision.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2020, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Optimizely\Decide;
+
+class OptimizelyDecision
+{
+    private $variationKey;
+    private $enabled;
+    private $variables;
+    private $ruleKey;
+    private $flagKey;
+    private $userContext;
+    private $reasons;
+    
+    
+    public function __construct($variationKey, $enabled, $variables, $ruleKey, $flagKey, $userContext, $reasons)
+    {
+        $this->variationKey = $variationKey;
+        $this->enabled = $enabled;
+        $this->variables = $variables;
+        $this->ruleKey = $ruleKey;
+        $this->flagKey = $flagKey;
+        $this->userContext = $userContext;
+        $this->reasons = $reasons;
+    }
+
+    public function jsonSerialize()
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Optimizely/Decide/OptimizelyDecisionMessage.php
+++ b/src/Optimizely/Decide/OptimizelyDecisionMessage.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2020, Optimizely
+ * Copyright 2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Decide/OptimizelyDecisionMessage.php
+++ b/src/Optimizely/Decide/OptimizelyDecisionMessage.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019-2020 Optimizely
+ * Copyright 2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,11 @@
  * limitations under the License.
  */
 
-namespace Optimizely\Enums;
+namespace Optimizely\Decide;
 
-class DecisionNotificationTypes
+class OptimizelyDecisionMessage
 {
-    const AB_TEST = "ab-test";
-    const FEATURE = "feature";
-    const FEATURE_TEST = "feature-test";
-    const FEATURE_VARIABLE = "feature-variable";
-    const FLAG = "flag";
-    const ALL_FEATURE_VARIABLES = "all-feature-variables";
+    const SDK_NOT_READY = 'Optimizely SDK not configured properly yet.';
+    const FLAG_KEY_INVALID = 'No flag was found for key "%s".';
+    const VARIABLE_VALUE_INVALID = 'Variable value for key "%s" is invalid or wrong type.';
 }

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -418,7 +418,6 @@ class DecisionService
         if (!isset($experimentToVariationMap[$experimentId])) {
             $message = sprintf('No experiment "%s" mapped to user "%s" in the forced variation map.', $experimentKey, $userId);
             $this->_logger->log(Logger::DEBUG, $message);
-            $decideReasons[] = $message;
             return null;
         }
 

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -93,6 +93,7 @@ class DecisionService
      *
      * @param string $userId         user ID
      * @param array  $userAttributes user attributes
+     * @param array  $decideReasons evaluation logs
      *
      * @return String representing bucketing ID if it is a String type in attributes else return user ID.
      */
@@ -119,6 +120,8 @@ class DecisionService
      * @param $experiment       Experiment      Experiment to get the variation for.
      * @param $userId           string          User identifier.
      * @param $attributes       array           Attributes of the user.
+     * @param $decideOptions    array           Options to customize evaluation.
+     * @param $decideReasons    array           Evaluation Logs.
      *
      * @return Variation   Variation  which the user is bucketed into.
      */
@@ -202,6 +205,8 @@ class DecisionService
      * @param  FeatureFlag   $featureFlag    The feature flag the user wants to access
      * @param  string        $userId         user ID
      * @param  array         $userAttributes user attributes
+     * @param  array         $decideOptions   Options to customize evaluation.
+     * @param  array         $decideReasons   Evaluation Logs.
      * @return Decision  if getVariationForFeatureExperiment or getVariationForFeatureRollout returns a Decision
      *         null      otherwise
      */
@@ -247,6 +252,8 @@ class DecisionService
      * @param  FeatureFlag   $featureFlag    The feature flag the user wants to access
      * @param  string        $userId         user id
      * @param  array         $userAttributes user userAttributes
+     * @param  array         $decideOptions   Options to customize evaluation.
+     * @param  array         $decideReasons   Evaluation Logs.
      * @return Decision  if a variation is returned for the user
      *         null  if feature flag is not used in any experiments or no variation is returned for the user
      */
@@ -306,6 +313,7 @@ class DecisionService
      * @param  FeatureFlag   $featureFlag    The feature flag the user wants to access
      * @param  string        $userId         user id
      * @param  array         $userAttributes user userAttributes
+     * @param  array         $decideReasons   Evaluation Logs.
      * @return Decision  if a variation is returned for the user
      *         null  if feature flag is not used in a rollout or
      *               no rollout found against the rollout ID or
@@ -387,6 +395,7 @@ class DecisionService
      * @param $projectConfig ProjectConfigInterface  ProjectConfigInterface instance.
      * @param $experimentKey string         Key for experiment.
      * @param $userId        string         The user Id.
+     * @param $decideReasons array          Evaluation Logs.
      *
      * @return Variation The variation which the given user and experiment should be forced into.
      */
@@ -478,6 +487,7 @@ class DecisionService
      * @param $projectConfig ProjectConfigInterface  ProjectConfigInterface instance.
      * @param $experiment    Experiment     Experiment in which user is to be bucketed.
      * @param $userId        string         string
+     * @param $decideReasons array          Evaluation Logs.
      *
      * @return null|Variation Representing the variation the user is forced into.
      */
@@ -504,7 +514,8 @@ class DecisionService
     /**
      * Get the stored user profile for the given user ID.
      *
-     * @param $userId string the ID of the user.
+     * @param $userId        string  ID of the user.
+     * @param $decideReasons array   Evaluation Logs.
      *
      * @return null|UserProfile the stored user profile.
      */
@@ -544,6 +555,7 @@ class DecisionService
      * @param $projectConfig ProjectConfigInterface  ProjectConfigInterface instance.
      * @param $experiment    Experiment     The experiment for which we are getting the stored variation.
      * @param $userProfile   UserProfile    The user profile from which we are getting the stored variation.
+     * @param $decideReasons array          Evaluation Logs.
      *
      * @return null|Variation the stored variation or null if not found.
      */

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2020, Optimizely Inc and Contributors
+ * Copyright 2017-2021, Optimizely Inc and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -177,7 +177,7 @@ class DecisionService
             $decideReasons[] = $message;
         } else {
             if (!in_array(OptimizelyDecideOption::IGNORE_USER_PROFILE_SERVICE, $decideOptions)) {
-                $this->saveVariation($experiment, $variation, $userProfile, $decideReasons);
+                $this->saveVariation($experiment, $variation, $userProfile);
             }
             $message = sprintf(
                 'User "%s" is in variation %s of experiment %s.',
@@ -599,7 +599,7 @@ class DecisionService
      * @param $variation   Variation   Variation the user is bucketed into.
      * @param $userProfile UserProfile User profile object to which we are persisting the variation assignment.
      */
-    private function saveVariation(Experiment $experiment, Variation $variation, UserProfile $userProfile, &$decideReasons = [])
+    private function saveVariation(Experiment $experiment, Variation $variation, UserProfile $userProfile)
     {
         if (is_null($this->_userProfileService)) {
             return;
@@ -627,7 +627,6 @@ class DecisionService
             );
 
             $this->_logger->log(Logger::INFO, $message);
-            $decideReasons[] = $message;
         } catch (Exception $e) {
             $message = sprintf(
                 'Failed to save variation "%s" of experiment "%s" for user "%s".',
@@ -637,7 +636,6 @@ class DecisionService
             );
 
             $this->_logger->log(Logger::WARNING, $message);
-            $decideReasons[] = $message;
         }
     }
 }

--- a/src/Optimizely/DecisionService/FeatureDecision.php
+++ b/src/Optimizely/DecisionService/FeatureDecision.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017, 2019 Optimizely Inc and Contributors
+ * Copyright 2017, 2019-2020 Optimizely Inc and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/DecisionService/FeatureDecision.php
+++ b/src/Optimizely/DecisionService/FeatureDecision.php
@@ -44,17 +44,25 @@ class FeatureDecision
     private $_source;
 
     /**
+     * Array of log messages that represent decision making.
+     *
+     * @var array
+     */
+    private $reasons;
+
+    /**
      * FeatureDecision constructor.
      *
      * @param $experiment
      * @param $variation
      * @param $source
      */
-    public function __construct($experiment, $variation, $source)
+    public function __construct($experiment, $variation, $source, array $reasons = [])
     {
         $this->_experiment = $experiment;
         $this->_variation = $variation;
         $this->_source = $source;
+        $this->reasons = $reasons;
     }
 
     public function getExperiment()
@@ -70,5 +78,10 @@ class FeatureDecision
     public function getSource()
     {
         return $this->_source;
+    }
+
+    public function getReasons()
+    {
+        return $this->reasons;
     }
 }

--- a/src/Optimizely/DecisionService/FeatureDecision.php
+++ b/src/Optimizely/DecisionService/FeatureDecision.php
@@ -20,7 +20,7 @@ class FeatureDecision
 {
     const DECISION_SOURCE_FEATURE_TEST = 'feature-test';
     const DECISION_SOURCE_ROLLOUT = 'rollout';
-    const DECITION_SOURCE_EXPERIMENT = 'experiment';
+    const DECISION_SOURCE_EXPERIMENT = 'experiment';
 
     /**
      * The experiment in this decision.

--- a/src/Optimizely/DecisionService/FeatureDecision.php
+++ b/src/Optimizely/DecisionService/FeatureDecision.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017, 2019-2020 Optimizely Inc and Contributors
+ * Copyright 2017, 2019, 2021 Optimizely Inc and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Enums/DecisionNotificationTypes.php
+++ b/src/Optimizely/Enums/DecisionNotificationTypes.php
@@ -20,9 +20,9 @@ namespace Optimizely\Enums;
 class DecisionNotificationTypes
 {
     const AB_TEST = "ab-test";
+    const ALL_FEATURE_VARIABLES = "all-feature-variables";
     const FEATURE = "feature";
     const FEATURE_TEST = "feature-test";
     const FEATURE_VARIABLE = "feature-variable";
     const FLAG = "flag";
-    const ALL_FEATURE_VARIABLES = "all-feature-variables";
 }

--- a/src/Optimizely/Enums/DecisionNotificationTypes.php
+++ b/src/Optimizely/Enums/DecisionNotificationTypes.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019-2020 Optimizely
+ * Copyright 2019-2021 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -410,7 +410,7 @@ class Optimizely
                 $userAttributes,
                 (object) array(
                     'flagKey'=> $flagKey,
-                    'featureEnabled'=> $featureEnabled,
+                    'enabled'=> $featureEnabled,
                     'variables' => $allVariables,
                     'variation' => $variationKey,
                     'ruleKey' => $ruleKey,

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -99,6 +99,9 @@ class Optimizely
      */
     private $_logger;
 
+    /**
+     * @var array A default list of options for decision making.
+     */
     private $defaultDecideOptions;
 
     /**

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -253,7 +253,7 @@ class Optimizely
 
     public function createUserContext($userId, array $userAttributes = [])
     {
-        // We do not check if config is ready as UserContext can be created evne when SDK is not ready.
+        // We do not check if config is ready as UserContext can be created even when SDK is not ready.
 
         // validate userId
         if (!$this->validateInputs(

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -401,6 +401,8 @@ class Optimizely
             }
         }
 
+        $shouldIncludeReasons = in_array(OptimizelyDecideOption::INCLUDE_REASONS, $decideOptions);
+
         // send notification
         $this->notificationCenter->sendNotifications(
             NotificationType::DECISION,
@@ -414,13 +416,11 @@ class Optimizely
                     'variables' => $allVariables,
                     'variation' => $variationKey,
                     'ruleKey' => $ruleKey,
-                    'reasons' => $decideReasons,
+                    'reasons' => $shouldIncludeReasons ? $decideReasons:[],
                     'decisionEventDispatched' => $decisionEventDispatched
                 )
             )
         );
-
-        $shouldIncludeReasons = in_array(OptimizelyDecideOption::INCLUDE_REASONS, $decideOptions);
 
         return new OptimizelyDecision(
             $variationKey,

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -375,9 +375,9 @@ class Optimizely
                 $this->sendImpressionEvent(
                     $config,
                     $ruleKey,
-                    $variationKey,
+                    $variationKey === null ? '' : $variationKey,
                     $flagKey,
-                    $ruleKey,
+                    $ruleKey === null ? '' : $ruleKey,
                     $source,
                     $featureEnabled,
                     $userId,
@@ -415,7 +415,7 @@ class Optimizely
                     'flagKey'=> $flagKey,
                     'enabled'=> $featureEnabled,
                     'variables' => $allVariables,
-                    'variation' => $variationKey,
+                    'variationKey' => $variationKey,
                     'ruleKey' => $ruleKey,
                     'reasons' => $shouldIncludeReasons ? $decideReasons:[],
                     'decisionEventDispatched' => $decisionEventDispatched

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -250,7 +250,17 @@ class Optimizely
         );
     }
 
-
+    /**
+     * Create a context of the user for which decision APIs will be called.
+     * 
+     * A user context will be created successfully even when the SDK is not fully configured yet.
+     *
+     * @param $userId string The user ID to be used for bucketing.
+     * @param $userAttributes array A Hash representing user attribute names and values.
+     *
+     * @return OptimizelyUserContext|null An OptimizelyUserContext associated with this OptimizelyClient,
+     *                                    or null If user attributes are not in valid format. 
+     */
     public function createUserContext($userId, array $userAttributes = [])
     {
         // We do not check if config is ready as UserContext can be created even when SDK is not ready.
@@ -273,6 +283,17 @@ class Optimizely
         return new OptimizelyUserContext($this, $userId, $userAttributes);
     }
 
+    /**
+     * Returns a decision result (OptimizelyDecision) for a given flag key and a user context, which contains all data required to deliver the flag.
+     * 
+     * If the SDK finds an error, it'll return a `decision` with null for `variationKey`. The decision will include an error message in `reasons`
+     *
+     * @param $userContext OptimizelyUserContext context of the user for which decision will be called.
+     * @param $key string A flag key for which a decision will be made.
+     * @param $decideOptions array A list of options for decision making.
+     *
+     * @return OptimizelyDecision A decision result 
+     */
     public function decide(OptimizelyUserContext $userContext, $key, array $decideOptions = [])
     {
         $decideReasons = [];
@@ -409,6 +430,14 @@ class Optimizely
         );
     }
 
+    /**
+     * Returns a hash of decision results (OptimizelyDecision) for all active flag keys.
+     * 
+     * @param $userContext OptimizelyUserContext context of the user for which decision will be called.
+     * @param $decideOptions array A list of options for decision making.
+     *
+     * @return array Hash of decisions containing flag keys as hash keys and corresponding decisions as their values.
+     */
     public function decideAll(OptimizelyUserContext $userContext, array $decideOptions = [])
     {
         // check if SDK is ready
@@ -428,6 +457,19 @@ class Optimizely
         return $this->decideForKeys($userContext, $keys, $decideOptions);
     }
 
+    /**
+     * Returns a hash of decision results (OptimizelyDecision) for multiple flag keys and a user context.
+     * 
+     * If the SDK finds an error for a key, the response will include a decision for the key showing `reasons` for the error.
+     * 
+     * The SDK will always return hash of decisions. When it can not process requests, it'll return an empty hash after logging the errors.
+     *
+     * @param $userContext OptimizelyUserContext context of the user for which decision will be called.
+     * @param $keys array A list of flag keys for which the decisions will be made.
+     * @param $decideOptions array A list of options for decision making.
+     *
+     * @return array Hash of decisions containing flag keys as hash keys and corresponding decisions as their values.
+     */
     public function decideForKeys(OptimizelyUserContext $userContext, array $keys, array $decideOptions = [])
     {
         // check if SDK is ready

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -252,14 +252,14 @@ class Optimizely
 
     /**
      * Create a context of the user for which decision APIs will be called.
-     * 
+     *
      * A user context will be created successfully even when the SDK is not fully configured yet.
      *
      * @param $userId string The user ID to be used for bucketing.
      * @param $userAttributes array A Hash representing user attribute names and values.
      *
      * @return OptimizelyUserContext|null An OptimizelyUserContext associated with this OptimizelyClient,
-     *                                    or null If user attributes are not in valid format. 
+     *                                    or null If user attributes are not in valid format.
      */
     public function createUserContext($userId, array $userAttributes = [])
     {
@@ -285,14 +285,14 @@ class Optimizely
 
     /**
      * Returns a decision result (OptimizelyDecision) for a given flag key and a user context, which contains all data required to deliver the flag.
-     * 
+     *
      * If the SDK finds an error, it'll return a `decision` with null for `variationKey`. The decision will include an error message in `reasons`
      *
      * @param $userContext OptimizelyUserContext context of the user for which decision will be called.
      * @param $key string A flag key for which a decision will be made.
      * @param $decideOptions array A list of options for decision making.
      *
-     * @return OptimizelyDecision A decision result 
+     * @return OptimizelyDecision A decision result
      */
     public function decide(OptimizelyUserContext $userContext, $key, array $decideOptions = [])
     {
@@ -432,7 +432,7 @@ class Optimizely
 
     /**
      * Returns a hash of decision results (OptimizelyDecision) for all active flag keys.
-     * 
+     *
      * @param $userContext OptimizelyUserContext context of the user for which decision will be called.
      * @param $decideOptions array A list of options for decision making.
      *
@@ -459,9 +459,9 @@ class Optimizely
 
     /**
      * Returns a hash of decision results (OptimizelyDecision) for multiple flag keys and a user context.
-     * 
+     *
      * If the SDK finds an error for a key, the response will include a decision for the key showing `reasons` for the error.
-     * 
+     *
      * The SDK will always return hash of decisions. When it can not process requests, it'll return an empty hash after logging the errors.
      *
      * @param $userContext OptimizelyUserContext context of the user for which decision will be called.

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -332,7 +332,7 @@ class Optimizely
         }
 
         // merge decide options and default decide options
-        $decideOptions += $this->defaultDecideOptions;
+        $decideOptions = array_merge($decideOptions, $this->defaultDecideOptions);
 
         // create optimizely decision result
         $userId = $userContext->getUserId();
@@ -481,6 +481,9 @@ class Optimizely
             $this->_logger->log(Logger::ERROR, sprintf(Errors::INVALID_DATAFILE, __FUNCTION__));
             return [];
         }
+
+        // merge decide options and default decide options
+        $decideOptions = array_merge($decideOptions, $this->defaultDecideOptions);
 
         $enabledFlagsOnly = in_array(OptimizelyDecideOption::ENABLED_FLAGS_ONLY, $decideOptions);
         $decisions = [];

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -350,9 +350,10 @@ class Optimizely
             $featureFlag,
             $userId,
             $userAttributes,
-            $decideOptions,
-            $decideReasons
+            $decideOptions
         );
+
+        $decideReasons = $decision->getReasons();
         $variation = $decision->getVariation();
 
         if ($variation) {
@@ -681,7 +682,7 @@ class Optimizely
             return null;
         }
 
-        $variation = $this->_decisionService->getVariation($config, $experiment, $userId, $attributes);
+        list($variation, $reasons) = $this->_decisionService->getVariation($config, $experiment, $userId, $attributes);
         $variationKey = ($variation === null) ? null : $variation->getKey();
 
         if ($config->isFeatureExperiment($experiment->getId())) {
@@ -761,7 +762,7 @@ class Optimizely
             return null;
         }
 
-        $forcedVariation = $this->_decisionService->getForcedVariation($config, $experimentKey, $userId);
+        list($forcedVariation, $reasons)  = $this->_decisionService->getForcedVariation($config, $experimentKey, $userId);
         if (isset($forcedVariation)) {
             return $forcedVariation->getKey();
         } else {

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2020, Optimizely
+ * Copyright 2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2020, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Optimizely;
+
+class OptimizelyUserContext
+{
+    private $userId;
+    private $userAttributes;
+    
+    
+    public function __construct($userId, array $userAttributes = [])
+    {
+        $this->userId = $userId;
+        $this->userAttributes = $userAttributes;
+
+        // todo: check cloning and if null can be passed with [] as default param
+        if ($userAttributes === null) {
+            $userAttributes = [];
+        }
+    }
+
+    public function setAttribute($key, $value)
+    {
+        $this->userAttributes[$key] = $value;
+    }
+
+    public function decide($key, $options = [])
+    {
+    }
+
+    public function decideForKeys(array $keys, $options = [])
+    {
+    }
+
+    public function decideAll($options = [])
+    {
+    }
+
+    public function trackEvent($eventKey, $eventTags = [])
+    {
+    }
+}

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -19,24 +19,21 @@ namespace Optimizely;
 
 class OptimizelyUserContext
 {
+    private $optimizelyClient;
     private $userId;
-    private $userAttributes;
+    private $attributes;
     
     
-    public function __construct($userId, array $userAttributes = [])
+    public function __construct(Optimizely $optimizelyClient, $userId, array $attributes = [])
     {
+        $this->optimizelyClient = $optimizelyClient;
         $this->userId = $userId;
-        $this->userAttributes = $userAttributes;
-
-        // todo: check cloning and if null can be passed with [] as default param
-        if ($userAttributes === null) {
-            $userAttributes = [];
-        }
+        $this->attributes = $attributes;
     }
 
     public function setAttribute($key, $value)
     {
-        $this->userAttributes[$key] = $value;
+        $this->attributes[$key] = $value;
     }
 
     public function decide($key, $options = [])
@@ -53,5 +50,20 @@ class OptimizelyUserContext
 
     public function trackEvent($eventKey, $eventTags = [])
     {
+    }
+
+    public function getUserId()
+    {
+        return $this->userId;
+    }
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function getOptimizely()
+    {
+        return $this->optimizelyClient;
     }
 }

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -17,7 +17,7 @@
 
 namespace Optimizely;
 
-class OptimizelyUserContext
+class OptimizelyUserContext implements \JsonSerializable
 {
     private $optimizelyClient;
     private $userId;
@@ -38,12 +38,12 @@ class OptimizelyUserContext
 
     public function decide($key, array $options = [])
     {
-        return $optimizelyClient->decide($this, $key, $options)
+        return $this->optimizelyClient->decide($this, $key, $options);
     }
 
     public function decideForKeys(array $keys, array $options = [])
     {
-        return $optimizelyClient->decideForKeys($this, $keys, $options);
+        return $this->optimizelyClient->decideForKeys($this, $keys, $options);
     }
 
     public function decideAll(array $options = [])
@@ -69,5 +69,13 @@ class OptimizelyUserContext
     public function getOptimizely()
     {
         return $this->optimizelyClient;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'userId' => $this->userId,
+            'attributes' => $this->attributes
+        ];
     }
 }

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -48,11 +48,12 @@ class OptimizelyUserContext implements \JsonSerializable
 
     public function decideAll(array $options = [])
     {
-        return $this->optimizelyClient->decideAll($this, $keys);
+        return $this->optimizelyClient->decideAll($this, $options);
     }
 
     public function trackEvent($eventKey, array $eventTags = [])
     {
+        $eventTags = $eventTags ?: null;
         return $this->optimizelyClient->track($eventKey, $this->userId, $this->attributes, $eventTags);
     }
 

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -36,20 +36,24 @@ class OptimizelyUserContext
         $this->attributes[$key] = $value;
     }
 
-    public function decide($key, $options = [])
+    public function decide($key, array $options = [])
     {
+        return $optimizelyClient->decide($this, $key, $options)
     }
 
-    public function decideForKeys(array $keys, $options = [])
+    public function decideForKeys(array $keys, array $options = [])
     {
+        return $optimizelyClient->decideForKeys($this, $keys, $options);
     }
 
-    public function decideAll($options = [])
+    public function decideAll(array $options = [])
     {
+        return $this->optimizelyClient->decideAll($this, $keys);
     }
 
-    public function trackEvent($eventKey, $eventTags = [])
+    public function trackEvent($eventKey, array $eventTags = [])
     {
+        return $this->optimizelyClient->track($eventKey, $this->userId, $this->attributes, $eventTags);
     }
 
     public function getUserId()

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,10 +138,13 @@ class Validator
      * @param $loggingClass String Class holding log strings with placeholders.
      * @param $loggingKey String Identifier of an experiment/rollout rule.
      *
-     * @return boolean Representing whether user meets audience conditions to be in experiment or not.
+     * @return [boolean, array]  Returns a boolean representing whether user meets audience conditions to be in experiment or not.
+     *                           And an array of log messages representing decision making.
      */
     public static function doesUserMeetAudienceConditions($config, $experiment, $userAttributes, $logger, $loggingClass = null, $loggingKey = null)
     {
+        $decideReasons = [];
+
         if ($loggingClass === null) {
             $loggingClass = 'Optimizely\Enums\ExperimentAudienceEvaluationLogs';
         }
@@ -163,12 +166,14 @@ class Validator
 
         // Return true if experiment is not targeted to any audience.
         if (empty($audienceConditions)) {
-            $logger->log(Logger::INFO, sprintf(
+            $message = sprintf(
                 $loggingClass::AUDIENCE_EVALUATION_RESULT_COMBINED,
                 $loggingKey,
                 'TRUE'
-            ));
-            return true;
+            );
+            $logger->log(Logger::INFO, $message);
+            $decideReasons [] = $message;
+            return [ true, $decideReasons ];
         }
 
         if ($userAttributes === null) {
@@ -209,13 +214,16 @@ class Validator
         $evalResult = $conditionTreeEvaluator->evaluate($audienceConditions, $evaluateAudience);
         $evalResult = $evalResult || false;
 
-        $logger->log(Logger::INFO, sprintf(
+        $message = sprintf(
             $loggingClass::AUDIENCE_EVALUATION_RESULT_COMBINED,
             $loggingKey,
             strtoupper(var_export($evalResult, true))
-        ));
+        );
 
-        return $evalResult;
+        $logger->log(Logger::INFO, $message);
+        $decideReasons[] = $message;
+
+        return [ $evalResult, $decideReasons];
     }
 
     /**

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -16,8 +16,6 @@
  */
 namespace Optimizely\Tests;
 
-// require(dirname(__FILE__).'/TestData.php');
-
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -428,7 +428,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ['device_type' => 'iPhone'],
             (object) array(
                 'flagKey'=>'double_single_variable_feature',
-                'featureEnabled'=> true,
+                'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
                 'variation' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -430,7 +430,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => true
@@ -590,7 +590,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => true
@@ -681,7 +681,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => true
@@ -772,7 +772,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => false
@@ -852,7 +852,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> false,
                 'variables'=> ["double_variable" => 14.99],
-                'variation' => null,
+                'variationKey' => null,
                 'ruleKey' => null,
                 'reasons' => [],
                 'decisionEventDispatched' => true
@@ -936,7 +936,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> false,
                 'variables'=> ["double_variable" => 14.99],
-                'variation' => null,
+                'variationKey' => null,
                 'ruleKey' => null,
                 'reasons' => [],
                 'decisionEventDispatched' => false
@@ -1012,7 +1012,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => false
@@ -1078,7 +1078,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => false
@@ -1140,7 +1140,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> false,
                 'variables'=> ["double_variable" => 14.99],
-                'variation' => 'variation',
+                'variationKey' => 'variation',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => true
@@ -1214,7 +1214,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => true
@@ -1288,7 +1288,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => true
@@ -1364,7 +1364,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => true
@@ -1439,7 +1439,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> [],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => true
@@ -1527,7 +1527,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> [],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => true
@@ -1667,7 +1667,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => $expectedReasons,
                 'decisionEventDispatched' => true
@@ -1762,7 +1762,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'empty_feature',
                 'enabled'=> false,
                 'variables'=> [],
-                'variation' => null,
+                'variationKey' => null,
                 'ruleKey' => null,
                 'reasons' => $expectedReasons,
                 'decisionEventDispatched' => false
@@ -1840,7 +1840,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> [],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => false
@@ -1951,7 +1951,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'flagKey'=>'double_single_variable_feature',
                 'enabled'=> true,
                 'variables'=> [],
-                'variation' => 'control',
+                'variationKey' => 'control',
                 'ruleKey' => 'test_experiment_double_feature',
                 'reasons' => [],
                 'decisionEventDispatched' => false

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -118,6 +118,17 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         $this->staticConfigManager = new StaticProjectConfigManager($this->datafile, true, $this->loggerMock, new NoOpErrorHandler);
     }
 
+    public function compareOptimizelyDecisions(OptimizelyDecision $expectedOptimizelyDecision, OptimizelyDecision $optimizelyDecision)
+    {
+        $this->assertEquals($expectedOptimizelyDecision->getVariationKey(), $optimizelyDecision->getVariationKey());
+        $this->assertEquals($expectedOptimizelyDecision->getEnabled(), $optimizelyDecision->getEnabled());
+        $this->assertEquals($expectedOptimizelyDecision->getVariables(), $optimizelyDecision->getVariables());
+        $this->assertEquals($expectedOptimizelyDecision->getRuleKey(), $optimizelyDecision->getRuleKey());
+        $this->assertEquals($expectedOptimizelyDecision->getFlagKey(), $optimizelyDecision->getFlagKey());
+        $this->assertEquals($expectedOptimizelyDecision->getUserContext(), $optimizelyDecision->getUserContext());
+        $this->assertEquals($expectedOptimizelyDecision->getFlagKey(), $optimizelyDecision->getFlagKey());
+    }
+
     public function testIsValidForInvalidOptimizelyObject()
     {
         $optlyObject = new Optimizely('Random datafile');
@@ -461,13 +472,8 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             $userContext,
             []
         );
-        $this->assertEquals($expectedOptimizelyDecision->getVariationKey(), $optimizelyDecision->getVariationKey());
-        $this->assertEquals($expectedOptimizelyDecision->getEnabled(), $optimizelyDecision->getEnabled());
-        $this->assertEquals($expectedOptimizelyDecision->getVariables(), $optimizelyDecision->getVariables());
-        $this->assertEquals($expectedOptimizelyDecision->getRuleKey(), $optimizelyDecision->getRuleKey());
-        $this->assertEquals($expectedOptimizelyDecision->getFlagKey(), $optimizelyDecision->getFlagKey());
-        $this->assertEquals($expectedOptimizelyDecision->getUserContext(), $optimizelyDecision->getUserContext());
-        $this->assertEquals($expectedOptimizelyDecision->getFlagKey(), $optimizelyDecision->getFlagKey());
+
+        $this->compareOptimizelyDecisions($expectedOptimizelyDecision, $optimizelyDecision);
     }
 
     public function testActivateInvalidOptimizelyObject()

--- a/tests/OptimizelyUserContextTests.php
+++ b/tests/OptimizelyUserContextTests.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2020, Optimizely
+ * Copyright 2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/OptimizelyUserContextTests.php
+++ b/tests/OptimizelyUserContextTests.php
@@ -129,10 +129,61 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
 
     public function testDecideAllCallsAndReturnsOptimizelyDecideAPI()
     {
+        $userId = 'test_user';
+        $attributes = [ "browser" => "chrome"];
+
+
+        $optimizelyMock = $this->getMockBuilder(Optimizely::class)
+            ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
+            ->setMethods(array('decideAll'))
+            ->getMock();
+
+
+        $optUserContext = new OptimizelyUserContext($optimizelyMock, $userId, $attributes);
+
+        //assert that sendImpressionEvent is called with expected params
+        $optimizelyMock->expects($this->exactly(1))
+        ->method('decideAll')
+        ->with(
+            $optUserContext,
+            ['DISABLE_DECISION_EVENT', 'ENABLED_FLAGS_ONLY']
+        )
+        ->will($this->returnValue('Mocked return value'));
+
+        $this->assertEquals(
+            'Mocked return value',
+            $optUserContext->decideAll(['DISABLE_DECISION_EVENT', 'ENABLED_FLAGS_ONLY'])
+        );
     }
 
     public function testDecideForKeysCallsAndReturnsOptimizelyDecideAPI()
     {
+        $userId = 'test_user';
+        $attributes = [ "browser" => "chrome"];
+
+
+        $optimizelyMock = $this->getMockBuilder(Optimizely::class)
+            ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
+            ->setMethods(array('decideForKeys'))
+            ->getMock();
+
+
+        $optUserContext = new OptimizelyUserContext($optimizelyMock, $userId, $attributes);
+
+        //assert that sendImpressionEvent is called with expected params
+        $optimizelyMock->expects($this->exactly(1))
+        ->method('decideForKeys')
+        ->with(
+            $optUserContext,
+            ['test_feature', 'test_experiment'],
+            ['DISABLE_DECISION_EVENT', 'ENABLED_FLAGS_ONLY']
+        )
+        ->will($this->returnValue('Mocked return value'));
+
+        $this->assertEquals(
+            'Mocked return value',
+            $optUserContext->decideForKeys(['test_feature', 'test_experiment'], ['DISABLE_DECISION_EVENT', 'ENABLED_FLAGS_ONLY'])
+        );
     }
 
     public function testTrackEventCallsAndReturnsOptimizelyDecideAPI()
@@ -141,5 +192,13 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
 
     public function testJsonSerialize()
     {
-    }
+        $userId = 'test_user';
+        $attributes = [ "browser" => "chrome"];
+        $optUserContext = new OptimizelyUserContext($this->optimizelyObject, $userId, $attributes);
+
+        $this->assertEquals([
+            'userId' => $this->userId,
+            'attributes' => $this->attributes
+        ], $optUserContext->jsonSerialize());
+     }
 }

--- a/tests/OptimizelyUserContextTests.php
+++ b/tests/OptimizelyUserContextTests.php
@@ -96,6 +96,17 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(["browser" => "firefox"], $optUserContext->getAttributes());
     }
 
+    public function testSetAttributeWhenNoAttributesProvidedInConstructor()
+    {
+        $userId = 'test_user';
+        $optUserContext = new OptimizelyUserContext($this->optimizelyObject, $userId);
+
+        $this->assertEquals([], $optUserContext->getAttributes());
+
+        $optUserContext->setAttribute('browser', 'firefox');
+        $this->assertEquals(["browser" => "firefox"], $optUserContext->getAttributes());
+    }
+
     public function testDecideCallsAndReturnsOptimizelyDecideAPI()
     {
         $userId = 'test_user';

--- a/tests/OptimizelyUserContextTests.php
+++ b/tests/OptimizelyUserContextTests.php
@@ -18,7 +18,6 @@ namespace Optimizely\Tests;
 
 require(dirname(__FILE__).'/TestData.php');
 
-
 use Exception;
 use TypeError;
 
@@ -29,8 +28,6 @@ use Optimizely\OptimizelyUserContext;
 
 class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
 {
-    const OUTPUT_STREAM = 'output';
-
     private $datafile;
     private $loggerMock;
     private $optimizelyObject;

--- a/tests/OptimizelyUserContextTests.php
+++ b/tests/OptimizelyUserContextTests.php
@@ -21,7 +21,6 @@ require(dirname(__FILE__).'/TestData.php');
 use Exception;
 use TypeError;
 
-use Optimizely\ErrorHandler\NoOpErrorHandler;
 use Optimizely\Logger\NoOpLogger;
 use Optimizely\Optimizely;
 use Optimizely\OptimizelyUserContext;
@@ -111,7 +110,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
 
         $optUserContext = new OptimizelyUserContext($optimizelyMock, $userId, $attributes);
 
-        //assert that sendImpressionEvent is called with expected params
+        //assert that decide is called with expected params
         $optimizelyMock->expects($this->exactly(1))
         ->method('decide')
         ->with(
@@ -127,11 +126,10 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testDecideAllCallsAndReturnsOptimizelyDecideAPI()
+    public function testDecideAllCallsAndReturnsOptimizelyDecideAllAPI()
     {
         $userId = 'test_user';
         $attributes = [ "browser" => "chrome"];
-
 
         $optimizelyMock = $this->getMockBuilder(Optimizely::class)
             ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
@@ -141,26 +139,25 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
 
         $optUserContext = new OptimizelyUserContext($optimizelyMock, $userId, $attributes);
 
-        //assert that sendImpressionEvent is called with expected params
+        //assert that decideAll is called with expected params
         $optimizelyMock->expects($this->exactly(1))
         ->method('decideAll')
         ->with(
             $optUserContext,
-            ['DISABLE_DECISION_EVENT', 'ENABLED_FLAGS_ONLY']
+            ['ENABLED_FLAGS_ONLY']
         )
         ->will($this->returnValue('Mocked return value'));
 
         $this->assertEquals(
             'Mocked return value',
-            $optUserContext->decideAll(['DISABLE_DECISION_EVENT', 'ENABLED_FLAGS_ONLY'])
+            $optUserContext->decideAll(['ENABLED_FLAGS_ONLY'])
         );
     }
 
-    public function testDecideForKeysCallsAndReturnsOptimizelyDecideAPI()
+    public function testDecideForKeysCallsAndReturnsOptimizelyDecideForKeysAPI()
     {
         $userId = 'test_user';
         $attributes = [ "browser" => "chrome"];
-
 
         $optimizelyMock = $this->getMockBuilder(Optimizely::class)
             ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
@@ -170,24 +167,52 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
 
         $optUserContext = new OptimizelyUserContext($optimizelyMock, $userId, $attributes);
 
-        //assert that sendImpressionEvent is called with expected params
+        //assert that decideForKeys is called with expected params
         $optimizelyMock->expects($this->exactly(1))
         ->method('decideForKeys')
         ->with(
             $optUserContext,
             ['test_feature', 'test_experiment'],
-            ['DISABLE_DECISION_EVENT', 'ENABLED_FLAGS_ONLY']
+            ['DISABLE_DECISION_EVENT']
         )
         ->will($this->returnValue('Mocked return value'));
 
         $this->assertEquals(
             'Mocked return value',
-            $optUserContext->decideForKeys(['test_feature', 'test_experiment'], ['DISABLE_DECISION_EVENT', 'ENABLED_FLAGS_ONLY'])
+            $optUserContext->decideForKeys(['test_feature', 'test_experiment'], ['DISABLE_DECISION_EVENT'])
         );
     }
 
-    public function testTrackEventCallsAndReturnsOptimizelyDecideAPI()
+    public function testTrackEventCallsAndReturnsOptimizelyTrackAPI()
     {
+        $userId = 'test_user';
+        $attributes = [];
+        $eventKey = "test_event";
+        $eventTags = [ "revenue" => 50];
+
+        $optimizelyMock = $this->getMockBuilder(Optimizely::class)
+            ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
+            ->setMethods(array('track'))
+            ->getMock();
+
+
+        $optUserContext = new OptimizelyUserContext($optimizelyMock, $userId, $attributes);
+
+        //assert that track is called with expected params
+        $optimizelyMock->expects($this->exactly(1))
+        ->method('track')
+        ->with(
+            $eventKey,
+            $userId,
+            $attributes,
+            $eventTags
+        )
+        ->will($this->returnValue('Mocked return value'));
+
+        $this->assertEquals(
+            'Mocked return value',
+            $optUserContext->trackEvent($eventKey, $eventTags)
+        );
     }
 
     public function testJsonSerialize()
@@ -197,8 +222,8 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $optUserContext = new OptimizelyUserContext($this->optimizelyObject, $userId, $attributes);
 
         $this->assertEquals([
-            'userId' => $this->userId,
-            'attributes' => $this->attributes
-        ], $optUserContext->jsonSerialize());
-     }
+            'userId' => $userId,
+            'attributes' => $attributes
+        ], json_decode(json_encode($optUserContext), true));
+    }
 }

--- a/tests/OptimizelyUserContextTests.php
+++ b/tests/OptimizelyUserContextTests.php
@@ -96,4 +96,50 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $optUserContext->setAttribute('browser', 'firefox');
         $this->assertEquals(["browser" => "firefox"], $optUserContext->getAttributes());
     }
+
+    public function testDecideCallsAndReturnsOptimizelyDecideAPI()
+    {
+        $userId = 'test_user';
+        $attributes = [ "browser" => "chrome"];
+
+
+        $optimizelyMock = $this->getMockBuilder(Optimizely::class)
+            ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
+            ->setMethods(array('decide'))
+            ->getMock();
+
+
+        $optUserContext = new OptimizelyUserContext($optimizelyMock, $userId, $attributes);
+
+        //assert that sendImpressionEvent is called with expected params
+        $optimizelyMock->expects($this->exactly(1))
+        ->method('decide')
+        ->with(
+            $optUserContext,
+            'test_feature',
+            ['DISABLE_DECISION_EVENT', 'ENABLED_FLAGS_ONLY']
+        )
+        ->will($this->returnValue('Mocked return value'));
+
+        $this->assertEquals(
+            'Mocked return value',
+            $optUserContext->decide('test_feature', ['DISABLE_DECISION_EVENT', 'ENABLED_FLAGS_ONLY'])
+        );
+    }
+
+    public function testDecideAllCallsAndReturnsOptimizelyDecideAPI()
+    {
+    }
+
+    public function testDecideForKeysCallsAndReturnsOptimizelyDecideAPI()
+    {
+    }
+
+    public function testTrackEventCallsAndReturnsOptimizelyDecideAPI()
+    {
+    }
+
+    public function testJsonSerialize()
+    {
+    }
 }

--- a/tests/OptimizelyUserContextTests.php
+++ b/tests/OptimizelyUserContextTests.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright 2020, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Optimizely\Tests;
+
+require(dirname(__FILE__).'/TestData.php');
+
+
+use Exception;
+use TypeError;
+
+use Optimizely\ErrorHandler\NoOpErrorHandler;
+use Optimizely\Logger\NoOpLogger;
+use Optimizely\Optimizely;
+use Optimizely\OptimizelyUserContext;
+
+class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
+{
+    const OUTPUT_STREAM = 'output';
+
+    private $datafile;
+    private $loggerMock;
+    private $optimizelyObject;
+
+    public function setUp()
+    {
+        $this->datafile = DATAFILE;
+
+        // Mock Logger
+        $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
+            ->setMethods(array('log'))
+            ->getMock();
+
+
+        $this->optimizelyObject = new Optimizely($this->datafile, null, $this->loggerMock);
+    }
+    public function testOptimizelyUserContextIsCreatedWithExpectedValues()
+    {
+        $userId = 'test_user';
+        $attributes = [ "browser" => "chrome"];
+        $optUserContext = new OptimizelyUserContext($this->optimizelyObject, $userId, $attributes);
+
+        $this->assertEquals($userId, $optUserContext->getUserId());
+        $this->assertEquals($attributes, $optUserContext->getAttributes());
+        $this->assertSame($this->optimizelyObject, $optUserContext->getOptimizely());
+    }
+
+    public function testOptimizelyUserContextThrowsErrorWhenNonArrayPassedAsAttributes()
+    {
+        $userId = 'test_user';
+
+        try {
+            $optUserContext = new OptimizelyUserContext($this->optimizelyObject, $userId, 'HelloWorld');
+        } catch (Exception $exception) {
+            return;
+        } catch (TypeError $exception) {
+            return;
+        }
+
+        $this->fail('Unexpected behavior. UserContext should have thrown an error.');
+    }
+
+    public function testSetAttribute()
+    {
+        $userId = 'test_user';
+        $attributes = [ "browser" => "chrome"];
+        $optUserContext = new OptimizelyUserContext($this->optimizelyObject, $userId, $attributes);
+
+        $this->assertEquals($attributes, $optUserContext->getAttributes());
+
+        $optUserContext->setAttribute('color', 'red');
+        $this->assertEquals([
+            "browser" => "chrome",
+            "color" => "red"
+        ], $optUserContext->getAttributes());
+    }
+
+    public function testSetAttributeOverridesValueOfExistingKey()
+    {
+        $userId = 'test_user';
+        $attributes = [ "browser" => "chrome"];
+        $optUserContext = new OptimizelyUserContext($this->optimizelyObject, $userId, $attributes);
+
+        $this->assertEquals($attributes, $optUserContext->getAttributes());
+
+        $optUserContext->setAttribute('browser', 'firefox');
+        $this->assertEquals(["browser" => "firefox"], $optUserContext->getAttributes());
+    }
+}

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2019, Optimizely
+ * Copyright 2016-2019, 2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -1768,9 +1768,9 @@ class InvalidErrorHandler
  */
 class DecisionTester extends DecisionService
 {
-    public function getBucketingId($userId, $userAttributes)
+    public function getBucketingId($userId, $userAttributes, &$decideReasons = [])
     {
-        return parent::getBucketingId($userId, $userAttributes);
+        return parent::getBucketingId($userId, $userAttributes, $decideReasons);
     }
 }
 

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019-2020, Optimizely
+ * Copyright 2019-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,11 +52,15 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::DEBUG, "Evaluating audiences for experiment \"test_experiment\": [].");
 
+        $evalCombinedAudienceMessage = "Audiences for experiment \"test_experiment\" collectively evaluated to TRUE.";
         $this->loggerMock->expects($this->at(1))
             ->method('log')
-            ->with(Logger::INFO, "Audiences for experiment \"test_experiment\" collectively evaluated to TRUE.");
+            ->with(Logger::INFO, $evalCombinedAudienceMessage);
 
-        $this->assertTrue(Validator::doesUserMeetAudienceConditions($this->config, $experiment, [], $this->loggerMock));
+        list($evalResult, $reasons) = Validator::doesUserMeetAudienceConditions($this->config, $experiment, [], $this->loggerMock);
+        $this->assertTrue($evalResult);
+        $this->assertContains($evalCombinedAudienceMessage, $reasons);
+        $this->assertCount(1, $reasons);
     }
 
     public function testdoesUserMeetAudienceConditionsEvaluatesAudienceIds()
@@ -94,7 +98,7 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
                         ->method('log')
                         ->will($this->returnCallback($this->collectLogsForAssertion));
 
-        Validator::doesUserMeetAudienceConditions($this->typedConfig, $experiment, ["house" => "I am in Slytherin"], $this->loggerMock);
+        list($result, $reasons) = Validator::doesUserMeetAudienceConditions($this->typedConfig, $experiment, ["house" => "I am in Slytherin"], $this->loggerMock);
 
         $this->assertContains(
             [Logger::DEBUG, "Evaluating audiences for experiment \"audience_combinations_experiment\": [\"or\",[\"or\",\"3468206642\",\"3988293898\"]]."],
@@ -116,6 +120,11 @@ class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
             [Logger::DEBUG, "Audience \"3988293898\" evaluated to TRUE."],
             $this->collectedLogs
         );
-        $this->assertContains([Logger::INFO, "Audiences for experiment \"audience_combinations_experiment\" collectively evaluated to TRUE."], $this->collectedLogs);
+
+        $evalCombinedAudienceMessage = "Audiences for experiment \"audience_combinations_experiment\" collectively evaluated to TRUE.";
+
+        $this->assertContains([Logger::INFO, $evalCombinedAudienceMessage], $this->collectedLogs);
+        $this->assertContains($evalCombinedAudienceMessage, $reasons);
+        $this->assertCount(1, $reasons);
     }
 }

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,7 +218,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 null,
                 $this->loggerMock
-            )
+            )[0]
         );
 
         $this->assertTrue(
@@ -227,21 +227,21 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 [],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
     public function testDoesUserMeetAudienceConditionsAudienceMatch()
     {
         $config = new DatafileProjectConfig(DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
-        $this->assertTrue(
-            Validator::doesUserMeetAudienceConditions(
-                $config,
-                $config->getExperimentFromKey('test_experiment'),
-                ['device_type' => 'iPhone', 'location' => 'San Francisco'],
-                $this->loggerMock
-            )
+        $result = Validator::doesUserMeetAudienceConditions(
+            $config,
+            $config->getExperimentFromKey('test_experiment'),
+            ['device_type' => 'iPhone', 'location' => 'San Francisco'],
+            $this->loggerMock
         );
+
+        $this->assertTrue($result[0]);
     }
 
     public function testDoesUserMeetAudienceConditionsAudienceNoMatch()
@@ -253,7 +253,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $config->getExperimentFromKey('test_experiment'),
                 ['device_type' => 'Android', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -272,7 +272,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 [],
                 $this->loggerMock
-            )
+            )[0]
         );
 
         // Audience Ids exist but audience conditions is empty.
@@ -284,7 +284,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 [],
                 $this->loggerMock
-            )
+            )[0]
         );
 
         // Audience Ids is empty and audience conditions is null.
@@ -296,7 +296,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 [],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -317,7 +317,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['device_type' => 'Android', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
 
         // Audience Ids exist and audience conditions is null.
@@ -331,7 +331,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['device_type' => 'iPhone', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -351,7 +351,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['device_type' => 'iPhone', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -371,7 +371,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['device_type' => 'iPhone', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -404,7 +404,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['device_type' => 'iPhone', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -461,7 +461,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['should_do_it' => true, 'house' => 'foo'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 


### PR DESCRIPTION
## Summary
Added new APIs to support the decide feature. Introduced a new `OptimizelyUserContext ` class through `createUserContext` class api. This creates an optimizely instance with memoized user context and exposes the following APIs
1. `setAttribute`
2. `decide`
3. `decideAll`
4. `decideForKeys`
5. `trackEvent`

## Test plan
1. Manually tested thoroughly.
2. Added unit tests to cover new functionality. 
3. Tested with FSC manually. 

### Testapp PR: https://github.com/optimizely/php-testapp/pull/66