### PR TITLE
Allow Guzzle 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Note about this Fork
+
+This is a forked repository, published separately from the mainstream Optimizely SDK on [packagist](https://packagist.org/packages/okdewit/optimizely-php-sdk).
+It is tagged as a new Major Release v4.0.0, and depends on Monolog v2.0.0 to resolve a conflict with Laravel 7 and 8 which can not use Monolog v1.0.0.
+
 # Optimizely PHP SDK
 [![Build Status](https://travis-ci.org/optimizely/php-sdk.svg?branch=master)](https://travis-ci.org/optimizely/php-sdk)
 [![Coverage Status](https://coveralls.io/repos/github/optimizely/php-sdk/badge.svg?branch=master)](https://coveralls.io/github/optimizely/php-sdk?branch=master)

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=5.5",
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
     "lastguest/murmurhash": "1.3.0",
-    "guzzlehttp/guzzle": "~6.2",
+    "guzzlehttp/guzzle": "~6.2|~7.0",
     "monolog/monolog": "~1.21"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "optimizely/optimizely-sdk",
+  "name": "okdewit/optimizely-php-sdk",
   "description": "Optimizely SDK for Full Stack PHP projects.",
   "keywords": ["optimizely", "sdk"],
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
     "lastguest/murmurhash": "1.3.0",
     "guzzlehttp/guzzle": "~6.2|~7.0",
-    "monolog/monolog": "~1.21"
+    "monolog/monolog": "^1.21|^2.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",


### PR DESCRIPTION
## Summary
Guzzle 7 is a required upgrade for frameworks such as Laravel 8, and many other packages now also start to require Guzzle 7.

I've searched the Optimizely SDK code for [backwards incompatible](
https://github.com/guzzle/guzzle/blob/master/UPGRADING.md) changes as documented in the Upgrade Guide, and it seems this package is perfectly compatible with both Guzzle 6 and Guzzle 7 without any code changes.

## Test plan
?