### PR TITLE
chore: Deprecation warning on getExperimentsMap.

### DIFF
--- a/src/Optimizely/OptimizelyConfig/OptimizelyFeature.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyFeature.php
@@ -99,11 +99,16 @@ class OptimizelyFeature implements \JsonSerializable
     }
 
     /**
+     * @deprecated
+     *
      * @return array Map of Experiment Keys to OptimizelyExperiments.
      */
     public function getExperimentsMap()
     {
         # This experimentsMap is deprecated. Use experimentRules and deliveryRules instead.
+
+        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use experimentRules and deliveryRules instead.', E_USER_NOTICE);
+
         return $this->experimentsMap;
     }
     

--- a/src/Optimizely/OptimizelyConfig/OptimizelyFeature.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyFeature.php
@@ -99,15 +99,13 @@ class OptimizelyFeature implements \JsonSerializable
     }
 
     /**
-     * @deprecated
+     * @deprecated. Use 'experimentRules' and 'deliveryRules' instead.
      *
      * @return array Map of Experiment Keys to OptimizelyExperiments.
      */
     public function getExperimentsMap()
     {
-        # This experimentsMap is deprecated. Use experimentRules and deliveryRules instead.
-
-        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use experimentRules and deliveryRules instead.', E_USER_NOTICE);
+        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use experimentRules and deliveryRules instead.', E_USER_WARNING);
 
         return $this->experimentsMap;
     }

--- a/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
+++ b/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
@@ -119,7 +119,6 @@ class OptimizelyEntitiesTest extends \PHPUnit_Framework_TestCase
     /**
     * @expectedException PHPUnit_Framework_Error
     */
-
     public function testOptimizelyFeatureGetExperimentsMapEmitsWarning()
     {
         $optFeature = new OptimizelyFeature(

--- a/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
+++ b/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
@@ -96,7 +96,7 @@ class OptimizelyEntitiesTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals("id", $optFeature->getId());
         $this->assertEquals("key", $optFeature->getKey());
-
+        # Suppressing warning in getExperimentMap to pass testcase
         $this->assertEquals(["a" => "apple"], @$optFeature->getExperimentsMap());
         $this->assertEquals(["o" => "orange"], $optFeature->getVariablesMap());
         $this->assertEquals([], $optFeature->getExperimentRules());

--- a/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
+++ b/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
@@ -97,8 +97,7 @@ class OptimizelyEntitiesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("id", $optFeature->getId());
         $this->assertEquals("key", $optFeature->getKey());
 
-        # getExperimentsMap is deprecated
-        # $this->assertEquals(["a" => "apple"], $optFeature->getExperimentsMap());
+        $this->assertEquals(["a" => "apple"], @$optFeature->getExperimentsMap());
         $this->assertEquals(["o" => "orange"], $optFeature->getVariablesMap());
         $this->assertEquals([], $optFeature->getExperimentRules());
         $this->assertEquals([], $optFeature->getDeliveryRules());
@@ -115,6 +114,25 @@ class OptimizelyEntitiesTest extends \PHPUnit_Framework_TestCase
         $expectedJson = json_encode(json_decode($expectedJson));
 
         $this->assertEquals($expectedJson, json_encode($optFeature));
+    }
+
+    /**
+    * @expectedException PHPUnit_Framework_Error
+    */
+    function testOptimizelyFeatureGetExperimentsMapEmitsWarning() {
+        $optFeature = new OptimizelyFeature(
+            "id",
+            "key",
+            ["a" => "apple"],
+            ["o" => "orange"],
+            [],
+            []
+        );
+
+        $this->assertEquals("id", $optFeature->getId());
+        $this->assertEquals("key", $optFeature->getKey());
+
+        $this->assertEquals(["a" => "apple"], $optFeature->getExperimentsMap());
     }
 
     public function testOptimizelyVariableEntity()

--- a/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
+++ b/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
@@ -96,7 +96,9 @@ class OptimizelyEntitiesTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals("id", $optFeature->getId());
         $this->assertEquals("key", $optFeature->getKey());
-        $this->assertEquals(["a" => "apple"], $optFeature->getExperimentsMap());
+
+        # getExperimentsMap is deprecated
+        # $this->assertEquals(["a" => "apple"], $optFeature->getExperimentsMap());
         $this->assertEquals(["o" => "orange"], $optFeature->getVariablesMap());
         $this->assertEquals([], $optFeature->getExperimentRules());
         $this->assertEquals([], $optFeature->getDeliveryRules());

--- a/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
+++ b/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
@@ -119,7 +119,9 @@ class OptimizelyEntitiesTest extends \PHPUnit_Framework_TestCase
     /**
     * @expectedException PHPUnit_Framework_Error
     */
-    function testOptimizelyFeatureGetExperimentsMapEmitsWarning() {
+
+    public function testOptimizelyFeatureGetExperimentsMapEmitsWarning()
+    {
         $optFeature = new OptimizelyFeature(
             "id",
             "key",


### PR DESCRIPTION
## Summary
- Added deprecation warning on getExperimentsMap of OptimizelyFeature.

## Test plan
- Added testcase for warning.
- All FSC testcases should pass.