### PR TITLE
feat: Duplicate experiment key issue with multi feature flag

### DIFF
--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -197,7 +197,7 @@ class Bucketer
         list($variationId, $reasons) = $this->findBucket($bucketingId, $userId, $experiment->getId(), $experiment->getTrafficAllocation());
         $decideReasons = array_merge($decideReasons, $reasons);
         if (!empty($variationId)) {
-            $variation = $config->getVariationFromId($experiment->getKey(), $variationId);
+            $variation = $config->getVariationFromIdByExperimentId($experiment->getId(), $variationId);
 
             return [ $variation, $decideReasons ];
         }

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -282,20 +282,22 @@ class DatafileProjectConfig implements ProjectConfigInterface
 
         $this->_variationKeyMap = [];
         $this->_variationIdMap = [];
+        $this->_variationKeyMapByExperimentId = [];
+        $this->_variationIdMapByExperimentId = [];
         $this->_experimentKeyMap = [];
 
         foreach (array_values($this->_experimentIdMap) as $experiment) {
             $this->_variationKeyMap[$experiment->getKey()] = [];
             $this->_variationIdMap[$experiment->getKey()] = [];
-            $this->_variationIdMapByExperimentId[$experiment->getID()] = [];
-            $this->_variationKeyMapByExperimentId[$experiment->getID()] = [];
+            $this->_variationIdMapByExperimentId[$experiment->getId()] = [];
+            $this->_variationKeyMapByExperimentId[$experiment->getId()] = [];
             $this->_experimentKeyMap[$experiment->getKey()] = $experiment;
 
             foreach ($experiment->getVariations() as $variation) {
                 $this->_variationKeyMap[$experiment->getKey()][$variation->getKey()] = $variation;
                 $this->_variationIdMap[$experiment->getKey()][$variation->getId()] = $variation;
-                $this->_variationKeyMapByExperimentId[$experiment->getID()][$variation->getKey()] = $variation;
-                $this->_variationIdMapByExperimentId[$experiment->getID()][$variation->getId()] = $variation;
+                $this->_variationKeyMapByExperimentId[$experiment->getId()][$variation->getKey()] = $variation;
+                $this->_variationIdMapByExperimentId[$experiment->getId()][$variation->getId()] = $variation;
             }
         }
 
@@ -314,17 +316,23 @@ class DatafileProjectConfig implements ProjectConfigInterface
 
         $rolloutVariationIdMap = [];
         $rolloutVariationKeyMap = [];
+        $rolloutVariationIdMapByExperimentId = [];
+        $rolloutVariationKeyMapByExperimentId = [];
         foreach ($this->_rollouts as $rollout) {
             $this->_rolloutIdMap[$rollout->getId()] = $rollout;
 
             foreach ($rollout->getExperiments() as $rule) {
                 $rolloutVariationIdMap[$rule->getKey()] = [];
                 $rolloutVariationKeyMap[$rule->getKey()] = [];
+                $rolloutVariationIdMapByExperimentId[$rule->getId()] = [];
+                $rolloutVariationKeyMapByExperimentId[$rule->getId()] = [];
 
                 $variations = $rule->getVariations();
                 foreach ($variations as $variation) {
                     $rolloutVariationIdMap[$rule->getKey()][$variation->getId()] = $variation;
                     $rolloutVariationKeyMap[$rule->getKey()][$variation->getKey()] = $variation;
+                    $rolloutVariationIdMapByExperimentId[$rule->getId()][$variation->getId()] = $variation;
+                    $rolloutVariationKeyMapByExperimentId[$rule->getId()][$variation->getKey()] = $variation;
                 }
             }
         }
@@ -332,6 +340,8 @@ class DatafileProjectConfig implements ProjectConfigInterface
         // Add variations for rollout experiments to variationIdMap and variationKeyMap
         $this->_variationIdMap = $this->_variationIdMap + $rolloutVariationIdMap;
         $this->_variationKeyMap = $this->_variationKeyMap + $rolloutVariationKeyMap;
+        $this->_variationIdMapByExperimentId = $this->_variationIdMapByExperimentId + $rolloutVariationIdMapByExperimentId;
+        $this->_variationKeyMapByExperimentId = $this->_variationKeyMapByExperimentId + $rolloutVariationKeyMapByExperimentId;
 
         foreach (array_values($this->_featureFlags) as $featureFlag) {
             $this->_featureKeyMap[$featureFlag->getKey()] = $featureFlag;

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -124,6 +124,16 @@ class DatafileProjectConfig implements ProjectConfigInterface
     private $_variationIdMap;
 
     /**
+     * @var array Associative array of experiment id to associative array of variation ID to variations.
+     */
+    private $_variationIdMapByExperimentId;
+
+    /**
+     * @var array Associative array of experiment id to associative array of variation key to variations.
+     */
+    private $_variationKeyMapByExperimentId;
+    
+    /**
      * @var array Associative array of event key to Event(s) in the datafile.
      */
     private $_eventKeyMap;
@@ -247,7 +257,7 @@ class DatafileProjectConfig implements ProjectConfigInterface
         }
 
         $this->_groupIdMap = ConfigParser::generateMap($groups, 'id', Group::class);
-        $this->_experimentKeyMap = ConfigParser::generateMap($experiments, 'key', Experiment::class);
+        $this->_experimentIdMap = ConfigParser::generateMap($experiments, 'id', Experiment::class);
         $this->_eventKeyMap = ConfigParser::generateMap($events, 'key', Event::class);
         $this->_attributeKeyMap = ConfigParser::generateMap($attributes, 'key', Attribute::class);
         $typedAudienceIdMap = ConfigParser::generateMap($typedAudiences, 'id', Audience::class);
@@ -256,32 +266,36 @@ class DatafileProjectConfig implements ProjectConfigInterface
         $this->_featureFlags = ConfigParser::generateMap($featureFlags, null, FeatureFlag::class);
 
         foreach (array_values($this->_groupIdMap) as $group) {
-            $experimentsInGroup = ConfigParser::generateMap($group->getExperiments(), 'key', Experiment::class);
+            $experimentsInGroup = ConfigParser::generateMap($group->getExperiments(), 'id', Experiment::class);
             foreach (array_values($experimentsInGroup) as $experiment) {
                 $experiment->setGroupId($group->getId());
                 $experiment->setGroupPolicy($group->getPolicy());
             }
-            $this->_experimentKeyMap = $this->_experimentKeyMap + $experimentsInGroup;
+            $this->_experimentIdMap = $this->_experimentIdMap + $experimentsInGroup;
         }
 
         foreach ($this->_rollouts as $rollout) {
             foreach ($rollout->getExperiments() as $experiment) {
-                $this->_experimentKeyMap[$experiment->getKey()] = $experiment;
+                $this->_experimentIdMap[$experiment->getId()] = $experiment;
             }
         }
 
         $this->_variationKeyMap = [];
         $this->_variationIdMap = [];
-        $this->_experimentIdMap = [];
+        $this->_experimentKeyMap = [];
 
-        foreach (array_values($this->_experimentKeyMap) as $experiment) {
+        foreach (array_values($this->_experimentIdMap) as $experiment) {
             $this->_variationKeyMap[$experiment->getKey()] = [];
             $this->_variationIdMap[$experiment->getKey()] = [];
-            $this->_experimentIdMap[$experiment->getId()] = $experiment;
+            $this->_variationIdMapByExperimentId[$experiment->getID()] = [];
+            $this->_variationKeyMapByExperimentId[$experiment->getID()] = [];
+            $this->_experimentKeyMap[$experiment->getKey()] = $experiment;
 
             foreach ($experiment->getVariations() as $variation) {
                 $this->_variationKeyMap[$experiment->getKey()][$variation->getKey()] = $variation;
                 $this->_variationIdMap[$experiment->getKey()][$variation->getId()] = $variation;
+                $this->_variationKeyMapByExperimentId[$experiment->getID()][$variation->getKey()] = $variation;
+                $this->_variationIdMapByExperimentId[$experiment->getID()][$variation->getId()] = $variation;
             }
         }
 
@@ -649,6 +663,60 @@ class DatafileProjectConfig implements ProjectConfigInterface
                 'No variation ID "%s" defined in datafile for experiment "%s".',
                 $variationId,
                 $experimentKey
+            )
+        );
+        $this->_errorHandler->handleError(new InvalidVariationException('Provided variation is not in datafile.'));
+        return new Variation();
+    }
+
+    /**
+     * @param $experimentId string ID for experiment.
+     * @param $variationId string ID for variation.
+     *
+     * @return Variation Entity corresponding to the provided experiment ID and variation ID.
+     *         Dummy entity is returned if key or ID is invalid.
+     */
+    public function getVariationFromIdByExperimentId($experimentId, $variationId)
+    {
+        if (isset($this->_variationIdMapByExperimentId[$experimentId])
+            && isset($this->_variationIdMapByExperimentId[$experimentId][$variationId])
+        ) {
+            return $this->_variationIdMapByExperimentId[$experimentId][$variationId];
+        }
+
+        $this->_logger->log(
+            Logger::ERROR,
+            sprintf(
+                'No variation ID "%s" defined in datafile for experiment "%s".',
+                $variationId,
+                $experimentId
+            )
+        );
+        $this->_errorHandler->handleError(new InvalidVariationException('Provided variation is not in datafile.'));
+        return new Variation();
+    }
+
+    /**
+     * @param $experimentId string ID for experiment.
+     * @param $variationKey string Key for variation.
+     *
+     * @return Variation Entity corresponding to the provided experiment ID and variation Key.
+     *         Dummy entity is returned if key or ID is invalid.
+     */
+    public function getVariationFromKeyByExperimentId($experimentId, $variationKey)
+    {
+        if (isset($this->_variationKeyMapByExperimentId[$experimentId])
+            && isset($this->_variationKeyMapByExperimentId[$experimentId][$variationKey])
+        ) {
+            return $this->_variationKeyMapByExperimentId[$experimentId][$variationKey];
+        }
+
+        $this->_logger->log(
+            Logger::ERROR,
+            sprintf(
+                'No variation Key "%s" defined in datafile for experiment "%s".',
+                $variationKey,
+                $experimentId
             )
         );
         $this->_errorHandler->handleError(new InvalidVariationException('Provided variation is not in datafile.'));

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019-2020, Optimizely
+ * Copyright 2019-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Config/ProjectConfigInterface.php
+++ b/src/Optimizely/Config/ProjectConfigInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016, 2018-2020 Optimizely
+ * Copyright 2016, 2018-2021 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Config/ProjectConfigInterface.php
+++ b/src/Optimizely/Config/ProjectConfigInterface.php
@@ -142,6 +142,24 @@ interface ProjectConfigInterface
     public function getVariationFromId($experimentKey, $variationId);
 
     /**
+     * @param $experimentId string ID for experiment.
+     * @param $variationId string ID for variation.
+     *
+     * @return Variation Entity corresponding to the provided experiment ID and variation ID.
+     *         Dummy entity is returned if key or ID is invalid.
+     */
+    public function getVariationFromIdByExperimentId($experimentId, $variationId);
+
+    /**
+     * @param $experimentId string ID for experiment.
+     * @param $variationKey string Key for variation.
+     *
+     * @return Variation Entity corresponding to the provided experiment ID and variation Key.
+     *         Dummy entity is returned if key or ID is invalid.
+     */
+    public function getVariationFromKeyByExperimentId($experimentId, $variationKey);
+
+    /**
      * Gets the feature variable instance given feature flag key and variable key
      *
      * @param string Feature flag key

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -518,7 +518,7 @@ class DecisionService
         $forcedVariations = $experiment->getForcedVariations();
         if (!is_null($forcedVariations) && isset($forcedVariations[$userId])) {
             $variationKey = $forcedVariations[$userId];
-            $variation = $projectConfig->getVariationFromKey($experiment->getKey(), $variationKey);
+            $variation = $projectConfig->getVariationFromKeyByExperimentId($experiment->getId(), $variationKey);
             if ($variationKey && !empty($variation->getKey())) {
                 $message = sprintf('User "%s" is forced in variation "%s" of experiment "%s".', $userId, $variationKey, $experiment->getKey());
 

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -222,7 +222,7 @@ class EventBuilder
      * Create impression event to be sent to the logging endpoint.
      *
      * @param $config ProjectConfigInterface Configuration for the project.
-     * @param $experimentKey Experiment Experiment being activated.
+     * @param $experimentId Experiment Experiment being activated.
      * @param $variationKey string Variation user
      * @param $userId string ID of user.
      * @param $attributes array Attributes of the user.

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -229,12 +229,12 @@ class EventBuilder
      *
      * @return LogEvent Event object to be sent to dispatcher.
      */
-    public function createImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
+    public function createImpressionEvent($config, $experimentId, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
     {
         $eventParams = $this->getCommonParams($config, $userId, $attributes);
 
-        $experiment = $config->getExperimentFromKey($experimentKey);
-        $variation = $config->getVariationFromKey($experimentKey, $variationKey);
+        $experiment = $config->getExperimentFromId($experimentId);
+        $variation = $config->getVariationFromKeyByExperimentId($experimentId, $variationKey);
         $impressionParams = $this->getImpressionParams($experiment, $variation, $flagKey, $ruleKey, $ruleType, $enabled);
 
         $eventParams[VISITORS][0][SNAPSHOTS][] = $impressionParams;

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -201,7 +201,7 @@ class Optimizely
     }
 
     /**
-     * @param  string        Experiment key
+     * @param  string        Experiment ID
      * @param  string        Variation key
      * @param  string        User ID
      * @param  array         Associative array of user attributes
@@ -209,7 +209,7 @@ class Optimizely
      */
     protected function sendImpressionEvent($config, $experimentId, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
     {
-        $experimentKey = $config->getExperimentFromId($experimentId)->getId();
+        $experimentKey = $config->getExperimentFromId($experimentId)->getKey();
         $impressionEvent = $this->_eventBuilder
             ->createImpressionEvent($config, $experimentId, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes);
         $this->_logger->log(Logger::INFO, sprintf('Activating user "%s" in experiment "%s".', $userId, $experimentKey));

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -207,10 +207,11 @@ class Optimizely
      * @param  array         Associative array of user attributes
      * @param  DatafileProjectConfig DatafileProjectConfig instance
      */
-    protected function sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
+    protected function sendImpressionEvent($config, $experimentId, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
     {
+        $experimentKey = $config->getExperimentFromId($experimentId)->getId();
         $impressionEvent = $this->_eventBuilder
-            ->createImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes);
+            ->createImpressionEvent($config, $experimentId, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes);
         $this->_logger->log(Logger::INFO, sprintf('Activating user "%s" in experiment "%s".', $userId, $experimentKey));
         $this->_logger->log(
             Logger::DEBUG,
@@ -244,10 +245,10 @@ class Optimizely
         $this->notificationCenter->sendNotifications(
             NotificationType::ACTIVATE,
             array(
-                $config->getExperimentFromKey($experimentKey),
+                $config->getExperimentFromId($experimentId),
                 $userId,
                 $attributes,
-                $config->getVariationFromKey($experimentKey, $variationKey),
+                $config->getVariationFromKeyByExperimentId($experimentId, $variationKey),
                 $impressionEvent
             )
         );
@@ -340,6 +341,7 @@ class Optimizely
         $variationKey = null;
         $featureEnabled = false;
         $ruleKey = null;
+        $experimentId = null;
         $flagKey = $key;
         $allVariables = [];
         $decisionEventDispatched = false;
@@ -360,9 +362,11 @@ class Optimizely
             $variationKey = $variation->getKey();
             $featureEnabled = $variation->getFeatureEnabled();
             $ruleKey = $decision->getExperiment()->getKey();
+            $experimentId = $decision->getExperiment()->getId();
         } else {
             $variationKey = null;
             $ruleKey = null;
+            $experimentId = null;
         }
 
         // send impression only if decide options do not contain DISABLE_DECISION_EVENT
@@ -374,7 +378,7 @@ class Optimizely
             if ($source == FeatureDecision::DECISION_SOURCE_FEATURE_TEST || $sendFlagDecisions) {
                 $this->sendImpressionEvent(
                     $config,
-                    $ruleKey,
+                    $experimentId,
                     $variationKey === null ? '' : $variationKey,
                     $flagKey,
                     $ruleKey === null ? '' : $ruleKey,
@@ -531,8 +535,9 @@ class Optimizely
             $this->_logger->log(Logger::INFO, sprintf('Not activating user "%s".', $userId));
             return null;
         }
+        $experimentId = $config->getExperimentFromKey($experimentKey)->getId();
 
-        $this->sendImpressionEvent($config, $experimentKey, $variationKey, '', $experimentKey, FeatureDecision::DECISION_SOURCE_EXPERIMENT, true, $userId, $attributes);
+        $this->sendImpressionEvent($config, $experimentId, $variationKey, '', $experimentKey, FeatureDecision::DECISION_SOURCE_EXPERIMENT, true, $userId, $attributes);
 
         return $variationKey;
     }
@@ -818,11 +823,13 @@ class Optimizely
                 $featureEnabled = $variation->getFeatureEnabled();
             }
             $ruleKey = $decision->getExperiment() ? $decision->getExperiment()->getKey() : '';
-            $this->sendImpressionEvent($config, $ruleKey, $variation ? $variation->getKey() : '', $featureFlagKey, $ruleKey, $decision->getSource(), $featureEnabled, $userId, $attributes);
+            $experimentId = $decision->getExperiment() ? $decision->getExperiment()->getId() : '';
+            $this->sendImpressionEvent($config, $experimentId, $variation ? $variation->getKey() : '', $featureFlagKey, $ruleKey, $decision->getSource(), $featureEnabled, $userId, $attributes);
         }
 
         if ($variation) {
             $experimentKey = $decision->getExperiment()->getKey();
+            $experimentId = $decision->getExperiment()->getId();
             $featureEnabled = $variation->getFeatureEnabled();
             if ($decision->getSource() == FeatureDecision::DECISION_SOURCE_FEATURE_TEST) {
                 $sourceInfo = (object) array(
@@ -830,7 +837,7 @@ class Optimizely
                     'variationKey'=> $variation->getKey()
                 );
 
-                $this->sendImpressionEvent($config, $experimentKey, $variation->getKey(), $featureFlagKey, $experimentKey, $decision->getSource(), $featureEnabled, $userId, $attributes);
+                $this->sendImpressionEvent($config, $experimentId, $variation->getKey(), $featureFlagKey, $experimentKey, $decision->getSource(), $featureEnabled, $userId, $attributes);
             } else {
                 $this->_logger->log(Logger::INFO, "The user '{$userId}' is not being experimented on Feature Flag '{$featureFlagKey}'.");
             }

--- a/tests/ConfigTests/DatafileProjectConfigTest.php
+++ b/tests/ConfigTests/DatafileProjectConfigTest.php
@@ -146,6 +146,7 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
             '177776' => $this->config->getExperimentFromId('177776'),
             '177774' => $this->config->getExperimentFromId('177774'),
             '177779' => $this->config->getExperimentFromId('177779'),
+            '7716830083' => $this->config->getExperimentFromId('7716830083'),
             ],
             $experimentIdMap->getValue($this->config)
         );
@@ -533,7 +534,7 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
         $event = $this->config->getEvent('purchase');
         $this->assertEquals('purchase', $event->getKey());
         $this->assertEquals('7718020063', $event->getId());
-        $this->assertEquals(['7716830082', '7723330021', '7718750065', '7716830585'], $event->getExperimentIds());
+        $this->assertEquals(['7716830082', '7716830083', '7723330021', '7718750065', '7716830585'], $event->getExperimentIds());
     }
 
     public function testGetEventInvalidKey()
@@ -653,6 +654,13 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('control', $variation->getKey());
     }
 
+    public function testGetVariationFromKeyValidExperimentIdValidVariationKey()
+    {
+        $variation = $this->config->getVariationFromKeyByExperimentId('7716830083', 'control');
+        $this->assertEquals('7722370028', $variation->getId());
+        $this->assertEquals('control', $variation->getKey());
+    }
+
     public function testGetVariationFromKeyValidExperimentKeyInvalidVariationKey()
     {
         $this->loggerMock->expects($this->once())
@@ -688,6 +696,13 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
         $variation = $this->config->getVariationFromId('test_experiment', '7722370027');
         $this->assertEquals('control', $variation->getKey());
         $this->assertEquals('7722370027', $variation->getId());
+    }
+
+    public function testGetVariationFromIdValidExperimentIdValidVariationId()
+    {
+        $variation = $this->config->getVariationFromIdByExperimentId('7716830083', '7722370028');
+        $this->assertEquals('control', $variation->getKey());
+        $this->assertEquals('7722370028', $variation->getId());
     }
 
     public function testGetVariationFromIdValidExperimentKeyInvalidVariationId()

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -142,7 +142,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $logEvent = $this->eventBuilder->createImpressionEvent(
             $this->config,
-            'test_experiment',
+            '7716830082',
             'variation',
             'test_experiment',
             'test_experiment',
@@ -202,7 +202,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         ];
         $logEvent = $this->eventBuilder->createImpressionEvent(
             $this->config,
-            'test_experiment',
+            '7716830082',
             'variation',
             'test_experiment',
             'test_experiment',
@@ -243,7 +243,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         ];
         $logEvent = $this->eventBuilder->createImpressionEvent(
             $this->config,
-            'test_experiment',
+            '7716830082',
             'variation',
             'test_experiment',
             'test_experiment',
@@ -285,7 +285,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         ];
         $logEvent = $this->eventBuilder->createImpressionEvent(
             $this->config,
-            'test_experiment',
+            '7716830082',
             'variation',
             'test_experiment',
             'test_experiment',
@@ -317,7 +317,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         ];
         $logEvent = $this->eventBuilder->createImpressionEvent(
             $this->config,
-            'test_experiment',
+            '7716830082',
             'variation',
             'test_experiment',
             'test_experiment',
@@ -358,7 +358,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         ];
         $logEvent = $this->eventBuilder->createImpressionEvent(
             $this->config,
-            'test_experiment',
+            '7716830082',
             'variation',
             'test_experiment',
             'test_experiment',
@@ -406,7 +406,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         ];
         $logEvent = $this->eventBuilder->createImpressionEvent(
             $this->config,
-            'test_experiment',
+            '7716830082',
             'variation',
             'test_experiment',
             'test_experiment',
@@ -457,7 +457,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $logEvent = $this->eventBuilder->createImpressionEvent(
             $configMock,
-            'test_experiment',
+            '7716830082',
             'variation',
             'test_experiment',
             'test_experiment',
@@ -504,7 +504,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
 
         $logEvent = $this->eventBuilder->createImpressionEvent(
             $configMock,
-            'test_experiment',
+            '7716830082',
             'variation',
             'test_experiment',
             'test_experiment',
@@ -834,7 +834,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         ];
         $logEvent = $this->eventBuilder->createImpressionEvent(
             $this->config,
-            'test_experiment',
+            '7716830082',
             'variation',
             'test_experiment',
             'test_experiment',

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -449,7 +449,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('sendImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'test_experiment_double_feature',
+                '122238',
                 'control',
                 'double_single_variable_feature',
                 'test_experiment_double_feature',
@@ -609,7 +609,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('sendImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'test_experiment_double_feature',
+                '122238',
                 'control',
                 'double_single_variable_feature',
                 'test_experiment_double_feature',
@@ -700,7 +700,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('sendImpressionEvent')
             ->with(
                 $this->anything(),
-                'test_experiment_double_feature',
+                '122238',
                 'control',
                 'double_single_variable_feature',
                 'test_experiment_double_feature',
@@ -1159,7 +1159,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('sendImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'test_experiment_double_feature',
+                '122238',
                 'variation',
                 'double_single_variable_feature',
                 'test_experiment_double_feature',
@@ -1233,7 +1233,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('sendImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'test_experiment_double_feature',
+                '122238',
                 'control',
                 'double_single_variable_feature',
                 'test_experiment_double_feature',
@@ -1307,7 +1307,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('sendImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'test_experiment_double_feature',
+                '122238',
                 'control',
                 'double_single_variable_feature',
                 'test_experiment_double_feature',
@@ -1383,7 +1383,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('sendImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'test_experiment_double_feature',
+                '122238',
                 'control',
                 'double_single_variable_feature',
                 'test_experiment_double_feature',
@@ -1458,7 +1458,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('sendImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'test_experiment_double_feature',
+                '122238',
                 'control',
                 'double_single_variable_feature',
                 'test_experiment_double_feature',
@@ -1546,7 +1546,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('sendImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'test_experiment_double_feature',
+                '122238',
                 'control',
                 'double_single_variable_feature',
                 'test_experiment_double_feature',
@@ -1686,7 +1686,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('sendImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'test_experiment_double_feature',
+                '122238',
                 'control',
                 'double_single_variable_feature',
                 'test_experiment_double_feature',
@@ -2144,7 +2144,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment', 'variation', '', 'test_experiment', 'experiment', true, '', $userAttributes);
+            ->with($this->projectConfig, '7716830082', 'variation', '', 'test_experiment', 'experiment', true, '', $userAttributes);
 
         // Call activate
         $this->assertEquals('variation', $optimizelyMock->activate('test_experiment', '', $userAttributes));
@@ -2239,7 +2239,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpression is called with expected params
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', '', 'group_experiment_1', 'experiment', true, 'user_1', null);
+            ->with($this->projectConfig, '7723330021', 'group_exp_1_var_2', '', 'group_experiment_1', 'experiment', true, 'user_1', null);
 
         // Call activate
         $this->assertSame('group_exp_1_var_2', $optimizelyMock->activate('group_experiment_1', 'user_1'));
@@ -2272,7 +2272,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpression is called with expected params
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', '', 'group_experiment_1', 'experiment', true, 'user_1', null);
+            ->with($this->projectConfig, '7723330021', 'group_exp_1_var_2', '', 'group_experiment_1', 'experiment', true, 'user_1', null);
 
         // set forced variation
         $this->assertTrue($optimizelyMock->setForcedVariation($experimentKey, $userId, $variationKey), 'Set variation for paused experiment should have failed.');
@@ -2333,7 +2333,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment', 'control', '', 'test_experiment', 'experiment', true, 'test_user', $userAttributes);
+            ->with($this->projectConfig, '7716830082', 'control', '', 'test_experiment', 'experiment', true, 'test_user', $userAttributes);
 
         // Call activate
         $this->assertEquals('control', $optimizelyMock->activate('test_experiment', 'test_user', $userAttributes));
@@ -2366,7 +2366,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment', 'control', '', 'test_experiment', 'experiment', true, 'test_user', $userAttributes);
+            ->with($this->projectConfig, '7716830082', 'control', '', 'test_experiment', 'experiment', true, 'test_user', $userAttributes);
 
         // Call activate
         $this->assertEquals('control', $optimizelyMock->activate('test_experiment', 'test_user', $userAttributes));
@@ -2391,7 +2391,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->at(0))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfigForTypedAudience, 'typed_audience_experiment', 'A', '', 'typed_audience_experiment', 'experiment', true, 'test_user', $userAttributes);
+            ->with($this->projectConfigForTypedAudience, '1323241597', 'A', '', 'typed_audience_experiment', 'experiment', true, 'test_user', $userAttributes);
 
         // Should be included via exact match string audience with id '3468206642'
         $this->assertEquals('A', $optimizelyMock->activate('typed_audience_experiment', 'test_user', $userAttributes));
@@ -2403,7 +2403,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->at(0))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfigForTypedAudience, 'typed_audience_experiment', 'A', '', 'typed_audience_experiment', 'experiment', true, 'test_user', $userAttributes);
+            ->with($this->projectConfigForTypedAudience, '1323241597', 'A', '', 'typed_audience_experiment', 'experiment', true, 'test_user', $userAttributes);
 
         //Should be included via exact match number audience with id '3468206646'
         $this->assertEquals('A', $optimizelyMock->activate('typed_audience_experiment', 'test_user', $userAttributes));
@@ -2443,7 +2443,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called once with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfigForTypedAudience, 'audience_combinations_experiment', 'A', '', 'audience_combinations_experiment', 'experiment', true, 'test_user', $userAttributes);
+            ->with($this->projectConfigForTypedAudience, '1323241598', 'A', '', 'audience_combinations_experiment', 'experiment', true, 'test_user', $userAttributes);
 
         // Should be included via substring match string audience with id '3988293898', and
         // exact match number audience with id '3468206646'
@@ -4306,7 +4306,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // assert that sendImpressionEvent is called with expected params
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment_double_feature', 'control', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, true, 'user_id', []);
+            ->with($this->projectConfig, '122238', 'control', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, true, 'user_id', []);
 
         $this->loggerMock->expects($this->at(0))
             ->method('log')
@@ -4411,7 +4411,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment_double_feature', 'variation', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, false, 'user_id', []);
+            ->with($this->projectConfig, '122238', 'variation', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, false, 'user_id', []);
 
         $this->loggerMock->expects($this->at(0))
             ->method('log')
@@ -4794,7 +4794,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // assert that sendImpressionEvent is called with expected params
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->projectConfig, 'test_experiment_double_feature', 'control', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, true, '', []);
+            ->with($this->projectConfig, '122238', 'control', 'double_single_variable_feature', 'test_experiment_double_feature', FeatureDecision::DECISION_SOURCE_FEATURE_TEST, true, '', []);
 
         $this->loggerMock->expects($this->at(0))
             ->method('log')
@@ -6429,7 +6429,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('createImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'group_experiment_1',
+                '7723330021',
                 'group_exp_1_var_2',
                 'group_experiment_1',
                 'group_experiment_1',
@@ -6487,7 +6487,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'Dispatching impression event to URL logx.optimizely.com/decision with params {"param1":"val1","param2":"val2"}.'
             );
 
-        $optlyObject->sendImpressionEvent($this->projectConfig, 'group_experiment_1', 'group_exp_1_var_2', 'group_experiment_1', 'group_experiment_1', 'experiment', true, 'user_1', null);
+        $optlyObject->sendImpressionEvent($this->projectConfig, '7723330021', 'group_exp_1_var_2', 'group_experiment_1', 'group_experiment_1', 'experiment', true, 'user_1', null);
     }
 
     public function testSendImpressionEventDispatchFailure()
@@ -6510,7 +6510,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('log')
             ->with(Logger::ERROR, 'Unable to dispatch impression event. Error ');
 
-        $optlyObject->sendImpressionEvent($this->projectConfig, 'test_experiment', 'control', 'test_experiment', 'test_experiment', 'experiment', true, 'test_user', []);
+        $optlyObject->sendImpressionEvent($this->projectConfig, '7716830082', 'control', 'test_experiment', 'test_experiment', 'experiment', true, 'test_user', []);
     }
 
     public function testSendImpressionEventWithAttributes()
@@ -6528,7 +6528,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->method('createImpressionEvent')
             ->with(
                 $this->projectConfig,
-                'test_experiment',
+                '7716830082',
                 'control',
                 'test_experiment',
                 'test_experiment',
@@ -6576,7 +6576,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $optlyObject->notificationCenter = $this->notificationCenterMock;
 
-        $optlyObject->sendImpressionEvent($this->projectConfig, 'test_experiment', 'control', 'test_experiment', 'test_experiment', 'experiment', true, 'test_user', $userAttributes);
+        $optlyObject->sendImpressionEvent($this->projectConfig, '7716830082', 'control', 'test_experiment', 'test_experiment', 'experiment', true, 'test_user', $userAttributes);
     }
 
     /*
@@ -6752,7 +6752,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         // Verify that sendImpressionEvent is called with expected attributes
         $optimizelyMock->expects($this->exactly(1))
             ->method('sendImpressionEvent')
-            ->with($this->anything(), 'rollout_1_exp_1', '177771', 'boolean_single_variable_feature', 'rollout_1_exp_1', 'rollout', true, 'user_id', []);
+            ->with($this->anything(), '177770', '177771', 'boolean_single_variable_feature', 'rollout_1_exp_1', 'rollout', true, 'user_id', []);
 
         $this->assertTrue($optimizelyMock->isFeatureEnabled('boolean_single_variable_feature', 'user_id', []));
     }

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -1694,9 +1694,9 @@ class TestBucketer extends Bucketer
  */
 class OptimizelyTester extends Optimizely
 {
-    public function sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
+    public function sendImpressionEvent($config, $experimentId, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
     {
-        parent::sendImpressionEvent($config, $experimentKey, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes);
+        parent::sendImpressionEvent($config, $experimentId, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes);
     }
 
     public function validateInputs(array $values, $logLevel = Logger::ERROR)

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -34,6 +34,42 @@ define(
     {
       "status": "Running",
       "key": "test_experiment",
+      "layerId": "7719770040",
+      "trafficAllocation": [
+        {
+          "entityId": "",
+          "endOfRange": 1500
+        },
+        {
+          "entityId": "7722370028",
+          "endOfRange": 4000
+        },
+        {
+          "entityId": "7721010010",
+          "endOfRange": 8000
+        }
+      ],
+      "audienceIds": [
+        "7718080042"
+      ],
+      "variations": [
+        {
+          "id": "7722370028",
+          "key": "control"
+        },
+        {
+          "id": "7721010010",
+          "key": "variation"
+        }
+      ],
+      "forcedVariations": {
+        "user1": "control"
+      },
+      "id": "7716830083"
+    },
+    {
+      "status": "Running",
+      "key": "test_experiment",
       "layerId": "7719770039",
       "trafficAllocation": [
         {
@@ -575,6 +611,7 @@ define(
     {
       "experimentIds": [
         "7716830082",
+        "7716830083",
         "7723330021",
         "7718750065",
         "7716830585"
@@ -590,6 +627,7 @@ define(
     {
       "experimentIds":[
         "7716830082",
+        "7716830083",
         "122230"
       ],
       "id": "7718020065",


### PR DESCRIPTION
## Summary
- Fixed an issue related to duplicate experimentKey.
- While trying to get variation from the variationKeyMap, it was unable to find because the latest experimentKey was overriding the previous one.

## TestPlan
- Run with FSC 