### PR TITLE
refact: return decide reasons instead of appending to a reference parameter

### DIFF
--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -110,7 +110,7 @@ class Bucketer
      * @param $parentId mixed ID representing Experiment or Group.
      * @param $trafficAllocations array Traffic allocations for variation or experiment.
      *
-     * @return string ID representing experiment or variation.
+     * @return [ string, array ]  ID representing experiment or variation and array of log messages representing decision making.
      */
     private function findBucket($bucketingId, $userId, $parentId, $trafficAllocations)
     {
@@ -140,7 +140,7 @@ class Bucketer
      * @param $bucketingId string A customer-assigned value used to create the key for the murmur hash.
      * @param $userId string User identifier.
      *
-     * @return Variation Variation which will be shown to the user.
+     * @return [ Variation, array ]  Variation which will be shown to the user and array of log messages representing decision making.
      */
     public function bucket(ProjectConfigInterface $config, Experiment $experiment, $bucketingId, $userId)
     {
@@ -159,7 +159,7 @@ class Bucketer
                 return [ null, $decideReasons ];
             }
 
-            [$userExperimentId, $reasons] = $this->findBucket($bucketingId, $userId, $group->getId(), $group->getTrafficAllocation());
+            list($userExperimentId, $reasons) = $this->findBucket($bucketingId, $userId, $group->getId(), $group->getTrafficAllocation());
             $decideReasons = array_merge($decideReasons, $reasons);
 
             if (empty($userExperimentId)) {
@@ -194,7 +194,7 @@ class Bucketer
         }
 
         // Bucket user if not in whitelist and in group (if any).
-        [$variationId, $reasons] = $this->findBucket($bucketingId, $userId, $experiment->getId(), $experiment->getTrafficAllocation());
+        list($variationId, $reasons) = $this->findBucket($bucketingId, $userId, $experiment->getId(), $experiment->getTrafficAllocation());
         $decideReasons = array_merge($decideReasons, $reasons);
         if (!empty($variationId)) {
             $variation = $config->getVariationFromId($experiment->getKey(), $variationId);

--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -109,12 +109,12 @@ class Bucketer
      * @param $userId string ID for user.
      * @param $parentId mixed ID representing Experiment or Group.
      * @param $trafficAllocations array Traffic allocations for variation or experiment.
-     * @param $decideReasons array Evaluation Logs.
      *
      * @return string ID representing experiment or variation.
      */
-    private function findBucket($bucketingId, $userId, $parentId, $trafficAllocations, &$decideReasons = [])
+    private function findBucket($bucketingId, $userId, $parentId, $trafficAllocations)
     {
+        $decideReasons = [];
         // Generate the bucketing key based on combination of user ID and experiment ID or group ID.
         $bucketingKey = $bucketingId.$parentId;
         $bucketingNumber = $this->generateBucketValue($bucketingKey);
@@ -125,11 +125,11 @@ class Bucketer
         foreach ($trafficAllocations as $trafficAllocation) {
             $currentEnd = $trafficAllocation->getEndOfRange();
             if ($bucketingNumber < $currentEnd) {
-                return $trafficAllocation->getEntityId();
+                return [$trafficAllocation->getEntityId(), $decideReasons];
             }
         }
 
-        return null;
+        return [null, $decideReasons];
     }
 
     /**
@@ -139,14 +139,15 @@ class Bucketer
      * @param $experiment Experiment Experiment or Rollout rule in which user is to be bucketed.
      * @param $bucketingId string A customer-assigned value used to create the key for the murmur hash.
      * @param $userId string User identifier.
-     * @param $decideReasons array Evaluation Logs.
      *
      * @return Variation Variation which will be shown to the user.
      */
-    public function bucket(ProjectConfigInterface $config, Experiment $experiment, $bucketingId, $userId, &$decideReasons = [])
+    public function bucket(ProjectConfigInterface $config, Experiment $experiment, $bucketingId, $userId)
     {
+        $decideReasons = [];
+
         if (is_null($experiment->getKey())) {
-            return null;
+            return [ null, $decideReasons ];
         }
 
         // Determine if experiment is in a mutually exclusive group.
@@ -155,15 +156,17 @@ class Bucketer
             $group = $config->getGroup($experiment->getGroupId());
 
             if (is_null($group->getId())) {
-                return null;
+                return [ null, $decideReasons ];
             }
 
-            $userExperimentId = $this->findBucket($bucketingId, $userId, $group->getId(), $group->getTrafficAllocation());
+            [$userExperimentId, $reasons] = $this->findBucket($bucketingId, $userId, $group->getId(), $group->getTrafficAllocation());
+            $decideReasons = array_merge($decideReasons, $reasons);
+
             if (empty($userExperimentId)) {
                 $message = sprintf('User "%s" is in no experiment.', $userId);
                 $this->_logger->log(Logger::INFO, $message);
                 $decideReasons[] = $message;
-                return null;
+                return [ null, $decideReasons ];
             }
 
             if ($userExperimentId != $experiment->getId()) {
@@ -176,7 +179,7 @@ class Bucketer
 
                 $this->_logger->log(Logger::INFO, $message);
                 $decideReasons[] = $message;
-                return null;
+                return [ null, $decideReasons ];
             }
 
             $message = sprintf(
@@ -191,13 +194,14 @@ class Bucketer
         }
 
         // Bucket user if not in whitelist and in group (if any).
-        $variationId = $this->findBucket($bucketingId, $userId, $experiment->getId(), $experiment->getTrafficAllocation());
+        [$variationId, $reasons] = $this->findBucket($bucketingId, $userId, $experiment->getId(), $experiment->getTrafficAllocation());
+        $decideReasons = array_merge($decideReasons, $reasons);
         if (!empty($variationId)) {
             $variation = $config->getVariationFromId($experiment->getKey(), $variationId);
 
-            return $variation;
+            return [ $variation, $decideReasons ];
         }
         
-        return null;
+        return [ null, $decideReasons ];
     }
 }

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -173,7 +173,8 @@ class DecisionService
             return null;
         }
 
-        $variation = $this->_bucketer->bucket($projectConfig, $experiment, $bucketingId, $userId, $decideReasons);
+        [$variation, $reasons] = $this->_bucketer->bucket($projectConfig, $experiment, $bucketingId, $userId);
+        $decideReasons = array_merge($decideReasons, $reasons);
         if ($variation === null) {
             $message = sprintf('User "%s" is in no variation.', $userId);
             $this->_logger->log(Logger::INFO, $message);
@@ -322,6 +323,7 @@ class DecisionService
      */
     public function getVariationForFeatureRollout(ProjectConfigInterface $projectConfig, FeatureFlag $featureFlag, $userId, $userAttributes, &$decideReasons = [])
     {
+        $decideReasons = [];
         $bucketing_id = $this->getBucketingId($userId, $userAttributes, $decideReasons);
         $featureFlagKey = $featureFlag->getKey();
         $rollout_id = $featureFlag->getRolloutId();
@@ -362,7 +364,8 @@ class DecisionService
             }
 
             // Evaluate if user satisfies the traffic allocation for this rollout rule
-            $variation = $this->_bucketer->bucket($projectConfig, $rolloutRule, $bucketing_id, $userId, $decideReasons);
+            [$variation, $reasons] = $this->_bucketer->bucket($projectConfig, $rolloutRule, $bucketing_id, $userId);
+            $decideReasons = array_merge($decideReasons, $reasons);
             if ($variation && $variation->getKey()) {
                 return new FeatureDecision($rolloutRule, $variation, FeatureDecision::DECISION_SOURCE_ROLLOUT, $decideReasons);
             }
@@ -382,7 +385,8 @@ class DecisionService
             return new FeatureDecision(null, null, null, $decideReasons);
         }
 
-        $variation = $this->_bucketer->bucket($projectConfig, $rolloutRule, $bucketing_id, $userId, $decideReasons);
+        [$variation, $reasons] = $this->_bucketer->bucket($projectConfig, $rolloutRule, $bucketing_id, $userId);
+        $decideReasons = array_merge($decideReasons, $reasons);
         if ($variation && $variation->getKey()) {
             return new FeatureDecision($rolloutRule, $variation, FeatureDecision::DECISION_SOURCE_ROLLOUT);
         }

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -171,6 +171,7 @@ class DecisionService
         }
 
         list($evalResult, $reasons) = Validator::doesUserMeetAudienceConditions($projectConfig, $experiment, $attributes, $this->_logger);
+        $decideReasons = array_merge($decideReasons, $reasons);
         if (!$evalResult) {
             $message = sprintf('User "%s" does not meet conditions to be in experiment "%s".', $userId, $experiment->getKey());
             $this->_logger->log(
@@ -363,7 +364,7 @@ class DecisionService
 
             // Evaluate if user meets the audience condition of this rollout rule
             list($evalResult, $reasons) = Validator::doesUserMeetAudienceConditions($projectConfig, $rolloutRule, $userAttributes, $this->_logger, 'Optimizely\Enums\RolloutAudienceEvaluationLogs', $i + 1);
-
+            $decideReasons = array_merge($decideReasons, $reasons);
             if (!$evalResult) {
                 $message = sprintf("User '%s' does not meet conditions for targeting rule %s.", $userId, $i+1);
                 $this->_logger->log(
@@ -388,6 +389,7 @@ class DecisionService
 
         // Evaluate if user meets the audience condition of Everyone Else Rule / Last Rule now
         list($evalResult, $reasons) = Validator::doesUserMeetAudienceConditions($projectConfig, $rolloutRule, $userAttributes, $this->_logger, 'Optimizely\Enums\RolloutAudienceEvaluationLogs', 'Everyone Else');
+        $decideReasons = array_merge($decideReasons, $reasons);
         if (!$evalResult) {
             $message = sprintf("User '%s' does not meet conditions for targeting rule 'Everyone Else'.", $userId);
             $this->_logger->log(

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -170,7 +170,8 @@ class DecisionService
             }
         }
 
-        if (!Validator::doesUserMeetAudienceConditions($projectConfig, $experiment, $attributes, $this->_logger)) {
+        list($evalResult, $reasons) = Validator::doesUserMeetAudienceConditions($projectConfig, $experiment, $attributes, $this->_logger);
+        if (!$evalResult) {
             $message = sprintf('User "%s" does not meet conditions to be in experiment "%s".', $userId, $experiment->getKey());
             $this->_logger->log(
                 Logger::INFO,
@@ -361,7 +362,9 @@ class DecisionService
             $rolloutRule = $rolloutRules[$i];
 
             // Evaluate if user meets the audience condition of this rollout rule
-            if (!Validator::doesUserMeetAudienceConditions($projectConfig, $rolloutRule, $userAttributes, $this->_logger, 'Optimizely\Enums\RolloutAudienceEvaluationLogs', $i + 1)) {
+            list($evalResult, $reasons) = Validator::doesUserMeetAudienceConditions($projectConfig, $rolloutRule, $userAttributes, $this->_logger, 'Optimizely\Enums\RolloutAudienceEvaluationLogs', $i + 1);
+
+            if (!$evalResult) {
                 $message = sprintf("User '%s' does not meet conditions for targeting rule %s.", $userId, $i+1);
                 $this->_logger->log(
                     Logger::DEBUG,
@@ -384,7 +387,8 @@ class DecisionService
         $rolloutRule = $rolloutRules[sizeof($rolloutRules) - 1];
 
         // Evaluate if user meets the audience condition of Everyone Else Rule / Last Rule now
-        if (!Validator::doesUserMeetAudienceConditions($projectConfig, $rolloutRule, $userAttributes, $this->_logger, 'Optimizely\Enums\RolloutAudienceEvaluationLogs', 'Everyone Else')) {
+        list($evalResult, $reasons) = Validator::doesUserMeetAudienceConditions($projectConfig, $rolloutRule, $userAttributes, $this->_logger, 'Optimizely\Enums\RolloutAudienceEvaluationLogs', 'Everyone Else');
+        if (!$evalResult) {
             $message = sprintf("User '%s' does not meet conditions for targeting rule 'Everyone Else'.", $userId);
             $this->_logger->log(
                 Logger::DEBUG,

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -137,14 +137,14 @@ class DecisionService
         }
 
         // check if a forced variation is set
-        [ $forcedVariation, $reasons ] = $this->getForcedVariation($projectConfig, $experiment->getKey(), $userId);
+        list($forcedVariation, $reasons) = $this->getForcedVariation($projectConfig, $experiment->getKey(), $userId);
         $decideReasons = array_merge($decideReasons, $reasons);
         if (!is_null($forcedVariation)) {
             return [ $forcedVariation, $decideReasons];
         }
 
         // check if the user has been whitelisted
-        [ $variation, $reasons ] = $this->getWhitelistedVariation($projectConfig, $experiment, $userId);
+        list($variation, $reasons) = $this->getWhitelistedVariation($projectConfig, $experiment, $userId);
         $decideReasons = array_merge($decideReasons, $reasons);
         if (!is_null($variation)) {
             return [ $variation, $decideReasons ];
@@ -154,11 +154,11 @@ class DecisionService
         if (!in_array(OptimizelyDecideOption::IGNORE_USER_PROFILE_SERVICE, $decideOptions)) {
             $userProfile = new UserProfile($userId);
             if (!is_null($this->_userProfileService)) {
-                [ $storedUserProfile, $reasons ] = $this->getStoredUserProfile($userId);
+                list($storedUserProfile, $reasons) = $this->getStoredUserProfile($userId);
                 $decideReasons = array_merge($decideReasons, $reasons);
                 if (!is_null($storedUserProfile)) {
                     $userProfile = $storedUserProfile;
-                    [ $variation, $reasons ] = $this->getStoredVariation($projectConfig, $experiment, $userProfile);
+                    list($variation, $reasons) = $this->getStoredVariation($projectConfig, $experiment, $userProfile);
                     $decideReasons = array_merge($decideReasons, $reasons);
                     if (!is_null($variation)) {
                         return [ $variation, $decideReasons ];
@@ -177,7 +177,7 @@ class DecisionService
             return [ null, $decideReasons];
         }
 
-        [$variation, $reasons] = $this->_bucketer->bucket($projectConfig, $experiment, $bucketingId, $userId);
+        list($variation, $reasons) = $this->_bucketer->bucket($projectConfig, $experiment, $bucketingId, $userId);
         $decideReasons = array_merge($decideReasons, $reasons);
         if ($variation === null) {
             $message = sprintf('User "%s" is in no variation.', $userId);
@@ -291,7 +291,7 @@ class DecisionService
                 continue;
             }
 
-            [$variation, $reasons] = $this->getVariation($projectConfig, $experiment, $userId, $userAttributes, $decideOptions);
+            list($variation, $reasons) = $this->getVariation($projectConfig, $experiment, $userId, $userAttributes, $decideOptions);
             $decideReasons = array_merge($decideReasons, $reasons);
             if ($variation && $variation->getKey()) {
                 $message = "The user '{$userId}' is bucketed into experiment '{$experiment->getKey()}' of feature '{$featureFlagKey}'.";
@@ -372,7 +372,7 @@ class DecisionService
             }
 
             // Evaluate if user satisfies the traffic allocation for this rollout rule
-            [$variation, $reasons] = $this->_bucketer->bucket($projectConfig, $rolloutRule, $bucketing_id, $userId);
+            list($variation, $reasons) = $this->_bucketer->bucket($projectConfig, $rolloutRule, $bucketing_id, $userId);
             $decideReasons = array_merge($decideReasons, $reasons);
             if ($variation && $variation->getKey()) {
                 return new FeatureDecision($rolloutRule, $variation, FeatureDecision::DECISION_SOURCE_ROLLOUT, $decideReasons);
@@ -393,7 +393,7 @@ class DecisionService
             return new FeatureDecision(null, null, null, $decideReasons);
         }
 
-        [$variation, $reasons] = $this->_bucketer->bucket($projectConfig, $rolloutRule, $bucketing_id, $userId);
+        list($variation, $reasons) = $this->_bucketer->bucket($projectConfig, $rolloutRule, $bucketing_id, $userId);
         $decideReasons = array_merge($decideReasons, $reasons);
         if ($variation && $variation->getKey()) {
             return new FeatureDecision($rolloutRule, $variation, FeatureDecision::DECISION_SOURCE_ROLLOUT);

--- a/src/Optimizely/DecisionService/FeatureDecision.php
+++ b/src/Optimizely/DecisionService/FeatureDecision.php
@@ -43,7 +43,11 @@ class FeatureDecision
      */
     private $_source;
 
-
+    /**
+     * Array of log messages that represent decision making.
+     *
+     * @var array
+     */
     private $reasons;
 
     /**
@@ -53,7 +57,7 @@ class FeatureDecision
      * @param $variation
      * @param $source
      */
-    public function __construct($experiment, $variation, $source, $reasons = [])
+    public function __construct($experiment, $variation, $source, array $reasons = [])
     {
         $this->_experiment = $experiment;
         $this->_variation = $variation;

--- a/src/Optimizely/DecisionService/FeatureDecision.php
+++ b/src/Optimizely/DecisionService/FeatureDecision.php
@@ -43,6 +43,9 @@ class FeatureDecision
      */
     private $_source;
 
+
+    private $reasons;
+
     /**
      * FeatureDecision constructor.
      *
@@ -50,11 +53,12 @@ class FeatureDecision
      * @param $variation
      * @param $source
      */
-    public function __construct($experiment, $variation, $source)
+    public function __construct($experiment, $variation, $source, $reasons = [])
     {
         $this->_experiment = $experiment;
         $this->_variation = $variation;
         $this->_source = $source;
+        $this->reasons = $reasons;
     }
 
     public function getExperiment()
@@ -70,5 +74,10 @@ class FeatureDecision
     public function getSource()
     {
         return $this->_source;
+    }
+
+    public function getReasons()
+    {
+        return $this->reasons;
     }
 }

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -682,7 +682,7 @@ class Optimizely
             return null;
         }
 
-        [ $variation, $reasons ] = $this->_decisionService->getVariation($config, $experiment, $userId, $attributes);
+        list($variation, $reasons) = $this->_decisionService->getVariation($config, $experiment, $userId, $attributes);
         $variationKey = ($variation === null) ? null : $variation->getKey();
 
         if ($config->isFeatureExperiment($experiment->getId())) {
@@ -762,7 +762,7 @@ class Optimizely
             return null;
         }
 
-        [ $forcedVariation, $reasons ]  = $this->_decisionService->getForcedVariation($config, $experimentKey, $userId);
+        list($forcedVariation, $reasons)  = $this->_decisionService->getForcedVariation($config, $experimentKey, $userId);
         if (isset($forcedVariation)) {
             return $forcedVariation->getKey();
         } else {

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -682,7 +682,7 @@ class Optimizely
             return null;
         }
 
-        $variation = $this->_decisionService->getVariation($config, $experiment, $userId, $attributes);
+        [ $variation, $reasons ] = $this->_decisionService->getVariation($config, $experiment, $userId, $attributes);
         $variationKey = ($variation === null) ? null : $variation->getKey();
 
         if ($config->isFeatureExperiment($experiment->getId())) {
@@ -762,7 +762,7 @@ class Optimizely
             return null;
         }
 
-        $forcedVariation = $this->_decisionService->getForcedVariation($config, $experimentKey, $userId);
+        [ $forcedVariation, $reasons ]  = $this->_decisionService->getForcedVariation($config, $experimentKey, $userId);
         if (isset($forcedVariation)) {
             return $forcedVariation->getKey();
         } else {

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -350,9 +350,10 @@ class Optimizely
             $featureFlag,
             $userId,
             $userAttributes,
-            $decideOptions,
-            $decideReasons
+            $decideOptions
         );
+
+        $decideReasons = $decision->getReasons();
         $variation = $decision->getVariation();
 
         if ($variation) {

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -104,7 +104,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::DEBUG, sprintf('Assigned bucket 1000 to user "%s" with bucketing ID "%s".', $this->testUserId, $this->testBucketingIdControl));
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $this->config->getExperimentFromKey('test_experiment'),
             $this->testBucketingIdControl,
@@ -118,7 +118,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::DEBUG, sprintf('Assigned bucket 3000 to user "%s" with bucketing ID "%s".', $this->testUserId, $this->testBucketingIdControl));
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $this->config->getExperimentFromKey('test_experiment'),
             $this->testBucketingIdControl,
@@ -135,7 +135,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::DEBUG, sprintf('Assigned bucket 7000 to user "%s" with bucketing ID "%s".', $this->testUserId, $this->testBucketingIdControl));
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $this->config->getExperimentFromKey('test_experiment'),
             $this->testBucketingIdControl,
@@ -152,7 +152,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::DEBUG, sprintf('Assigned bucket 9000 to user "%s" with bucketing ID "%s".', $this->testUserId, $this->testBucketingIdControl));
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $this->config->getExperimentFromKey('test_experiment'),
             $this->testBucketingIdControl,
@@ -182,7 +182,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::DEBUG, sprintf('Assigned bucket 4000 to user "%s" with bucketing ID "%s".', $this->testUserId, $this->testBucketingIdControl));
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $this->config->getExperimentFromKey('group_experiment_1'),
             $this->testBucketingIdControl,
@@ -217,7 +217,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->with(Logger::DEBUG, sprintf('Assigned bucket 7000 to user "%s" with bucketing ID "%s".', $this->testUserId, $this->testBucketingIdControl));
 
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $this->config->getExperimentFromKey('group_experiment_1'),
             $this->testBucketingIdControl,
@@ -248,7 +248,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::INFO, 'User "testUserId" is not in experiment group_experiment_1 of group 7722400015.');
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $this->config->getExperimentFromKey('group_experiment_1'),
             $this->testBucketingIdControl,
@@ -266,7 +266,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::INFO, 'User "testUserId" is in no experiment.');
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $this->config->getExperimentFromKey('group_experiment_1'),
             $this->testBucketingIdControl,
@@ -284,7 +284,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::INFO, 'User "testUserId" is in no experiment.');
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $this->config->getExperimentFromKey('group_experiment_1'),
             $this->testBucketingIdControl,
@@ -317,7 +317,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
         // make sure that the bucketing ID is used for the variation
         // bucketing and not the user ID
         
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $experiment,
             $this->testBucketingIdControl,
@@ -403,7 +403,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
               ]
         );
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $rollout_rule,
             'bucketingId',
@@ -415,7 +415,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
             $actualVariation
         );
 
-        [$actualVariation, $reasons] = $bucketer->bucket(
+        list($actualVariation, $reasons) = $bucketer->bucket(
             $this->config,
             $rollout_rule,
             'bucketingId',

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -104,7 +104,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $pausedExperiment, $this->testUserId);
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $pausedExperiment, $this->testUserId);
 
         $this->assertNull($variation);
     }
@@ -122,7 +122,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $this->testUserId, $this->testUserAttributes);
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $this->testUserId, $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -214,7 +214,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1');
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1');
 
         $this->assertEquals(
             $expectedVariation,
@@ -251,7 +251,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1');
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1');
 
         $this->assertEquals(
             $expectedVariation,
@@ -277,7 +277,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1', $this->testUserAttributes);
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1', $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -308,7 +308,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1', $this->testUserAttributes);
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1', $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -329,7 +329,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, 'not_whitelisted_user', $this->testUserAttributes);
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, 'not_whitelisted_user', $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -348,7 +348,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $this->testUserId); // no matching attributes
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $this->testUserId); // no matching attributes
 
         $this->assertNull($variation);
     }
@@ -386,7 +386,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $userId);
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $userId);
         $this->assertEquals($expectedVariation, $variation);
     }
 
@@ -430,7 +430,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -483,7 +483,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -536,7 +536,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -580,7 +580,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        $variation = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
+        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -606,23 +606,23 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $optlyObject->activate($experimentKey, $userId, $userAttributes);
 
         // confirm normal bucketing occurs before setting the forced variation
-        $forcedVariationKey = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
+        $forcedVariationKey  = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
         $this->assertEquals($bucketedVariationKey, $forcedVariationKey);
 
-        // test valid experiment
-        $this->assertTrue($optlyObject->setForcedVariation($experimentKey, $userId, $forcedVariationKey), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
-        $forcedVariationKey = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
-        $this->assertEquals($forcedVariationKey, $forcedVariationKey);
+        // // test valid experiment
+        // $this->assertTrue($optlyObject->setForcedVariation($experimentKey, $userId, $forcedVariationKey), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
+        // $forcedVariationKey = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
+        // $this->assertEquals($forcedVariationKey, $forcedVariationKey);
 
-        // clear forced variation and confirm that normal bucketing occurs
-        $this->assertTrue($optlyObject->setForcedVariation($experimentKey, $userId, null), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
-        $forcedVariationKey = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
-        $this->assertEquals($bucketedVariationKey, $forcedVariationKey);
+        // // clear forced variation and confirm that normal bucketing occurs
+        // $this->assertTrue($optlyObject->setForcedVariation($experimentKey, $userId, null), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
+        // $forcedVariationKey = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
+        // $this->assertEquals($bucketedVariationKey, $forcedVariationKey);
 
-        // check that a paused experiment returns null
-        $this->assertTrue($optlyObject->setForcedVariation($pausedExperimentKey, $userId, 'variation'), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
-        $forcedVariationKey = $optlyObject->getVariation($pausedExperimentKey, $userId, $userAttributes);
-        $this->assertNull($forcedVariationKey);
+        // // check that a paused experiment returns null
+        // $this->assertTrue($optlyObject->setForcedVariation($pausedExperimentKey, $userId, 'variation'), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
+        // $forcedVariationKey = $optlyObject->getVariation($pausedExperimentKey, $userId, $userAttributes);
+        // $this->assertNull($forcedVariationKey);
     }
 
     public function testGetVariationWithBucketingId()
@@ -734,12 +734,11 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
     public function testGetVariationForFeatureExperimentGivenNonMutexGroupAndUserNotBucketed()
     {
         $multivariate_experiment = $this->config->getExperimentFromKey('test_experiment_multivariate');
-        $map = [ [$multivariate_experiment, 'user1', [], null] ];
 
         // make sure the user is not bucketed into the feature experiment
         $this->decisionServiceMock->expects($this->at(0))
             ->method('getVariation')
-            ->will($this->returnValueMap($map));
+            ->will($this->returnValue([ null, []]));
 
         $this->loggerMock->expects($this->at(0))
             ->method('log')
@@ -761,7 +760,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $variation = $this->config->getVariationFromId('test_experiment_multivariate', '122231');
         $this->decisionServiceMock->expects($this->at(0))
             ->method('getVariation')
-            ->will($this->returnValue($variation));
+            ->will($this->returnValue([$variation, []]));
 
         $featureFlag = $this->config->getFeatureFlagFromKey('multi_variate_feature');
         $expected_decision = new FeatureDecision($experiment, $variation, FeatureDecision::DECISION_SOURCE_FEATURE_TEST);
@@ -784,7 +783,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $variation = $mutex_exp->getVariations()[0];
         $this->decisionServiceMock->expects($this->at(0))
             ->method('getVariation')
-            ->will($this->returnValue($variation));
+            ->will($this->returnValue([$variation, []]));
 
         $mutex_exp = $this->config->getExperimentFromKey('group_experiment_1');
         $variation = $mutex_exp->getVariations()[0];
@@ -809,7 +808,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $variation = $mutex_exp->getVariations()[0];
         $this->decisionServiceMock->expects($this->at(0))
             ->method('getVariation')
-            ->will($this->returnValue(null));
+            ->will($this->returnValue([null, []]));
 
 
         $mutex_exp = $this->config->getExperimentFromKey('group_experiment_1');
@@ -1273,36 +1272,36 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         // invalid experiment key should return a null variation
         $this->assertFalse($this->decisionService->setForcedVariation($this->config, $invalidExperimentKey, $userId, $variationKey));
-        $this->assertNull($this->decisionService->getForcedVariation($this->config, $invalidExperimentKey, $userId));
+        $this->assertNull($this->decisionService->getForcedVariation($this->config, $invalidExperimentKey, $userId)[0]);
 
         // setting a null variation should return a null variation
         $this->assertTrue($this->decisionService->setForcedVariation($this->config, $experimentKey, $userId, null));
-        $this->assertNull($this->decisionService->getForcedVariation($this->config, $experimentKey, $userId));
+        $this->assertNull($this->decisionService->getForcedVariation($this->config, $experimentKey, $userId)[0]);
 
         // setting an invalid variation should return a null variation
         $this->assertFalse($this->decisionService->setForcedVariation($this->config, $experimentKey, $userId, $invalidVariationKey));
-        $this->assertNull($this->decisionService->getForcedVariation($this->config, $experimentKey, $userId));
+        $this->assertNull($this->decisionService->getForcedVariation($this->config, $experimentKey, $userId)[0]);
 
         // confirm the forced variation is returned after a set
         $this->assertTrue($this->decisionService->setForcedVariation($this->config, $experimentKey, $userId, $variationKey));
-        $forcedVariation = $this->decisionService->getForcedVariation($this->config, $experimentKey, $userId);
+        $forcedVariation = $this->decisionService->getForcedVariation($this->config, $experimentKey, $userId)[0];
         $this->assertEquals($variationKey, $forcedVariation->getKey());
 
         // check multiple sets
         $this->assertTrue($this->decisionService->setForcedVariation($this->config, $experimentKey2, $userId, $variationKey2));
-        $forcedVariation2 = $this->decisionService->getForcedVariation($this->config, $experimentKey2, $userId);
+        $forcedVariation2 = $this->decisionService->getForcedVariation($this->config, $experimentKey2, $userId)[0];
         $this->assertEquals($variationKey2, $forcedVariation2->getKey());
         // make sure the second set does not overwrite the first set
-        $forcedVariation = $this->decisionService->getForcedVariation($this->config, $experimentKey, $userId);
+        $forcedVariation = $this->decisionService->getForcedVariation($this->config, $experimentKey, $userId)[0];
         $this->assertEquals($variationKey, $forcedVariation->getKey());
         // make sure unsetting the second experiment-to-variation mapping does not unset the
         // first experiment-to-variation mapping
         $this->assertTrue($this->decisionService->setForcedVariation($this->config, $experimentKey2, $userId, null));
-        $forcedVariation = $this->decisionService->getForcedVariation($this->config, $experimentKey, $userId);
+        $forcedVariation = $this->decisionService->getForcedVariation($this->config, $experimentKey, $userId)[0];
         $this->assertEquals($variationKey, $forcedVariation->getKey());
 
         // an invalid user ID should return a null variation
-        $this->assertNull($this->decisionService->getForcedVariation($this->config, $experimentKey, $invalidUserId));
+        $this->assertNull($this->decisionService->getForcedVariation($this->config, $experimentKey, $invalidUserId)[0]);
     }
 
     // test that all the logs in setForcedVariation are getting called

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -611,23 +611,23 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $optlyObject->activate($experimentKey, $userId, $userAttributes);
 
         // confirm normal bucketing occurs before setting the forced variation
-        $forcedVariationKey  = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
+        $forcedVariationKey = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
         $this->assertEquals($bucketedVariationKey, $forcedVariationKey);
 
-        // // test valid experiment
-        // $this->assertTrue($optlyObject->setForcedVariation($experimentKey, $userId, $forcedVariationKey), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
-        // $forcedVariationKey = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
-        // $this->assertEquals($forcedVariationKey, $forcedVariationKey);
+        // test valid experiment
+        $this->assertTrue($optlyObject->setForcedVariation($experimentKey, $userId, $forcedVariationKey), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
+        $forcedVariationKey = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
+        $this->assertEquals($forcedVariationKey, $forcedVariationKey);
 
-        // // clear forced variation and confirm that normal bucketing occurs
-        // $this->assertTrue($optlyObject->setForcedVariation($experimentKey, $userId, null), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
-        // $forcedVariationKey = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
-        // $this->assertEquals($bucketedVariationKey, $forcedVariationKey);
+        // clear forced variation and confirm that normal bucketing occurs
+        $this->assertTrue($optlyObject->setForcedVariation($experimentKey, $userId, null), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
+        $forcedVariationKey = $optlyObject->getVariation($experimentKey, $userId, $userAttributes);
+        $this->assertEquals($bucketedVariationKey, $forcedVariationKey);
 
-        // // check that a paused experiment returns null
-        // $this->assertTrue($optlyObject->setForcedVariation($pausedExperimentKey, $userId, 'variation'), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
-        // $forcedVariationKey = $optlyObject->getVariation($pausedExperimentKey, $userId, $userAttributes);
-        // $this->assertNull($forcedVariationKey);
+        // check that a paused experiment returns null
+        $this->assertTrue($optlyObject->setForcedVariation($pausedExperimentKey, $userId, 'variation'), sprintf('Set variation to "%s" failed.', $forcedVariationKey));
+        $forcedVariationKey = $optlyObject->getVariation($pausedExperimentKey, $userId, $userAttributes);
+        $this->assertNull($forcedVariationKey);
     }
 
     public function testGetVariationWithBucketingId()

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -114,7 +114,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $expectedVariation = new Variation('7722370027', 'control');
         $this->bucketerMock->expects($this->once())
             ->method('bucket')
-            ->willReturn($expectedVariation);
+            ->willReturn([$expectedVariation, []]);
 
         $runningExperiment = $this->config->getExperimentFromKey('test_experiment');
 
@@ -264,7 +264,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $expectedVariation = new Variation('7722370027', 'control');
         $this->bucketerMock->expects($this->once())
             ->method('bucket')
-            ->willReturn($expectedVariation);
+            ->willReturn([$expectedVariation, []]);
 
         $runningExperiment = $this->config->getExperimentFromKey('test_experiment');
 
@@ -290,7 +290,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $expectedVariation = new Variation('7722370027', 'control');
         $this->bucketerMock->expects($this->once())
             ->method('bucket')
-            ->willReturn($expectedVariation);
+            ->willReturn([$expectedVariation, []]);
 
         $runningExperiment = $this->config->getExperimentFromKey('test_experiment');
 
@@ -321,7 +321,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $expectedVariation = new Variation('7722370027', 'control');
         $this->bucketerMock->expects($this->once())
             ->method('bucket')
-            ->willReturn($expectedVariation);
+            ->willReturn([$expectedVariation, []]);
 
         $runningExperiment = $this->config->getExperimentFromKey('test_experiment');
 
@@ -398,7 +398,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->bucketerMock->expects($this->once())
             ->method('bucket')
-            ->willReturn($expectedVariation);
+            ->willReturn([$expectedVariation, []]);
 
         $this->loggerMock->expects($this->any())
             ->method('log')
@@ -447,7 +447,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->bucketerMock->expects($this->once())
             ->method('bucket')
-            ->willReturn($expectedVariation);
+            ->willReturn([$expectedVariation, []]);
 
         $this->loggerMock->expects($this->any())
             ->method('log')
@@ -500,7 +500,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->bucketerMock->expects($this->once())
             ->method('bucket')
-            ->willReturn($expectedVariation);
+            ->willReturn([$expectedVariation, []]);
 
         $this->loggerMock->expects($this->any())
             ->method('log')
@@ -553,7 +553,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->bucketerMock->expects($this->once())
             ->method('bucket')
-            ->willReturn($expectedVariation);
+            ->willReturn([$expectedVariation, []]);
 
         $this->loggerMock->expects($this->any())
             ->method('log')
@@ -1029,7 +1029,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->bucketerMock
             ->method('bucket')
-            ->willReturn($expected_variation);
+            ->willReturn([$expected_variation, []]);
 
         $this->assertEquals(
             $expected_decision,
@@ -1063,11 +1063,11 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         // Make bucket return null when called for first targeting rule
         $this->bucketerMock->expects($this->at(0))
             ->method('bucket')
-            ->willReturn(null);
+            ->willReturn([null, []]);
         // Make bucket return expected variation when called second time for everyone else
         $this->bucketerMock->expects($this->at(1))
             ->method('bucket')
-            ->willReturn($expected_variation);
+            ->willReturn([$expected_variation, []]);
 
         $this->assertEquals(
             $expected_decision,
@@ -1095,11 +1095,11 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         // Make bucket return null when called for first targeting rule
         $this->bucketerMock->expects($this->at(0))
             ->method('bucket')
-            ->willReturn(null);
+            ->willReturn([null, []]);
         // Make bucket return null when called second time for everyone else
         $this->bucketerMock->expects($this->at(1))
             ->method('bucket')
-            ->willReturn(null);
+            ->willReturn([null, []]);
 
         $actualFeatureDecision = $this->decisionService->getVariationForFeatureRollout(
             $this->config,
@@ -1143,7 +1143,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         // Expect bucket to be called exactly once for the everyone else/last rule.
         $this->bucketerMock->expects($this->exactly(1))
             ->method('bucket')
-            ->willReturn($expected_variation);
+            ->willReturn([$expected_variation, []]);
 
         $this->loggerMock->expects($this->any())
                         ->method('log')
@@ -1225,7 +1225,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         // Expect bucket to be called exactly once for the everyone else/last rule.
         $this->bucketerMock->expects($this->exactly(1))
             ->method('bucket')
-            ->willReturn($expected_variation);
+            ->willReturn([$expected_variation, []]);
 
         $this->loggerMock->expects($this->any())
                         ->method('log')

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -104,7 +104,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $pausedExperiment, $this->testUserId);
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $pausedExperiment, $this->testUserId);
 
         $this->assertNull($variation);
     }
@@ -122,7 +122,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $this->testUserId, $this->testUserAttributes);
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, $this->testUserId, $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -214,7 +214,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1');
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1');
 
         $this->assertEquals(
             $expectedVariation,
@@ -251,7 +251,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1');
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1');
 
         $this->assertEquals(
             $expectedVariation,
@@ -277,7 +277,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1', $this->testUserAttributes);
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1', $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -308,7 +308,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1', $this->testUserAttributes);
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, 'user1', $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -329,7 +329,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, 'not_whitelisted_user', $this->testUserAttributes);
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, 'not_whitelisted_user', $this->testUserAttributes);
 
         $this->assertEquals(
             $expectedVariation,
@@ -348,7 +348,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $this->testUserId); // no matching attributes
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, $this->testUserId); // no matching attributes
 
         $this->assertNull($variation);
     }
@@ -386,7 +386,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $userId);
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, $userId);
         $this->assertEquals($expectedVariation, $variation);
     }
 
@@ -430,7 +430,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -483,7 +483,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -536,7 +536,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs
@@ -580,7 +580,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $bucketer->setAccessible(true);
         $bucketer->setValue($this->decisionService, $this->bucketerMock);
 
-        [ $variation, $reasons ] = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
+        list($variation, $reasons) = $this->decisionService->getVariation($this->config, $runningExperiment, $userId, $this->testUserAttributes);
         $this->assertEquals($expectedVariation, $variation);
 
         // Verify Logs

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -1051,7 +1051,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             ->method('bucket')
             ->willReturn([$expected_variation, []]);
 
-        $this->assertEquals(
+        $this->compareFeatureDecisionsExceptReasons(
             $expected_decision,
             $this->decisionService->getVariationForFeatureRollout($this->config, $featureFlag, 'user_1', $user_attributes)
         );

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -143,8 +143,13 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $this->loggerMock->expects($this->at(0))
             ->method('log')
             ->with(Logger::WARNING, 'Bucketing ID attribute is not a string. Defaulted to user ID.');
+        
+        $expectedReasons = ['Bucketing ID attribute is not a string. Defaulted to user ID.'];
 
-        $this->assertSame($this->testUserId, $decisionService->getBucketingId($this->testUserId, $userAttributesWithBucketingId));
+        $this->assertEquals(
+            [$this->testUserId, $expectedReasons],
+            $decisionService->getBucketingId($this->testUserId, $userAttributesWithBucketingId)
+        );
     }
 
     public function testGetBucketingIdWhenBucketingIdIsNull()
@@ -160,7 +165,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $this->loggerMock->expects($this->never())
             ->method('log');
 
-        $this->assertSame($this->testUserId, $decisionService->getBucketingId($this->testUserId, $userAttributesWithBucketingId));
+        $this->assertEquals([$this->testUserId, []], $decisionService->getBucketingId($this->testUserId, $userAttributesWithBucketingId));
     }
 
     public function testGetBucketingIdWhenBucketingIdIsString()
@@ -176,7 +181,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $this->loggerMock->expects($this->never())
             ->method('log');
 
-        $this->assertSame('i_am_bucketing_id', $decisionService->getBucketingId($this->testUserId, $userAttributesWithBucketingId));
+        $this->assertEquals(['i_am_bucketing_id', []], $decisionService->getBucketingId($this->testUserId, $userAttributesWithBucketingId));
     }
 
     public function testGetBucketingIdWhenBucketingIdIsEmptyString()
@@ -192,7 +197,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $this->loggerMock->expects($this->never())
             ->method('log');
 
-        $this->assertSame('', $decisionService->getBucketingId($this->testUserId, $userAttributesWithBucketingId));
+        $this->assertEquals(['', []], $decisionService->getBucketingId($this->testUserId, $userAttributesWithBucketingId));
     }
 
     public function testGetVariationReturnsWhitelistedVariation()

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2020, Optimizely
+ * Copyright 2017-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1641,137 +1641,138 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($optimizelyDecisions), 6);
     }
 
-    // public function testDecideOptionIncludeReasons()
-    // {
-    //     $optimizely = new Optimizely($this->datafile);
-    //     $userContext = $optimizely->createUserContext('test_user', ['device_type' => 'iPhone']);
+    public function testDecideOptionIncludeReasons()
+    {
+        $optimizely = new Optimizely($this->datafile);
+        $userContext = $optimizely->createUserContext('test_user', ['device_type' => 'iPhone']);
         
-    //     $optimizelyMock = $this->getMockBuilder(Optimizely::class)
-    //         ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
-    //         ->setMethods(array('sendImpressionEvent'))
-    //         ->getMock();
+        $optimizelyMock = $this->getMockBuilder(Optimizely::class)
+            ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
+            ->setMethods(array('sendImpressionEvent'))
+            ->getMock();
 
-    //     $expectedReasons = [
-    //         'User "test_user" is in variation control of experiment test_experiment_double_feature.',
-    //         "The user 'test_user' is bucketed into experiment 'test_experiment_double_feature' of feature 'double_single_variable_feature'."
-    //     ];
+        $expectedReasons = [
+            'Assigned bucket 4513 to user "test_user" with bucketing ID "test_user".',
+            'User "test_user" is in variation control of experiment test_experiment_double_feature.',
+            "The user 'test_user' is bucketed into experiment 'test_experiment_double_feature' of feature 'double_single_variable_feature'."
+        ];
 
-    //     // Verify that sendNotifications is called with expected params
-    //     $arrayParam = array(
-    //         DecisionNotificationTypes::FLAG,
-    //         'test_user',
-    //         ['device_type' => 'iPhone'],
-    //         (object) array(
-    //             'flagKey'=>'double_single_variable_feature',
-    //             'enabled'=> true,
-    //             'variables'=> ["double_variable" => 42.42],
-    //             'variation' => 'control',
-    //             'ruleKey' => 'test_experiment_double_feature',
-    //             'reasons' => $expectedReasons,
-    //             'decisionEventDispatched' => true
-    //         )
-    //     );
+        // Verify that sendNotifications is called with expected params
+        $arrayParam = array(
+            DecisionNotificationTypes::FLAG,
+            'test_user',
+            ['device_type' => 'iPhone'],
+            (object) array(
+                'flagKey'=>'double_single_variable_feature',
+                'enabled'=> true,
+                'variables'=> ["double_variable" => 42.42],
+                'variation' => 'control',
+                'ruleKey' => 'test_experiment_double_feature',
+                'reasons' => $expectedReasons,
+                'decisionEventDispatched' => true
+            )
+        );
 
-    //     $this->notificationCenterMock->expects($this->once())
-    //         ->method('sendNotifications')
-    //         ->with(
-    //             NotificationType::DECISION,
-    //             $arrayParam
-    //         );
+        $this->notificationCenterMock->expects($this->once())
+            ->method('sendNotifications')
+            ->with(
+                NotificationType::DECISION,
+                $arrayParam
+            );
 
-    //     //assert that sendImpressionEvent is called with expected params
-    //     $optimizelyMock->expects($this->exactly(1))
-    //         ->method('sendImpressionEvent')
-    //         ->with(
-    //             $this->projectConfig,
-    //             'test_experiment_double_feature',
-    //             'control',
-    //             'double_single_variable_feature',
-    //             'test_experiment_double_feature',
-    //             FeatureDecision::DECISION_SOURCE_FEATURE_TEST,
-    //             true,
-    //             'test_user',
-    //             ['device_type' => 'iPhone']
-    //         );
+        //assert that sendImpressionEvent is called with expected params
+        $optimizelyMock->expects($this->exactly(1))
+            ->method('sendImpressionEvent')
+            ->with(
+                $this->projectConfig,
+                'test_experiment_double_feature',
+                'control',
+                'double_single_variable_feature',
+                'test_experiment_double_feature',
+                FeatureDecision::DECISION_SOURCE_FEATURE_TEST,
+                true,
+                'test_user',
+                ['device_type' => 'iPhone']
+            );
 
-    //     $optimizelyMock->notificationCenter = $this->notificationCenterMock;
+        $optimizelyMock->notificationCenter = $this->notificationCenterMock;
         
-    //     $optimizelyDecision = $optimizelyMock->decide($userContext, 'double_single_variable_feature', ['INCLUDE_REASONS']);
-    //     $expectedOptimizelyDecision = new OptimizelyDecision(
-    //         'control',
-    //         true,
-    //         ['double_variable' => 42.42],
-    //         'test_experiment_double_feature',
-    //         'double_single_variable_feature',
-    //         $userContext,
-    //         []
-    //     );
+        $optimizelyDecision = $optimizelyMock->decide($userContext, 'double_single_variable_feature', ['INCLUDE_REASONS']);
+        $expectedOptimizelyDecision = new OptimizelyDecision(
+            'control',
+            true,
+            ['double_variable' => 42.42],
+            'test_experiment_double_feature',
+            'double_single_variable_feature',
+            $userContext,
+            []
+        );
 
-    //     $this->compareOptimizelyDecisions($expectedOptimizelyDecision, $optimizelyDecision);
-    //     $this->assertEquals($expectedReasons, $optimizelyDecision->getReasons());
-    // }
+        $this->compareOptimizelyDecisions($expectedOptimizelyDecision, $optimizelyDecision);
+        $this->assertEquals($expectedReasons, $optimizelyDecision->getReasons());
+    }
 
-    // public function testDecideOptionIncludeReasonsWhenPassedInDefaultOptions()
-    // {
-    //     $optimizely = new Optimizely($this->datafile);
-    //     $userContext = $optimizely->createUserContext('test_user', ['device_type' => 'iPhone']);
+    public function testDecideOptionIncludeReasonsWhenPassedInDefaultOptions()
+    {
+        $optimizely = new Optimizely($this->datafile);
+        $userContext = $optimizely->createUserContext('test_user', ['device_type' => 'iPhone']);
         
-    //     $optimizelyMock = $this->getMockBuilder(Optimizely::class)
-    //         ->setConstructorArgs(array(
-    //             $this->datafile, null, $this->loggerMock, null, null, null, null, null, null, ['INCLUDE_REASONS']
-    //             ))
-    //         ->setMethods(array('sendImpressionEvent'))
-    //         ->getMock();
+        $optimizelyMock = $this->getMockBuilder(Optimizely::class)
+            ->setConstructorArgs(array(
+                $this->datafile, null, $this->loggerMock, null, null, null, null, null, null, ['INCLUDE_REASONS']
+                ))
+            ->setMethods(array('sendImpressionEvent'))
+            ->getMock();
 
-    //     $expectedReasons = [
-    //         "The feature flag 'empty_feature' is not used in any experiments.",
-    //         "Feature flag 'empty_feature' is not used in a rollout.",
-    //         "User 'test_user' is not bucketed into rollout for feature flag 'empty_feature'."
-    //     ];
+        $expectedReasons = [
+            "The feature flag 'empty_feature' is not used in any experiments.",
+            "Feature flag 'empty_feature' is not used in a rollout.",
+            "User 'test_user' is not bucketed into rollout for feature flag 'empty_feature'."
+        ];
 
-    //     // Verify that sendNotifications is called with expected params
-    //     $arrayParam = array(
-    //         DecisionNotificationTypes::FLAG,
-    //         'test_user',
-    //         ['device_type' => 'iPhone'],
-    //         (object) array(
-    //             'flagKey'=>'empty_feature',
-    //             'enabled'=> false,
-    //             'variables'=> [],
-    //             'variation' => null,
-    //             'ruleKey' => null,
-    //             'reasons' => $expectedReasons,
-    //             'decisionEventDispatched' => false
-    //         )
-    //     );
+        // Verify that sendNotifications is called with expected params
+        $arrayParam = array(
+            DecisionNotificationTypes::FLAG,
+            'test_user',
+            ['device_type' => 'iPhone'],
+            (object) array(
+                'flagKey'=>'empty_feature',
+                'enabled'=> false,
+                'variables'=> [],
+                'variation' => null,
+                'ruleKey' => null,
+                'reasons' => $expectedReasons,
+                'decisionEventDispatched' => false
+            )
+        );
 
-    //     $this->notificationCenterMock->expects($this->once())
-    //         ->method('sendNotifications')
-    //         ->with(
-    //             NotificationType::DECISION,
-    //             $arrayParam
-    //         );
+        $this->notificationCenterMock->expects($this->once())
+            ->method('sendNotifications')
+            ->with(
+                NotificationType::DECISION,
+                $arrayParam
+            );
 
-    //     //assert that sendImpressionEvent is called with expected params
-    //     $optimizelyMock->expects($this->never())
-    //         ->method('sendImpressionEvent');
+        //assert that sendImpressionEvent is called with expected params
+        $optimizelyMock->expects($this->never())
+            ->method('sendImpressionEvent');
 
-    //     $optimizelyMock->notificationCenter = $this->notificationCenterMock;
+        $optimizelyMock->notificationCenter = $this->notificationCenterMock;
         
-    //     $optimizelyDecision = $optimizelyMock->decide($userContext, 'empty_feature');
-    //     $expectedOptimizelyDecision = new OptimizelyDecision(
-    //         null,
-    //         false,
-    //         [],
-    //         null,
-    //         'empty_feature',
-    //         $userContext,
-    //         []
-    //     );
+        $optimizelyDecision = $optimizelyMock->decide($userContext, 'empty_feature');
+        $expectedOptimizelyDecision = new OptimizelyDecision(
+            null,
+            false,
+            [],
+            null,
+            'empty_feature',
+            $userContext,
+            []
+        );
 
-    //     $this->compareOptimizelyDecisions($expectedOptimizelyDecision, $optimizelyDecision);
-    //     $this->assertEquals($expectedReasons, $optimizelyDecision->getReasons());
-    // }
+        $this->compareOptimizelyDecisions($expectedOptimizelyDecision, $optimizelyDecision);
+        $this->assertEquals($expectedReasons, $optimizelyDecision->getReasons());
+    }
 
     public function testDecideParamOptionsWorkTogetherWithDefaultOptions()
     {

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1641,137 +1641,137 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($optimizelyDecisions), 6);
     }
 
-    public function testDecideOptionIncludeReasons()
-    {
-        $optimizely = new Optimizely($this->datafile);
-        $userContext = $optimizely->createUserContext('test_user', ['device_type' => 'iPhone']);
+    // public function testDecideOptionIncludeReasons()
+    // {
+    //     $optimizely = new Optimizely($this->datafile);
+    //     $userContext = $optimizely->createUserContext('test_user', ['device_type' => 'iPhone']);
         
-        $optimizelyMock = $this->getMockBuilder(Optimizely::class)
-            ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
-            ->setMethods(array('sendImpressionEvent'))
-            ->getMock();
+    //     $optimizelyMock = $this->getMockBuilder(Optimizely::class)
+    //         ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
+    //         ->setMethods(array('sendImpressionEvent'))
+    //         ->getMock();
 
-        $expectedReasons = [
-            'User "test_user" is in variation control of experiment test_experiment_double_feature.',
-            "The user 'test_user' is bucketed into experiment 'test_experiment_double_feature' of feature 'double_single_variable_feature'."
-        ];
+    //     $expectedReasons = [
+    //         'User "test_user" is in variation control of experiment test_experiment_double_feature.',
+    //         "The user 'test_user' is bucketed into experiment 'test_experiment_double_feature' of feature 'double_single_variable_feature'."
+    //     ];
 
-        // Verify that sendNotifications is called with expected params
-        $arrayParam = array(
-            DecisionNotificationTypes::FLAG,
-            'test_user',
-            ['device_type' => 'iPhone'],
-            (object) array(
-                'flagKey'=>'double_single_variable_feature',
-                'enabled'=> true,
-                'variables'=> ["double_variable" => 42.42],
-                'variation' => 'control',
-                'ruleKey' => 'test_experiment_double_feature',
-                'reasons' => $expectedReasons,
-                'decisionEventDispatched' => true
-            )
-        );
+    //     // Verify that sendNotifications is called with expected params
+    //     $arrayParam = array(
+    //         DecisionNotificationTypes::FLAG,
+    //         'test_user',
+    //         ['device_type' => 'iPhone'],
+    //         (object) array(
+    //             'flagKey'=>'double_single_variable_feature',
+    //             'enabled'=> true,
+    //             'variables'=> ["double_variable" => 42.42],
+    //             'variation' => 'control',
+    //             'ruleKey' => 'test_experiment_double_feature',
+    //             'reasons' => $expectedReasons,
+    //             'decisionEventDispatched' => true
+    //         )
+    //     );
 
-        $this->notificationCenterMock->expects($this->once())
-            ->method('sendNotifications')
-            ->with(
-                NotificationType::DECISION,
-                $arrayParam
-            );
+    //     $this->notificationCenterMock->expects($this->once())
+    //         ->method('sendNotifications')
+    //         ->with(
+    //             NotificationType::DECISION,
+    //             $arrayParam
+    //         );
 
-        //assert that sendImpressionEvent is called with expected params
-        $optimizelyMock->expects($this->exactly(1))
-            ->method('sendImpressionEvent')
-            ->with(
-                $this->projectConfig,
-                'test_experiment_double_feature',
-                'control',
-                'double_single_variable_feature',
-                'test_experiment_double_feature',
-                FeatureDecision::DECISION_SOURCE_FEATURE_TEST,
-                true,
-                'test_user',
-                ['device_type' => 'iPhone']
-            );
+    //     //assert that sendImpressionEvent is called with expected params
+    //     $optimizelyMock->expects($this->exactly(1))
+    //         ->method('sendImpressionEvent')
+    //         ->with(
+    //             $this->projectConfig,
+    //             'test_experiment_double_feature',
+    //             'control',
+    //             'double_single_variable_feature',
+    //             'test_experiment_double_feature',
+    //             FeatureDecision::DECISION_SOURCE_FEATURE_TEST,
+    //             true,
+    //             'test_user',
+    //             ['device_type' => 'iPhone']
+    //         );
 
-        $optimizelyMock->notificationCenter = $this->notificationCenterMock;
+    //     $optimizelyMock->notificationCenter = $this->notificationCenterMock;
         
-        $optimizelyDecision = $optimizelyMock->decide($userContext, 'double_single_variable_feature', ['INCLUDE_REASONS']);
-        $expectedOptimizelyDecision = new OptimizelyDecision(
-            'control',
-            true,
-            ['double_variable' => 42.42],
-            'test_experiment_double_feature',
-            'double_single_variable_feature',
-            $userContext,
-            []
-        );
+    //     $optimizelyDecision = $optimizelyMock->decide($userContext, 'double_single_variable_feature', ['INCLUDE_REASONS']);
+    //     $expectedOptimizelyDecision = new OptimizelyDecision(
+    //         'control',
+    //         true,
+    //         ['double_variable' => 42.42],
+    //         'test_experiment_double_feature',
+    //         'double_single_variable_feature',
+    //         $userContext,
+    //         []
+    //     );
 
-        $this->compareOptimizelyDecisions($expectedOptimizelyDecision, $optimizelyDecision);
-        $this->assertEquals($expectedReasons, $optimizelyDecision->getReasons());
-    }
+    //     $this->compareOptimizelyDecisions($expectedOptimizelyDecision, $optimizelyDecision);
+    //     $this->assertEquals($expectedReasons, $optimizelyDecision->getReasons());
+    // }
 
-    public function testDecideOptionIncludeReasonsWhenPassedInDefaultOptions()
-    {
-        $optimizely = new Optimizely($this->datafile);
-        $userContext = $optimizely->createUserContext('test_user', ['device_type' => 'iPhone']);
+    // public function testDecideOptionIncludeReasonsWhenPassedInDefaultOptions()
+    // {
+    //     $optimizely = new Optimizely($this->datafile);
+    //     $userContext = $optimizely->createUserContext('test_user', ['device_type' => 'iPhone']);
         
-        $optimizelyMock = $this->getMockBuilder(Optimizely::class)
-            ->setConstructorArgs(array(
-                $this->datafile, null, $this->loggerMock, null, null, null, null, null, null, ['INCLUDE_REASONS']
-                ))
-            ->setMethods(array('sendImpressionEvent'))
-            ->getMock();
+    //     $optimizelyMock = $this->getMockBuilder(Optimizely::class)
+    //         ->setConstructorArgs(array(
+    //             $this->datafile, null, $this->loggerMock, null, null, null, null, null, null, ['INCLUDE_REASONS']
+    //             ))
+    //         ->setMethods(array('sendImpressionEvent'))
+    //         ->getMock();
 
-        $expectedReasons = [
-            "The feature flag 'empty_feature' is not used in any experiments.",
-            "Feature flag 'empty_feature' is not used in a rollout.",
-            "User 'test_user' is not bucketed into rollout for feature flag 'empty_feature'."
-        ];
+    //     $expectedReasons = [
+    //         "The feature flag 'empty_feature' is not used in any experiments.",
+    //         "Feature flag 'empty_feature' is not used in a rollout.",
+    //         "User 'test_user' is not bucketed into rollout for feature flag 'empty_feature'."
+    //     ];
 
-        // Verify that sendNotifications is called with expected params
-        $arrayParam = array(
-            DecisionNotificationTypes::FLAG,
-            'test_user',
-            ['device_type' => 'iPhone'],
-            (object) array(
-                'flagKey'=>'empty_feature',
-                'enabled'=> false,
-                'variables'=> [],
-                'variation' => null,
-                'ruleKey' => null,
-                'reasons' => $expectedReasons,
-                'decisionEventDispatched' => false
-            )
-        );
+    //     // Verify that sendNotifications is called with expected params
+    //     $arrayParam = array(
+    //         DecisionNotificationTypes::FLAG,
+    //         'test_user',
+    //         ['device_type' => 'iPhone'],
+    //         (object) array(
+    //             'flagKey'=>'empty_feature',
+    //             'enabled'=> false,
+    //             'variables'=> [],
+    //             'variation' => null,
+    //             'ruleKey' => null,
+    //             'reasons' => $expectedReasons,
+    //             'decisionEventDispatched' => false
+    //         )
+    //     );
 
-        $this->notificationCenterMock->expects($this->once())
-            ->method('sendNotifications')
-            ->with(
-                NotificationType::DECISION,
-                $arrayParam
-            );
+    //     $this->notificationCenterMock->expects($this->once())
+    //         ->method('sendNotifications')
+    //         ->with(
+    //             NotificationType::DECISION,
+    //             $arrayParam
+    //         );
 
-        //assert that sendImpressionEvent is called with expected params
-        $optimizelyMock->expects($this->never())
-            ->method('sendImpressionEvent');
+    //     //assert that sendImpressionEvent is called with expected params
+    //     $optimizelyMock->expects($this->never())
+    //         ->method('sendImpressionEvent');
 
-        $optimizelyMock->notificationCenter = $this->notificationCenterMock;
+    //     $optimizelyMock->notificationCenter = $this->notificationCenterMock;
         
-        $optimizelyDecision = $optimizelyMock->decide($userContext, 'empty_feature');
-        $expectedOptimizelyDecision = new OptimizelyDecision(
-            null,
-            false,
-            [],
-            null,
-            'empty_feature',
-            $userContext,
-            []
-        );
+    //     $optimizelyDecision = $optimizelyMock->decide($userContext, 'empty_feature');
+    //     $expectedOptimizelyDecision = new OptimizelyDecision(
+    //         null,
+    //         false,
+    //         [],
+    //         null,
+    //         'empty_feature',
+    //         $userContext,
+    //         []
+    //     );
 
-        $this->compareOptimizelyDecisions($expectedOptimizelyDecision, $optimizelyDecision);
-        $this->assertEquals($expectedReasons, $optimizelyDecision->getReasons());
-    }
+    //     $this->compareOptimizelyDecisions($expectedOptimizelyDecision, $optimizelyDecision);
+    //     $this->assertEquals($expectedReasons, $optimizelyDecision->getReasons());
+    // }
 
     public function testDecideParamOptionsWorkTogetherWithDefaultOptions()
     {

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1712,6 +1712,27 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedReasons, $optimizelyDecision->getReasons());
     }
 
+    public function testDecideLogsWhenAudienceEvalFails()
+    {
+        $optimizely = new Optimizely($this->datafile);
+        $userContext = $optimizely->createUserContext('test_user');
+        
+        $optimizelyMock = $this->getMockBuilder(Optimizely::class)
+            ->setConstructorArgs(array($this->datafile, null, $this->loggerMock))
+            ->setMethods(array('sendImpressionEvent'))
+            ->getMock();
+
+        $expectedReasons = [
+            'User "test_user" does not meet conditions to be in experiment "test_experiment_multivariate".',
+            "The user 'test_user' is not bucketed into any of the experiments using the feature 'multi_variate_feature'.",
+            "Feature flag 'multi_variate_feature' is not used in a rollout.",
+            "User 'test_user' is not bucketed into rollout for feature flag 'multi_variate_feature'."
+        ];
+        
+        $optimizelyDecision = $optimizelyMock->decide($userContext, 'multi_variate_feature', ['INCLUDE_REASONS']);
+        $this->assertEquals($expectedReasons, $optimizelyDecision->getReasons());
+    }
+
     public function testDecideOptionIncludeReasonsWhenPassedInDefaultOptions()
     {
         $optimizely = new Optimizely($this->datafile);

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1652,6 +1652,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $expectedReasons = [
+            'Audiences for experiment "test_experiment_double_feature" collectively evaluated to TRUE.',
             'Assigned bucket 4513 to user "test_user" with bucketing ID "test_user".',
             'User "test_user" is in variation control of experiment test_experiment_double_feature.',
             "The user 'test_user' is bucketed into experiment 'test_experiment_double_feature' of feature 'double_single_variable_feature'."
@@ -1723,6 +1724,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $expectedReasons = [
+            'Audiences for experiment "test_experiment_multivariate" collectively evaluated to FALSE.',
             'User "test_user" does not meet conditions to be in experiment "test_experiment_multivariate".',
             "The user 'test_user' is not bucketed into any of the experiments using the feature 'multi_variate_feature'.",
             "Feature flag 'multi_variate_feature' is not used in a rollout.",

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019-2020, Optimizely
+ * Copyright 2019-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -218,7 +218,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 null,
                 $this->loggerMock
-            )
+            )[0]
         );
 
         $this->assertTrue(
@@ -227,21 +227,21 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 [],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
     public function testDoesUserMeetAudienceConditionsAudienceMatch()
     {
         $config = new DatafileProjectConfig(DATAFILE, new NoOpLogger(), new NoOpErrorHandler());
-        $this->assertTrue(
-            Validator::doesUserMeetAudienceConditions(
-                $config,
-                $config->getExperimentFromKey('test_experiment'),
-                ['device_type' => 'iPhone', 'location' => 'San Francisco'],
-                $this->loggerMock
-            )
+        $result = Validator::doesUserMeetAudienceConditions(
+            $config,
+            $config->getExperimentFromKey('test_experiment'),
+            ['device_type' => 'iPhone', 'location' => 'San Francisco'],
+            $this->loggerMock
         );
+
+        $this->assertTrue($result[0]);
     }
 
     public function testDoesUserMeetAudienceConditionsAudienceNoMatch()
@@ -253,7 +253,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $config->getExperimentFromKey('test_experiment'),
                 ['device_type' => 'Android', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -272,7 +272,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 [],
                 $this->loggerMock
-            )
+            )[0]
         );
 
         // Audience Ids exist but audience conditions is empty.
@@ -284,7 +284,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 [],
                 $this->loggerMock
-            )
+            )[0]
         );
 
         // Audience Ids is empty and audience conditions is null.
@@ -296,7 +296,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 [],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -317,7 +317,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['device_type' => 'Android', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
 
         // Audience Ids exist and audience conditions is null.
@@ -331,7 +331,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['device_type' => 'iPhone', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -351,7 +351,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['device_type' => 'iPhone', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -371,7 +371,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['device_type' => 'iPhone', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -404,7 +404,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['device_type' => 'iPhone', 'location' => 'San Francisco'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 
@@ -461,7 +461,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                 $experiment,
                 ['should_do_it' => true, 'house' => 'foo'],
                 $this->loggerMock
-            )
+            )[0]
         );
     }
 

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
This PR refactors the way we collect logs for decideReasons. Previously, an array was being passed as reference to each method and each method appended it's log in the passed array. Now, each method returns it's logs along with it's response. 

## Test plan
- Modified Unit Tests.
- All existing checks should pass.

## Issues
- "THING-1234" or "Fixes #123"
