### PR TITLE
feat(ForcedDecisions): add forced-decisions APIs to OptimizelyUserContext

### DIFF
--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -245,7 +245,13 @@ class DatafileProjectConfig implements ProjectConfigInterface
      */
     private $_sendFlagDecisions;
 
+    /**
+     * Map indicating variations of flag decisions
+     *
+     * @return map
+     */
     private $_flagVariationsMap;
+
     /**
      * DatafileProjectConfig constructor to load and set project configuration data.
      *
@@ -381,11 +387,13 @@ class DatafileProjectConfig implements ProjectConfigInterface
         foreach ($this->_featureFlags as $flag) {
             $variations = array();
             $flagRules = $this->getAllRulesForFlag($flag);
+
             foreach ($flagRules as $rule) {
-                $variations = array_filter(array_values($rule->getVariations()), function ($variation) use ($variations) {
+                $variations = array_merge($variations, array_filter(array_values($rule->getVariations()), function ($variation) use ($variations) {
                     return !in_array($variation->getId(), $variations);
-                });
+                }));
             }
+
             $this->_flagVariationsMap[$flag->getKey()] = $variations;
         }
         // Add variations for rollout experiments to variationIdMap and variationKeyMap

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -405,11 +405,11 @@ class DatafileProjectConfig implements ProjectConfigInterface
         }
     }
 
-    function getAllRulesForFlag(_ flag: FeatureFlag) -> [Experiment] {
-    var rules = flag.experimentIds.compactMap { experimentIdMap[$0] }
-let rollout = self.rolloutIdMap[flag.rolloutId]
-        rules.append(contentsOf: rollout?.experiments ?? [])
-        return rules
+    function getAllRulesForFlag(FeatureFlag $flag) {
+        $rules = $flag->getExperimentIds();
+        $rollout = $this->_rolloutIdMap[$flag->getRolloutId()];
+        array_push($rules , rollout);
+        return rules;
     }
     /**
      * Create ProjectConfig based on datafile string.

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -385,16 +385,21 @@ class DatafileProjectConfig implements ProjectConfigInterface
         }
         $this->_flagVariationsMap = array();
         foreach ($this->_featureFlags as $flag) {
-            $variations = array();
+            $flagVariations = array();
             $flagRules = $this->getAllRulesForFlag($flag);
 
             foreach ($flagRules as $rule) {
-                $variations = array_merge($variations, array_filter(array_values($rule->getVariations()), function ($variation) use ($variations) {
-                    return !in_array($variation->getId(), $variations);
+                $flagVariations = array_merge($flagVariations, array_filter(array_values($rule->getVariations()), function ($variation) use ($flagVariations) {
+                    foreach ($flagVariations as $flagVariation) {
+                        if ($flagVariation->getId() == $variation->getId()) {
+                            return false;
+                        }
+                    }
+                    return true;
                 }));
             }
 
-            $this->_flagVariationsMap[$flag->getKey()] = $variations;
+            $this->_flagVariationsMap[$flag->getKey()] = $flagVariations;
         }
         // Add variations for rollout experiments to variationIdMap and variationKeyMap
         $this->_variationIdMap = $this->_variationIdMap + $rolloutVariationIdMap;

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -377,7 +377,19 @@ class DatafileProjectConfig implements ProjectConfigInterface
                 }
             }
         }
-        $_flagVariationsMap
+        $this->_flagVariationsMap = array();
+        foreach ($this->_featureFlags as $flag)
+        {
+            $variations = array();
+
+            foreach ($this->getAllRulesForFlag($flag) as $rule)
+            {
+                $variations = array_filter(array_values($rule->getVariations()), function ($variation) use ($variations) {
+                    return !in_array($variation->getId(), $variations);
+                });
+            }
+            $this->_flagVariationsMap[$flag->getKey()] = $variations;
+        }
         // Add variations for rollout experiments to variationIdMap and variationKeyMap
         $this->_variationIdMap = $this->_variationIdMap + $rolloutVariationIdMap;
         $this->_variationKeyMap = $this->_variationKeyMap + $rolloutVariationKeyMap;
@@ -406,9 +418,13 @@ class DatafileProjectConfig implements ProjectConfigInterface
     }
 
     function getAllRulesForFlag(FeatureFlag $flag) {
-        $rules = $flag->getExperimentIds();
+        $rules = array();
+        foreach (flag.experimentIds as $experimentId)
+        {
+            array_push($rules, $this->_experimentIdMap[$experimentId]);
+        }
         $rollout = $this->_rolloutIdMap[$flag->getRolloutId()];
-        array_push($rules , rollout);
+        array_push($rules, $rollout->getExperiments());
         return rules;
     }
     /**
@@ -873,6 +889,16 @@ class DatafileProjectConfig implements ProjectConfigInterface
     public function isFeatureExperiment($experimentId)
     {
         return array_key_exists($experimentId, $this->_experimentFeatureMap);
+    }
+
+    /**
+     * Returns map array of Flag key as key and Variations as value
+     *
+     * @return array
+     */
+    public function getFlagVariationsMap()
+    {
+        return $this->_flagVariationsMap;
     }
 
     /**

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -245,6 +245,7 @@ class DatafileProjectConfig implements ProjectConfigInterface
      */
     private $_sendFlagDecisions;
 
+    private $_flagVariationsMap;
     /**
      * DatafileProjectConfig constructor to load and set project configuration data.
      *
@@ -376,7 +377,7 @@ class DatafileProjectConfig implements ProjectConfigInterface
                 }
             }
         }
-
+        $_flagVariationsMap
         // Add variations for rollout experiments to variationIdMap and variationKeyMap
         $this->_variationIdMap = $this->_variationIdMap + $rolloutVariationIdMap;
         $this->_variationKeyMap = $this->_variationKeyMap + $rolloutVariationKeyMap;
@@ -404,6 +405,12 @@ class DatafileProjectConfig implements ProjectConfigInterface
         }
     }
 
+    function getAllRulesForFlag(_ flag: FeatureFlag) -> [Experiment] {
+    var rules = flag.experimentIds.compactMap { experimentIdMap[$0] }
+let rollout = self.rolloutIdMap[flag.rolloutId]
+        rules.append(contentsOf: rollout?.experiments ?? [])
+        return rules
+    }
     /**
      * Create ProjectConfig based on datafile string.
      *

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -646,6 +646,26 @@ class DatafileProjectConfig implements ProjectConfigInterface
     }
 
     /**
+     * Gets the variation associated with experiment or rollout in instance of given feature flag key
+     *
+     * @param string Feature flag key
+     * @param string variation key
+     *
+     * @return Variation / null
+     */
+    public function getFlagVariationByKey($flagKey, $variationKey)
+    {
+        if (array_key_exists($flagKey, $this->_flagVariationsMap)) {
+            foreach ($this->_flagVariationsMap[$flagKey] as $variation) {
+                if ($variation->getKey() == $variationKey) {
+                    return $variation;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * @param String $featureKey Key of the feature flag
      *
      * @return FeatureFlag Entity corresponding to the key.

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -378,12 +378,10 @@ class DatafileProjectConfig implements ProjectConfigInterface
             }
         }
         $this->_flagVariationsMap = array();
-        foreach ($this->_featureFlags as $flag)
-        {
+        foreach ($this->_featureFlags as $flag) {
             $variations = array();
-
-            foreach ($this->getAllRulesForFlag($flag) as $rule)
-            {
+            $flagRules = $this->getAllRulesForFlag($flag);
+            foreach ($flagRules as $ruleList) {
                 $variations = array_filter(array_values($rule->getVariations()), function ($variation) use ($variations) {
                     return !in_array($variation->getId(), $variations);
                 });
@@ -417,15 +415,17 @@ class DatafileProjectConfig implements ProjectConfigInterface
         }
     }
 
-    function getAllRulesForFlag(FeatureFlag $flag) {
+    private function getAllRulesForFlag(FeatureFlag $flag)
+    {
         $rules = array();
-        foreach (flag.experimentIds as $experimentId)
-        {
+        foreach ($flag->getExperimentIds() as $experimentId) {
             array_push($rules, $this->_experimentIdMap[$experimentId]);
         }
-        $rollout = $this->_rolloutIdMap[$flag->getRolloutId()];
-        array_push($rules, $rollout->getExperiments());
-        return rules;
+        if ($this->_rolloutIdMap && key_exists($flag->getRolloutId(), $this->_rolloutIdMap)) {
+            $rollout = $this->_rolloutIdMap[$flag->getRolloutId()];
+            $rules = array_merge($rules, $rollout->getExperiments());
+        }
+        return $rules;
     }
     /**
      * Create ProjectConfig based on datafile string.

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -381,7 +381,7 @@ class DatafileProjectConfig implements ProjectConfigInterface
         foreach ($this->_featureFlags as $flag) {
             $variations = array();
             $flagRules = $this->getAllRulesForFlag($flag);
-            foreach ($flagRules as $ruleList) {
+            foreach ($flagRules as $rule) {
                 $variations = array_filter(array_values($rule->getVariations()), function ($variation) use ($variations) {
                     return !in_array($variation->getId(), $variations);
                 });

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -389,14 +389,20 @@ class DatafileProjectConfig implements ProjectConfigInterface
             $flagRules = $this->getAllRulesForFlag($flag);
 
             foreach ($flagRules as $rule) {
-                $flagVariations = array_merge($flagVariations, array_filter(array_values($rule->getVariations()), function ($variation) use ($flagVariations) {
+                $filtered_variations = [];
+                foreach (array_values($rule->getVariations()) as $variation) {
+                    $exist = false;
                     foreach ($flagVariations as $flagVariation) {
                         if ($flagVariation->getId() == $variation->getId()) {
-                            return false;
+                            $exist = true;
+                            break;
                         }
                     }
-                    return true;
-                }));
+                    if (!$exist) {
+                        array_push($filtered_variations, $variation);
+                    }
+                }
+                $flagVariations = array_merge($flagVariations, $filtered_variations);
             }
 
             $this->_flagVariationsMap[$flag->getKey()] = $flagVariations;

--- a/src/Optimizely/Config/ProjectConfigInterface.php
+++ b/src/Optimizely/Config/ProjectConfigInterface.php
@@ -199,7 +199,23 @@ interface ProjectConfigInterface
      * @return FeatureVariable / null
      */
     public function getFeatureVariableFromKey($featureFlagKey, $variableKey);
-    
+
+    /**
+     * Gets the variation associated with experiment or rollout in instance of given feature flag key
+     *
+     * @param string Feature flag key
+     * @param string variation key
+     *
+     * @return Variation / null
+     */
+    public function getFlagVariationByKey($flagKey, $variationKey);
+
+    /**
+     * Returns map array of Flag key as key and Variations as value
+     *
+     * @return array
+     */
+    public function getFlagVariationsMap();
     /**
      * Determines if given experiment is a feature test.
      *

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -19,6 +19,7 @@ namespace Optimizely\DecisionService;
 use Exception;
 use Monolog\Logger;
 use Optimizely\Bucketer;
+use Optimizely\OptimizelyDecisionContext;
 use Optimizely\Config\ProjectConfigInterface;
 use Optimizely\Decide\OptimizelyDecideOption;
 use Optimizely\Entity\Experiment;
@@ -375,7 +376,8 @@ class DecisionService
     {
         $decideReasons = [];
         // check forced-decision first
-        list($decisionResponse, $reasons) = $user->findValidatedForcedDecision($flagKey, $rule->getKey());
+        $context = new OptimizelyDecisionContext($flagKey, $rule->getKey());
+        list($decisionResponse, $reasons) = $user->findValidatedForcedDecision($context);
         $decideReasons = array_merge($decideReasons, $reasons);
         if ($decisionResponse) {
             return [$decisionResponse, $decideReasons];
@@ -407,7 +409,8 @@ class DecisionService
         $skipToEveryoneElse = false;
         // check forced-decision first
         $rule = $rules[$ruleIndex];
-        list($forcedDecisionResponse, $reasons) = $user->findValidatedForcedDecision($flagKey, $rule->getKey());
+        $context = new OptimizelyDecisionContext($flagKey, $rule->getKey());
+        list($forcedDecisionResponse, $reasons) = $user->findValidatedForcedDecision($context);
 
         $decideReasons = array_merge($decideReasons, $reasons);
         if ($forcedDecisionResponse) {

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -215,10 +215,9 @@ class DecisionService
      * Get the variation the user is bucketed into for the given FeatureFlag
      *
      * @param  ProjectConfigInterface $projectConfig  ProjectConfigInterface instance.
-     * @param  FeatureFlag   $featureFlag    The feature flag the user wants to access
-     * @param  string        $userId         user ID
-     * @param  array         $userAttributes user attributes
-     * @param  array         $decideOptions   Options to customize evaluation.
+     * @param  FeatureFlag            $featureFlag    The feature flag the user wants to access
+     * @param  OptimizelyUserContext  $user           Optimizely User context containing user id and attribute
+     * @param  array                  $decideOptions  Options to customize evaluation.
      *
      * @return FeatureDecision  representing decision.
      */
@@ -269,8 +268,7 @@ class DecisionService
      *
      * @param  ProjectConfigInterface $projectConfig  ProjectConfigInterface instance.
      * @param  FeatureFlag   $featureFlag    The feature flag the user wants to access
-     * @param  string        $userId         user id
-     * @param  array         $userAttributes user userAttributes
+     * @param  OptimizelyUserContext  $user     Optimizely User context containing user id and attribute
      * @param  array         $decideOptions   Options to customize evaluation.
      *
      * @return FeatureDecision  representing decision.
@@ -331,8 +329,8 @@ class DecisionService
      *
      * @param  ProjectConfigInterface $projectConfig  ProjectConfigInterface instance.
      * @param  FeatureFlag   $featureFlag    The feature flag the user wants to access
-     * @param  string        $userId         user id
-     * @param  array         $userAttributes user userAttributes
+     * @param  OptimizelyUserContext  $user  Optimizely User context containing user id and attribute
+     * @param  array         $decideOptions   Options to customize evaluation.
      * @return FeatureDecision  representing decision.
      */
     public function getVariationForFeatureRollout(ProjectConfigInterface $projectConfig, FeatureFlag $featureFlag, OptimizelyUserContext $user, $decideOptions = [])
@@ -394,11 +392,14 @@ class DecisionService
      * Gets the forced variation key for the given user and experiment.
      *
      * @param $projectConfig ProjectConfigInterface  ProjectConfigInterface instance.
-     * @param $experimentKey string         Key for experiment.
-     * @param $userId        string         The user Id.
+     * @param $flagKey  string             Key of feature flag.
+     * @param $rules    array              Array of delivery rules.
+     * @param $ruleIndex  integer          Index of delivery rule of which validation of forced decision is needed.
+     * @param $user OptimizelyUserContext  Optimizely User context containing user id and attribute
+     * @param $options array               Options to customize evaluation.
      *
-     * @return [ Variation, array ] The variation which the given user and experiment should be forced into and
-     *                              array of log messages representing decision making.
+     * @return [ FeatureDecision, Boolean ] The variation which the given user and experiment should be forced into and
+     *                              skipToEveryone boolean to  decision making.
      */
     public function getVariationFromDeliveryRule(ProjectConfigInterface $projectConfig, $flagKey, array $rules, $ruleIndex, OptimizelyUserContext $user, array $options = [])
     {

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -407,7 +407,7 @@ class DecisionService
         $skipToEveryoneElse = false;
         // check forced-decision first
         $rule = $rules[$ruleIndex];
-        list($forcedDecisionResponse, $reasons) = $user->findValidatedForcedDecision($flagKey, $rule->getKey(), $options);
+        list($forcedDecisionResponse, $reasons) = $user->findValidatedForcedDecision($flagKey, $rule->getKey());
 
         $decideReasons = array_merge($decideReasons, $reasons);
         if ($forcedDecisionResponse) {

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -362,7 +362,7 @@ class DecisionService
             list($decisionResponses, $skipToEveryoneElse) = $this->getVariationFromDeliveryRule($projectConfig, $featureFlagKey, $rolloutRules, $index, $user, $decideOptions);
             $decideReasons = array_merge($decideReasons, $decisionResponses->getReasons());
             $variation = $decisionResponses->getVariation();
-            if ($variation != null) {
+            if ($variation) {
                 return new FeatureDecision($rolloutRules[$index], $variation, FeatureDecision::DECISION_SOURCE_ROLLOUT, $decideReasons);
             }
             // the last rule is special for "Everyone Else"
@@ -377,7 +377,7 @@ class DecisionService
         // check forced-decision first
         list($decisionResponse, $reasons) = $user->findValidatedForcedDecision($flagKey, $rule->getKey());
         $decideReasons = array_merge($decideReasons, $reasons);
-        if ($decisionResponse != null) {
+        if ($decisionResponse) {
             return [$decisionResponse, $decideReasons];
         }
 
@@ -410,7 +410,7 @@ class DecisionService
         list($forcedDecisionResponse, $reasons) = $user->findValidatedForcedDecision($flagKey, $rule->getKey(), $options);
 
         $decideReasons = array_merge($decideReasons, $reasons);
-        if ($forcedDecisionResponse != null) {
+        if ($forcedDecisionResponse) {
             return [new FeatureDecision($rule, $forcedDecisionResponse, null, $decideReasons), $skipToEveryoneElse];
         }
 
@@ -436,7 +436,7 @@ class DecisionService
             $decideReasons[] = $message;
             list($bucketedVariation, $reasons) = $this->_bucketer->bucket($projectConfig, $rule, $bucketingId, $userId);
             $decideReasons = array_merge($decideReasons, $reasons);
-            if ($bucketedVariation != null) {
+            if ($bucketedVariation) {
                 $message = sprintf('User "%s" is in the traffic group of targeting rule "%s".', $userId, $loggingKey);
                 $this->_logger->log(Logger::INFO, $message);
                 $decideReasons[] = $message;

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -440,7 +440,7 @@ class DecisionService
                 $message = sprintf('User "%s" is in the traffic group of targeting rule "%s".', $userId, $loggingKey);
                 $this->_logger->log(Logger::INFO, $message);
                 $decideReasons[] = $message;
-            } else if (!$everyoneElse) {
+            } elseif (!$everyoneElse) {
                 // skip this logging for EveryoneElse since this has a message not for EveryoneElse
                 $message = sprintf('User "%s" is not in the traffic group for targeting rule "%s". Checking Everyone Else rule now.', $userId, $loggingKey);
                 $this->_logger->log(Logger::INFO, $message);

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -361,11 +361,11 @@ class DecisionService
             return new FeatureDecision(null, null, null, $decideReasons);
         }
         $index = 0;
-        while($index < sizeof($rolloutRules)) {
+        while ($index < sizeof($rolloutRules)) {
             list($decisionResponse, $reasons) = $this->getVariationFromDeliveryRule($projectConfig, $featureFlagKey, $rolloutRules, $index, $user, $decideOptions);
             $decideReasons = array_merge($decideReasons, $reasons);
             list($variation, $skipToEveryoneElse) = $decisionResponse == null? [null, true] : [$decisionResponse, false];
-            if($variation != null) {
+            if ($variation != null) {
                 return new FeatureDecision($rolloutRules[$index], $variation, FeatureDecision::DECISION_SOURCE_ROLLOUT, $decideReasons);
             }
             // the last rule is special for "Everyone Else"
@@ -378,9 +378,9 @@ class DecisionService
     {
         $decideReasons = [];
         // check forced-decision first
-        list($decisionResponse, $reasons) = $user->findValidatedForcedDecision($flagKey, $rule->getKey(), $this->_logger);
+        list($decisionResponse, $reasons) = $user->findValidatedForcedDecision($flagKey, $rule->getKey());
         $decideReasons = array_merge($decideReasons, $reasons);
-        if($decisionResponse != null) {
+        if ($decisionResponse != null) {
             return new FeatureDecision(null, $decisionResponse, FeatureDecision::DECISION_SOURCE_EXPERIMENT, $decideReasons);
         }
 
@@ -413,10 +413,10 @@ class DecisionService
         $skipToEveryoneElse = false;
         // check forced-decision first
         $rule = $rules[$ruleIndex];
-        list($forcedDecisionResponse, $reasons) = $user->findValidatedForcedDecision($flagKey, $rule->getKey(), $options, $this->_logger);
+        list($forcedDecisionResponse, $reasons) = $user->findValidatedForcedDecision($flagKey, $rule->getKey(), $options);
 
         $decideReasons = array_merge($decideReasons, $reasons);
-        if($forcedDecisionResponse != null) {
+        if ($forcedDecisionResponse != null) {
             return new FeatureDecision($rule, $forcedDecisionResponse, null, $decideReasons);
         }
 
@@ -427,10 +427,11 @@ class DecisionService
 
         $everyoneElse = $ruleIndex == sizeof($rules) - 1;
         $loggingKey = $everyoneElse ? "Everyone Else" : $ruleIndex + 1;
+        $bucketedVariation = null;
 
         list($evalResult, $reasons) = Validator::doesUserMeetAudienceConditions($projectConfig, $rule, $attributes, $this->_logger);
         $decideReasons = array_merge($decideReasons, $reasons);
-        if(!$evalResult) {
+        if (!$evalResult) {
             $message = sprintf('User "%s" meets condition for targeting rule "%s".', $userId, $rule->getKey());
             $this->_logger->log(
                 Logger::INFO,

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -27,6 +27,7 @@ use Optimizely\Event\LogEvent;
 use Optimizely\Utils\EventTagUtils;
 use Optimizely\Utils\GeneratorUtils;
 use Optimizely\Utils\Validator;
+use phpDocumentor\Reflection\Types\This;
 
 class EventBuilder
 {
@@ -139,18 +140,28 @@ class EventBuilder
      * Helper function to get parameters specific to impression event.
      *
      * @param $experiment Experiment Experiment being activated.
-     * @param $variationId String ID representing the variation for the user.
+     * @param $variation Variation representing the variation for the user is allocated.
+     * @param $flagKey string feature flag key.
+     * @param $ruleKey string feature or rollout experiment key.
+     * @param $ruleType string feature or rollout experiment source type.
+     * @param $enabled Boolean feature enabled.
      *
      * @return array Hash representing parameters particular to impression event.
      */
     private function getImpressionParams(Experiment $experiment, $variation, $flagKey, $ruleKey, $ruleType, $enabled)
     {
         $variationKey = $variation->getKey() ? $variation->getKey() : '';
+        $experimentID = '';
+        $campaignID = '';
+        if ($experiment->getId()) {
+            $experimentID = $experiment->getId();
+            $campaignID = $experiment->getLayerId();
+        }
         $impressionParams = [
             DECISIONS => [
                 [
-                    CAMPAIGN_ID => $experiment->getLayerId(),
-                    EXPERIMENT_ID => $experiment->getId(),
+                    CAMPAIGN_ID => $campaignID,
+                    EXPERIMENT_ID => $experimentID,
                     VARIATION_ID => $variation->getId(),
                     METADATA => [
                         FLAG_KEY => $flagKey,
@@ -232,9 +243,14 @@ class EventBuilder
     public function createImpressionEvent($config, $experimentId, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
     {
         $eventParams = $this->getCommonParams($config, $userId, $attributes);
-
         $experiment = $config->getExperimentFromId($experimentId);
-        $variation = $config->getVariationFromKeyByExperimentId($experimentId, $variationKey);
+
+        if (empty($experimentId)) {
+            $variation = $config->getFlagVariationByKey($flagKey, $variationKey);
+        } else {
+            $variation = $config->getVariationFromKeyByExperimentId($experimentId, $variationKey);
+        }
+
         $impressionParams = $this->getImpressionParams($experiment, $variation, $flagKey, $ruleKey, $ruleType, $enabled);
 
         $eventParams[VISITORS][0][SNAPSHOTS][] = $impressionParams;

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -150,19 +150,26 @@ class EventBuilder
      */
     private function getImpressionParams(Experiment $experiment, $variation, $flagKey, $ruleKey, $ruleType, $enabled)
     {
-        $variationKey = $variation->getKey() ? $variation->getKey() : '';
+        $variationKey = '';
+        $variationId = null;
+        if ($variation) {
+            $variationKey = $variation->getKey() ? $variation->getKey() : '';
+            $variationId = $variation->getId();
+        }
         $experimentID = '';
         $campaignID = '';
-        if ($experiment->getId()) {
-            $experimentID = $experiment->getId();
-            $campaignID = $experiment->getLayerId();
+        if ($experiment) {
+            if ($experiment->getId()) {
+                $experimentID = $experiment->getId();
+                $campaignID = $experiment->getLayerId();
+            }
         }
         $impressionParams = [
             DECISIONS => [
                 [
                     CAMPAIGN_ID => $campaignID,
                     EXPERIMENT_ID => $experimentID,
-                    VARIATION_ID => $variation->getId(),
+                    VARIATION_ID => $variationId,
                     METADATA => [
                         FLAG_KEY => $flagKey,
                         RULE_KEY => $ruleKey,

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -353,8 +353,7 @@ class Optimizely
         // get decision
         $decision = null;
         // check forced-decisions first
-        list($forcedDecisionResponse, $reasons) = $userContext->findValidatedForcedDecision($flagKey, $ruleKey, $decideOptions);
-        $decideReasons = array_merge($decideReasons, $reasons);
+        list($forcedDecisionResponse, $reasons) = $userContext->findValidatedForcedDecision($flagKey, $ruleKey);
         if ($forcedDecisionResponse) {
             $decision = new FeatureDecision(null, $forcedDecisionResponse, FeatureDecision::DECISION_SOURCE_FEATURE_TEST, $decideReasons);
         } else {
@@ -366,8 +365,8 @@ class Optimizely
                 $decideOptions
             );
         }
-
-        $decideReasons = $decision->getReasons();
+        $decideReasons = array_merge($decideReasons, $reasons);
+        $decideReasons = array_merge($decideReasons, $decision->getReasons());
         $variation = $decision->getVariation();
 
         if ($variation) {

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -795,6 +795,7 @@ class Optimizely
      * @param array Associative array of user attributes
      *
      * @return boolean
+     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function isFeatureEnabled($featureFlagKey, $userId, $attributes = null)
     {
@@ -886,6 +887,7 @@ class Optimizely
      * @param  string User ID
      * @param  array Associative array of user attributes
      * @return array List of feature flag keys
+     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getEnabledFeatures($userId, $attributes = null)
     {
@@ -1008,6 +1010,7 @@ class Optimizely
      * @param array  Associative array of user attributes
      *
      * @return string boolean variable value / null
+     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getFeatureVariableBoolean($featureFlagKey, $variableKey, $userId, $attributes = null)
     {
@@ -1029,6 +1032,7 @@ class Optimizely
      * @param array  Associative array of user attributes
      *
      * @return string integer variable value / null
+     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getFeatureVariableInteger($featureFlagKey, $variableKey, $userId, $attributes = null)
     {
@@ -1050,6 +1054,7 @@ class Optimizely
      * @param array  Associative array of user attributes
      *
      * @return string double variable value / null
+     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getFeatureVariableDouble($featureFlagKey, $variableKey, $userId, $attributes = null)
     {
@@ -1071,6 +1076,7 @@ class Optimizely
      * @param array  Associative array of user attributes
      *
      * @return string variable value / null
+     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getFeatureVariableString($featureFlagKey, $variableKey, $userId, $attributes = null)
     {
@@ -1092,6 +1098,7 @@ class Optimizely
     * @param array  Associative array of user attributes
     *
     * @return array Associative array of json variable including key and value
+    * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
     */
     public function getFeatureVariableJSON($featureFlagKey, $variableKey, $userId, $attributes = null)
     {
@@ -1112,6 +1119,7 @@ class Optimizely
      * @param array  Associative array of user attributes
      *
      * @return array|null array of all the variables, or null if the feature key is invalid
+     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getAllFeatureVariables($featureFlagKey, $userId, $attributes = null)
     {

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -355,7 +355,7 @@ class Optimizely
         // check forced-decisions first
         list($forcedDecisionResponse, $reasons) = $userContext->findValidatedForcedDecision($flagKey, $ruleKey, $decideOptions);
         $decideReasons = array_merge($decideReasons, $reasons);
-        if ($forcedDecisionResponse != null) {
+        if ($forcedDecisionResponse) {
             $decision = new FeatureDecision(null, $forcedDecisionResponse, FeatureDecision::DECISION_SOURCE_FEATURE_TEST, $decideReasons);
         } else {
             // regular decision

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -799,7 +799,6 @@ class Optimizely
      * @param array Associative array of user attributes
      *
      * @return boolean
-     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function isFeatureEnabled($featureFlagKey, $userId, $attributes = null)
     {
@@ -891,7 +890,6 @@ class Optimizely
      * @param  string User ID
      * @param  array Associative array of user attributes
      * @return array List of feature flag keys
-     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getEnabledFeatures($userId, $attributes = null)
     {
@@ -1014,7 +1012,6 @@ class Optimizely
      * @param array  Associative array of user attributes
      *
      * @return string boolean variable value / null
-     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getFeatureVariableBoolean($featureFlagKey, $variableKey, $userId, $attributes = null)
     {
@@ -1036,7 +1033,6 @@ class Optimizely
      * @param array  Associative array of user attributes
      *
      * @return string integer variable value / null
-     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getFeatureVariableInteger($featureFlagKey, $variableKey, $userId, $attributes = null)
     {
@@ -1058,7 +1054,6 @@ class Optimizely
      * @param array  Associative array of user attributes
      *
      * @return string double variable value / null
-     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getFeatureVariableDouble($featureFlagKey, $variableKey, $userId, $attributes = null)
     {
@@ -1080,7 +1075,6 @@ class Optimizely
      * @param array  Associative array of user attributes
      *
      * @return string variable value / null
-     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getFeatureVariableString($featureFlagKey, $variableKey, $userId, $attributes = null)
     {
@@ -1102,7 +1096,6 @@ class Optimizely
     * @param array  Associative array of user attributes
     *
     * @return array Associative array of json variable including key and value
-    * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
     */
     public function getFeatureVariableJSON($featureFlagKey, $variableKey, $userId, $attributes = null)
     {
@@ -1123,7 +1116,6 @@ class Optimizely
      * @param array  Associative array of user attributes
      *
      * @return array|null array of all the variables, or null if the feature key is invalid
-     * @deprecated Use 'decide' methods of 'OptimizelyUserContext' instead.
      */
     public function getAllFeatureVariables($featureFlagKey, $userId, $attributes = null)
     {

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -28,6 +28,7 @@ use Optimizely\Decide\OptimizelyDecision;
 use Optimizely\Decide\OptimizelyDecisionMessage;
 use Optimizely\DecisionService\DecisionService;
 use Optimizely\DecisionService\FeatureDecision;
+use Optimizely\OptimizelyDecisionContext;
 use Optimizely\Entity\Experiment;
 use Optimizely\Entity\FeatureVariable;
 use Optimizely\Enums\DecisionNotificationTypes;
@@ -353,7 +354,8 @@ class Optimizely
         // get decision
         $decision = null;
         // check forced-decisions first
-        list($forcedDecisionResponse, $reasons) = $userContext->findValidatedForcedDecision($flagKey, $ruleKey);
+        $context = new OptimizelyDecisionContext($flagKey, $ruleKey);
+        list($forcedDecisionResponse, $reasons) = $userContext->findValidatedForcedDecision($context);
         if ($forcedDecisionResponse) {
             $decision = new FeatureDecision(null, $forcedDecisionResponse, FeatureDecision::DECISION_SOURCE_FEATURE_TEST, $decideReasons);
         } else {

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -358,7 +358,7 @@ class Optimizely
             $decision = $this->_decisionService->getVariationForFeature(
                 $config,
                 $featureFlag,
-                $this->createUserContext($userId, $userAttributes),
+                $userContext,
                 $decideOptions
             );
         }
@@ -695,7 +695,8 @@ class Optimizely
             return null;
         }
 
-        list($variation, $reasons) = $this->_decisionService->getVariation($config, $experiment, $this->createUserContext($userId, $attributes = []));
+        $userContext = $this->createUserContext($userId, $attributes ? $attributes : []);
+        list($variation, $reasons) = $this->_decisionService->getVariation($config, $experiment, $userContext);
         $variationKey = ($variation === null) ? null : $variation->getKey();
 
         if ($config->isFeatureExperiment($experiment->getId())) {
@@ -823,8 +824,8 @@ class Optimizely
         }
 
         $featureEnabled = false;
-        $attributes = $attributes? $attributes : [];
-        $decision = $this->_decisionService->getVariationForFeature($config, $featureFlag, $this->createUserContext($userId, $attributes));
+        $userContext = $this->createUserContext($userId, $attributes?: []);
+        $decision = $this->_decisionService->getVariationForFeature($config, $featureFlag, $userContext);
         $variation = $decision->getVariation();
 
         if ($config->getSendFlagDecisions() && ($decision->getSource() == FeatureDecision::DECISION_SOURCE_ROLLOUT || !$variation)) {
@@ -957,8 +958,8 @@ class Optimizely
             // Error logged in DatafileProjectConfig - getFeatureFlagFromKey
             return null;
         }
-        $attributes = $attributes? $attributes : [];
-        $decision = $this->_decisionService->getVariationForFeature($config, $featureFlag, $this->createUserContext($userId, $attributes));
+        $userContext = $this->createUserContext($userId, $attributes? $attributes : []);
+        $decision = $this->_decisionService->getVariationForFeature($config, $featureFlag, $userContext);
         $variation = $decision->getVariation();
         $experiment = $decision->getExperiment();
         $featureEnabled = $variation !== null ? $variation->getFeatureEnabled() : false;

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -351,15 +351,14 @@ class Optimizely
         // check forced-decisions first
         list($forcedDecisionResponse, $reasons) = $userContext->findValidatedForcedDecision($flagKey, $ruleKey, $decideOptions);
         $decideReasons = array_merge($decideReasons, $reasons);
-        if($forcedDecisionResponse != null) {
+        if ($forcedDecisionResponse != null) {
             $decision = new FeatureDecision(null, $forcedDecisionResponse, FeatureDecision::DECISION_SOURCE_FEATURE_TEST, $decideReasons);
         } else {
             // regular decision
             $decision = $this->_decisionService->getVariationForFeature(
                 $config,
                 $featureFlag,
-                $userId,
-                $userAttributes,
+                $this->createUserContext($userId, $userAttributes),
                 $decideOptions
             );
         }
@@ -696,7 +695,7 @@ class Optimizely
             return null;
         }
 
-        list($variation, $reasons) = $this->_decisionService->getVariation($config, $experiment, $userId, $attributes);
+        list($variation, $reasons) = $this->_decisionService->getVariation($config, $experiment, $this->createUserContext($userId, $attributes = []));
         $variationKey = ($variation === null) ? null : $variation->getKey();
 
         if ($config->isFeatureExperiment($experiment->getId())) {
@@ -824,7 +823,8 @@ class Optimizely
         }
 
         $featureEnabled = false;
-        $decision = $this->_decisionService->getVariationForFeature($config, $featureFlag, $userId, $attributes);
+        $attributes = $attributes? $attributes : [];
+        $decision = $this->_decisionService->getVariationForFeature($config, $featureFlag, $this->createUserContext($userId, $attributes));
         $variation = $decision->getVariation();
 
         if ($config->getSendFlagDecisions() && ($decision->getSource() == FeatureDecision::DECISION_SOURCE_ROLLOUT || !$variation)) {
@@ -957,8 +957,8 @@ class Optimizely
             // Error logged in DatafileProjectConfig - getFeatureFlagFromKey
             return null;
         }
-
-        $decision = $this->_decisionService->getVariationForFeature($config, $featureFlag, $userId, $attributes);
+        $attributes = $attributes? $attributes : [];
+        $decision = $this->_decisionService->getVariationForFeature($config, $featureFlag, $this->createUserContext($userId, $attributes));
         $variation = $decision->getVariation();
         $experiment = $decision->getExperiment();
         $featureEnabled = $variation !== null ? $variation->getFeatureEnabled() : false;
@@ -1133,7 +1133,7 @@ class Optimizely
             return null;
         }
 
-        $decision = $this->_decisionService->getVariationForFeature($config, $featureFlag, $userId, $attributes);
+        $decision = $this->_decisionService->getVariationForFeature($config, $featureFlag, $this->createUserContext($userId, $attributes));
         $variation = $decision->getVariation();
         $experiment = $decision->getExperiment();
         $featureEnabled = $variation !== null ? $variation->getFeatureEnabled() : false;

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -201,11 +201,15 @@ class Optimizely
     }
 
     /**
+     * @param  DatafileProjectConfig DatafileProjectConfig instance
      * @param  string        Experiment ID
      * @param  string        Variation key
+     * @param  string        Flag key
+     * @param  string        Rule key
+     * @param  string        Rule type
+     * @param  boolean       Feature enabled
      * @param  string        User ID
      * @param  array         Associative array of user attributes
-     * @param  DatafileProjectConfig DatafileProjectConfig instance
      */
     protected function sendImpressionEvent($config, $experimentId, $variationKey, $flagKey, $ruleKey, $ruleType, $enabled, $userId, $attributes)
     {
@@ -1302,15 +1306,16 @@ class Optimizely
         return $isValid;
     }
 
+    /**
+     * Gets the variation associated with experiment or rollout in instance of given feature flag key
+     *
+     * @param string Feature flag key
+     * @param string variation key
+     *
+     * @return Variation / null
+     */
     public function getFlagVariationByKey($flagKey, $variationKey)
     {
-        if (array_key_exists($flagKey, $this->getConfig()->getFlagVariationsMap())) {
-            foreach ($this->getConfig()->getFlagVariationsMap()[$flagKey] as $variation) {
-                if ($variation->getKey() == $variationKey) {
-                    return $variation;
-                }
-            }
-        }
-        return null;
+        return $this->getConfig()->getFlagVariationByKey($flagKey, $variationKey);
     }
 }

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -369,8 +369,10 @@ class Optimizely
         if ($variation) {
             $variationKey = $variation->getKey();
             $featureEnabled = $variation->getFeatureEnabled();
-            $ruleKey = $decision->getExperiment()->getKey();
-            $experimentId = $decision->getExperiment()->getId();
+            if ($decision->getExperiment()) {
+                $ruleKey = $decision->getExperiment()->getKey();
+                $experimentId = $decision->getExperiment()->getId();
+            }
         } else {
             $variationKey = null;
             $ruleKey = null;
@@ -1294,13 +1296,11 @@ class Optimizely
 
     public function getFlagVariationByKey($flagKey, $variationKey)
     {
-        if(array_key_exists($flagKey, $this->_config->getFlagVariationsMap()))
-        {
-            $variations = array_filter(array_values($this->_config->getFlagVariationsMap()[$flagKey]), function ($variations) use ($variationKey) {
-                return in_array($variationKey, $variations->getKey());
-            });
-            if(!empty($variations)) {
-                return $variations[0];
+        if (array_key_exists($flagKey, $this->getConfig()->getFlagVariationsMap())) {
+            foreach ($this->getConfig()->getFlagVariationsMap()[$flagKey] as $variation) {
+                if ($variation->getKey() == $variationKey) {
+                    return $variation;
+                }
             }
         }
         return null;

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -1263,7 +1263,14 @@ class Optimizely
      */
     public function isValid()
     {
-        return $this->getConfig() !== null;
+        if (!$this->getConfig()) {
+            $this->_logger->log(
+                Logger::ERROR,
+                "Optimizely SDK not configured properly yet."
+            );
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -1267,7 +1267,7 @@ class Optimizely
         if (!$this->getConfig()) {
             $this->_logger->log(
                 Logger::ERROR,
-                "Optimizely SDK not configured properly yet."
+                Errors::NO_CONFIG
             );
             return false;
         }

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -1281,4 +1281,12 @@ class Optimizely
 
         return $isValid;
     }
+
+    public function getFlagVariationByKey($flagKey, $variationKey)
+    {
+        if(array_key_exists($flagKey, $this->_config))
+        {
+
+        }
+    }
 }

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -60,7 +60,7 @@ class OptimizelyUserContext implements \JsonSerializable
         return true;
     }
 
-    public function setForcedDecision($flagKey, $variationKey, $ruleKey = null)
+    public function setForcedDecision($flagKey, $ruleKey, $variationKey)
     {
         // check if SDK is ready
         if (!$this->optimizelyClient->isValid()) {

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -99,9 +99,9 @@ class OptimizelyUserContext implements \JsonSerializable
             $variation = $this->optimizelyClient->getFlagVariationByKey($flagKey, $variationKey);
             if ($variation) {
                 array_push($decideReasons, 'Decided by forced decision.');
-                array_push($decideReasons, sprintf('Variation "%s" is mapped to %s and user "%s" in the forced decision map.', $variationKey, $ruleKey? 'flag "'.$flagKey.'", rule "'.$ruleKey.'"': 'flag "'.$flagKey.'"', $this->userId));
+                array_push($decideReasons, sprintf('Variation (%s) is mapped to %s and user (%s) in the forced decision map.', $variationKey, $ruleKey? 'flag ('.$flagKey.'), rule ('.$ruleKey.')': 'flag ('.$flagKey.')', $this->userId));
             } else {
-                array_push($decideReasons, sprintf('Invalid variation is mapped to %s and user "%s" in the forced decision map.', $ruleKey? 'flag "'.$flagKey.'", rule "'.$ruleKey.'"': 'flag "'.$flagKey.'"', $this->userId));
+                array_push($decideReasons, sprintf('Invalid variation is mapped to %s and user (%s) in the forced decision map.', $ruleKey? 'flag ('.$flagKey.'), rule ('.$ruleKey.')': 'flag ('.$flagKey.')', $this->userId));
             }
         }
         return [$variation, $decideReasons];

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -22,8 +22,8 @@ class OptimizelyUserContext implements \JsonSerializable
     private $optimizelyClient;
     private $userId;
     private $attributes;
-    
-    
+    private $forcedDecisions;
+
     public function __construct(Optimizely $optimizelyClient, $userId, array $attributes = [])
     {
         $this->optimizelyClient = $optimizelyClient;
@@ -31,6 +31,60 @@ class OptimizelyUserContext implements \JsonSerializable
         $this->attributes = $attributes;
     }
 
+    public function setForcedDecision($flagKey, $ruleKey = null, $variationKey)
+    {
+        $index = $this->findExisitingRuleAndFlagKey($flagKey, $ruleKey);
+        if($index != -1)
+        {
+            $this->forcedDecisions[$index]->variationKey = $variationKey;
+        } else {
+            array_push($this->forcedDecisions, new ForcedDecision($flagKey,$ruleKey, $variationKey));
+        }
+        return true;
+    }
+
+    public function getForcedDecision($flagKey, $ruleKey = null)
+    {
+        return findForcedDecision($flagKey, $ruleKey);
+    }
+
+    private function findValidatedForcedDecision($flagKey, $ruleKey, array $options = [])
+    {
+        $decideReasons = [];
+        $variationKey = $this->findForcedDecision($flagKey, $ruleKey);
+        if($variationKey != null)
+        {
+            $variation = ($this->optimizelyClient)->getF
+            if()
+        }
+    }
+    private function findExistingRuleAndFlagKey($flagKey, $ruleKey)
+    {
+        for ($index = 0; count($this->forcedDecisions); $index++)
+        {
+            if ($this->forcedDecisions[$index]->getFlagKey() == $flagKey &&  $this->forcedDecisions[$index]->getRuleKey() == $ruleKey) {
+                return $index;
+            }
+        }
+        return -1;
+    }
+
+    private function findForcedDecision($flagKey, $ruleKey)
+    {
+        if(count($this->forcedDecisions) == 0)
+        {
+            return null;
+        }
+
+        $index = $this->findExistingRuleAndFlagKey($flagKey, $ruleKey);
+
+        if ($index != -1)
+        {
+            return $this->forcedDecisions[$index]->getVariationKey();
+        }
+
+        return null;
+    }
     protected function copy()
     {
         return new OptimizelyUserContext($this->optimizelyClient, $this->userId, $this->attributes);
@@ -83,5 +137,42 @@ class OptimizelyUserContext implements \JsonSerializable
             'userId' => $this->userId,
             'attributes' => $this->attributes
         ];
+    }
+}
+class ForcedDecision
+{
+    private $flagKey;
+    private $ruleKey;
+    public $variationKey;
+
+    public function __construct($flagKey, $ruleKey, $variationKey)
+    {
+        $this->flagKey = $flagKey;
+        $this->ruleKey = $ruleKey;
+        $this->variationKey = $variationKey;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFlagKey()
+    {
+        return $this->flagKey;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getRuleKey()
+    {
+        return $this->ruleKey;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationKey()
+    {
+        return $this->variationKey;
     }
 }

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -43,7 +43,7 @@ class OptimizelyUserContext implements \JsonSerializable
         }
         $index = $this->findExistingRuleAndFlagKey($flagKey, $ruleKey);
         if ($index != -1) {
-            unset($this->forcedDecisions[$index]);
+            array_splice($this->forcedDecisions, $index, 1);
             return true;
         }
         return false;
@@ -53,6 +53,9 @@ class OptimizelyUserContext implements \JsonSerializable
     {
         // check if SDK is ready
         if (!$this->optimizelyClient->isValid()) {
+            return false;
+        }
+        if (!$this->forcedDecisions || count($this->forcedDecisions) == 0) {
             return false;
         }
         $this->forcedDecisions = [];

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -94,14 +94,14 @@ class OptimizelyUserContext implements \JsonSerializable
     {
         $decideReasons = [];
         $variationKey = $this->findForcedDecision($flagKey, $ruleKey);
-        if ($variationKey != null) {
+        if ($variationKey) {
             $variation = $this->optimizelyClient->getFlagVariationByKey($flagKey, $variationKey);
-            $message = sprintf('Variation "%s" is mapped to "%s" and user "%s" in the forced decision map.', $variationKey, $flagKey, $this->userId);
+            $message = sprintf('Variation "%s" is mapped to %s and user "%s" in the forced decision map.', $variationKey, $ruleKey? 'flag "'.$flagKey.'", rule "'.$ruleKey.'"': 'flag "'.$flagKey.'"', $this->userId);
 
             $decideReasons[] = $message;
             return [$variation, $decideReasons];
         } else {
-            $message = sprintf('Invalid variation is mapped to "%s" and user "%s" in the forced decision map.', $flagKey, $this->userId);
+            $message = sprintf('Invalid variation is mapped to %s and user "%s" in the forced decision map.', $ruleKey? 'flag "'.$flagKey.'", rule "'.$ruleKey.'"': 'flag "'.$flagKey.'"', $this->userId);
 
             $decideReasons[] = $message;
         }

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -55,9 +55,7 @@ class OptimizelyUserContext implements \JsonSerializable
         if (!$this->optimizelyClient->isValid()) {
             return false;
         }
-        if (!$this->forcedDecisions || count($this->forcedDecisions) == 0) {
-            return false;
-        }
+
         $this->forcedDecisions = [];
         return true;
     }

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -48,15 +48,23 @@ class OptimizelyUserContext implements \JsonSerializable
         return findForcedDecision($flagKey, $ruleKey);
     }
 
-    private function findValidatedForcedDecision($flagKey, $ruleKey, array $options = [])
+    public function findValidatedForcedDecision($flagKey, $ruleKey, array $options = [], $logger)
     {
         $decideReasons = [];
         $variationKey = $this->findForcedDecision($flagKey, $ruleKey);
         if($variationKey != null)
         {
-            $variation = ($this->optimizelyClient)->getF
-            if()
+            $variation = ($this->optimizelyClient)->getFlagVariationByKey($flagKey, $variationKey);
+            $message = sprintf('Variation "%s" is mapped to "%s" and user "%s" in the forced decision map.', $variationKey, $flagKey, $this->userId);
+            $logger->log(Logger::INFO, $message);
+            $decideReasons[] = $message;
+            return [$variation, $decideReasons];
+        } else {
+            $message = sprintf('Invalid variation is mapped to "%s" and user "%s" in the forced decision map.', $flagKey, $this->userId);
+            $logger->log(Logger::INFO, $message);
+            $decideReasons[] = $message;
         }
+        return [null, $decideReasons];
     }
     private function findExistingRuleAndFlagKey($flagKey, $ruleKey)
     {

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -34,12 +34,31 @@ class OptimizelyUserContext implements \JsonSerializable
         $this->attributes = $attributes;
     }
 
+    public function removeForcedDecision($flagKey, $ruleKey = null)
+    {
+        $index = $this->findExistingRuleAndFlagKey($flagKey, $ruleKey);
+        if ($index != -1) {
+            unset($this->forcedDecisions[$index]);
+            return true;
+        }
+        return false;
+    }
+
+    public function removeAllForcedDecisions()
+    {
+        $this->forcedDecisions = [];
+        return true;
+    }
+
     public function setForcedDecision($flagKey, $variationKey, $ruleKey = null)
     {
         $index = $this->findExistingRuleAndFlagKey($flagKey, $ruleKey);
         if ($index != -1) {
-            $this->forcedDecisions[$index]->variationKey = $variationKey;
+            $this->forcedDecisions[$index]->setVariationKey($variationKey);
         } else {
+            if (!$this->forcedDecisions) {
+                $this->forcedDecisions = array();
+            }
             array_push($this->forcedDecisions, new ForcedDecision($flagKey, $ruleKey, $variationKey));
         }
         return true;
@@ -151,13 +170,20 @@ class ForcedDecision
 {
     private $flagKey;
     private $ruleKey;
-    public $variationKey;
+    private $variationKey;
 
     public function __construct($flagKey, $ruleKey, $variationKey)
     {
         $this->flagKey = $flagKey;
         $this->ruleKey = $ruleKey;
-        $this->variationKey = $variationKey;
+        $this->setVariationKey($variationKey);
+    }
+
+    public function setVariationKey($variationKey)
+    {
+        if (isset($variationKey) && trim($variationKey) !== '') {
+            $this->variationKey = $variationKey;
+        }
     }
 
     /**

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -66,6 +66,9 @@ class OptimizelyUserContext implements \JsonSerializable
         if (!$this->optimizelyClient->isValid()) {
             return false;
         }
+        if (empty($flagKey)) {
+            return false;
+        }
         $index = $this->findExistingRuleAndFlagKey($flagKey, $ruleKey);
         if ($index != -1) {
             $this->forcedDecisions[$index]->setVariationKey($variationKey);

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -90,20 +90,19 @@ class OptimizelyUserContext implements \JsonSerializable
         return true;
     }
 
-    public function findValidatedForcedDecision($flagKey, $ruleKey, array $options = [])
+    public function findValidatedForcedDecision($flagKey, $ruleKey)
     {
         $decideReasons = [];
         $variationKey = $this->findForcedDecision($flagKey, $ruleKey);
         $variation = null;
         if ($variationKey) {
             $variation = $this->optimizelyClient->getFlagVariationByKey($flagKey, $variationKey);
-        }
-        if ($variation) {
-            $message = sprintf('Variation "%s" is mapped to %s and user "%s" in the forced decision map.', $variationKey, $ruleKey? 'flag "'.$flagKey.'", rule "'.$ruleKey.'"': 'flag "'.$flagKey.'"', $this->userId);
-            $decideReasons[] = $message;
-        } else {
-            $message = sprintf('Invalid variation is mapped to %s and user "%s" in the forced decision map.', $ruleKey? 'flag "'.$flagKey.'", rule "'.$ruleKey.'"': 'flag "'.$flagKey.'"', $this->userId);
-            $decideReasons[] = $message;
+            if ($variation) {
+                array_push($decideReasons, 'Decided by forced decision.');
+                array_push($decideReasons, sprintf('Variation "%s" is mapped to %s and user "%s" in the forced decision map.', $variationKey, $ruleKey? 'flag "'.$flagKey.'", rule "'.$ruleKey.'"': 'flag "'.$flagKey.'"', $this->userId));
+            } else {
+                array_push($decideReasons, sprintf('Invalid variation is mapped to %s and user "%s" in the forced decision map.', $ruleKey? 'flag "'.$flagKey.'", rule "'.$ruleKey.'"': 'flag "'.$flagKey.'"', $this->userId));
+            }
         }
         return [$variation, $decideReasons];
     }

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -125,7 +125,7 @@ class OptimizelyUserContext implements \JsonSerializable
     public function findForcedDecision($context)
     {
         $foundVariationKey = null;
-        if (!$this->forcedDecisions) {
+        if (!isset($this->forcedDecisions)) {
             return null;
         }
         if (count($this->forcedDecisions) == 0) {

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -47,7 +47,7 @@ class OptimizelyUserContext implements \JsonSerializable
 
     public function getForcedDecision($flagKey, $ruleKey = null)
     {
-        return findForcedDecision($flagKey, $ruleKey);
+        return $this->findForcedDecision($flagKey, $ruleKey);
     }
 
     public function findValidatedForcedDecision($flagKey, $ruleKey, array $options = [])

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -36,7 +36,7 @@ class OptimizelyUserContext implements \JsonSerializable
 
     public function setForcedDecision($flagKey, $variationKey, $ruleKey = null)
     {
-        $index = $this->findExisitingRuleAndFlagKey($flagKey, $ruleKey);
+        $index = $this->findExistingRuleAndFlagKey($flagKey, $ruleKey);
         if ($index != -1) {
             $this->forcedDecisions[$index]->variationKey = $variationKey;
         } else {

--- a/src/Optimizely/Utils/Errors.php
+++ b/src/Optimizely/Utils/Errors.php
@@ -20,4 +20,5 @@ class Errors
 {
     const INVALID_FORMAT = 'Provided %s is in an invalid format.';
     const INVALID_DATAFILE = 'Datafile has invalid format. Failing "%s".';
+    const NO_CONFIG = 'Optimizely SDK not configured properly yet.';
 }

--- a/tests/ConfigTests/DatafileProjectConfigTest.php
+++ b/tests/ConfigTests/DatafileProjectConfigTest.php
@@ -122,6 +122,10 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
             'rollout_1_exp_3' =>  $this->config->getExperimentFromKey('rollout_1_exp_3'),
             'rollout_2_exp_1' =>  $this->config->getExperimentFromKey('rollout_2_exp_1'),
             'rollout_2_exp_2' =>  $this->config->getExperimentFromKey('rollout_2_exp_2'),
+            'flag1_targeted_delivery' =>  $this->config->getExperimentFromKey('flag1_targeted_delivery'),
+            'flag1_targeted_delivery2' =>  $this->config->getExperimentFromKey('flag1_targeted_delivery2'),
+            'flag1_targeted_delivery3' =>  $this->config->getExperimentFromKey('flag1_targeted_delivery3'),
+            'default-rollout-5969-20778120250' =>  $this->config->getExperimentFromKey('default-rollout-5969-20778120250'),
             ],
             $experimentKeyMap->getValue($this->config)
         );
@@ -147,6 +151,10 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
             '177774' => $this->config->getExperimentFromId('177774'),
             '177779' => $this->config->getExperimentFromId('177779'),
             '7716830083' => $this->config->getExperimentFromId('7716830083'),
+            '9300000018548' => $this->config->getExperimentFromId('9300000018548'),
+            '9300000018549' => $this->config->getExperimentFromId('9300000018549'),
+            '9300000018550' => $this->config->getExperimentFromId('9300000018550'),
+            'default-rollout-5969-20778120250' => $this->config->getExperimentFromId('default-rollout-5969-20778120250'),
             ],
             $experimentIdMap->getValue($this->config)
         );
@@ -184,7 +192,10 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             [
             '7718080042' => $this->config->getAudience('7718080042'),
-            '11155' => $this->config->getAudience('11155')
+            '11155' => $this->config->getAudience('11155'),
+            '20803170009' => $this->config->getAudience('20803170009'),
+            '20787080332' => $this->config->getAudience('20787080332'),
+            '20778250294' => $this->config->getAudience('20778250294')
             ],
             $audienceIdMap->getValue($this->config)
         );
@@ -233,7 +244,11 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
                     $this->config->getVariationFromKey('group_experiment_2', 'group_exp_2_var_1'),
                     $this->config->getVariationFromKey('group_experiment_2', 'group_exp_2_var_2')
                 ],
-                'empty_feature' => []
+                'empty_feature' => [],
+                'same_variation_flag' => [
+                    $this->config->getVariationFromKey('flag1_targeted_delivery', 'new_variation'),
+                    $this->config->getVariationFromKey('default-rollout-5969-20778120250', 'off')
+                ]
             ],
             $flagVariationsMap->getValue($this->config)
         );
@@ -299,6 +314,18 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
             ],
             'test_experiment_json_feature' => [
                 'json_variation' => $this->config->getVariationFromKey('test_experiment_json_feature', 'json_variation')
+            ],
+            'flag1_targeted_delivery' => [
+                'new_variation' => $this->config->getVariationFromKey('flag1_targeted_delivery', 'new_variation')
+            ],
+            'flag1_targeted_delivery2' => [
+                'new_variation' => $this->config->getVariationFromKey('flag1_targeted_delivery2', 'new_variation')
+            ],
+            'flag1_targeted_delivery3' => [
+                'new_variation' => $this->config->getVariationFromKey('flag1_targeted_delivery3', 'new_variation')
+            ],
+            'default-rollout-5969-20778120250' => [
+                'off' => $this->config->getVariationFromKey('default-rollout-5969-20778120250', 'off')
             ]
             ],
             $variationKeyMap->getValue($this->config)
@@ -364,6 +391,18 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
             ],
             'test_experiment_json_feature' => [
                 '122246' => $this->config->getVariationFromId('test_experiment_json_feature', '122246')
+            ],
+            'flag1_targeted_delivery' => [
+                '16421' => $this->config->getVariationFromId('flag1_targeted_delivery', '16421')
+            ],
+            'flag1_targeted_delivery2' => [
+                '16421' => $this->config->getVariationFromId('flag1_targeted_delivery2', '16421')
+            ],
+            'flag1_targeted_delivery3' => [
+                '16421' => $this->config->getVariationFromId('flag1_targeted_delivery3', '16421')
+            ],
+            'default-rollout-5969-20778120250' => [
+                '16419' => $this->config->getVariationFromId('default-rollout-5969-20778120250', '16419')
             ]
             ],
             $variationIdMap->getValue($this->config)
@@ -383,7 +422,8 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
             'multiple_variables_feature' => $this->config->getFeatureFlagFromKey('multiple_variables_feature'),
             'multi_variate_feature' => $this->config->getFeatureFlagFromKey('multi_variate_feature'),
             'mutex_group_feature' => $this->config->getFeatureFlagFromKey('mutex_group_feature'),
-            'empty_feature' => $this->config->getFeatureFlagFromKey('empty_feature')
+            'empty_feature' => $this->config->getFeatureFlagFromKey('empty_feature'),
+            'same_variation_flag' => $this->config->getFeatureFlagFromKey('same_variation_flag')
             ],
             $featureFlagKeyMap->getValue($this->config)
         );
@@ -395,7 +435,8 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             [
             '166660' => $this->config->getRolloutFromId('166660'),
-            '166661' => $this->config->getRolloutFromId('166661')
+            '166661' => $this->config->getRolloutFromId('166661'),
+            'rollout-5969-20778120250' => $this->config->getRolloutFromId('rollout-5969-20778120250')
             ],
             $rolloutIdMap->getValue($this->config)
         );

--- a/tests/ConfigTests/DatafileProjectConfigTest.php
+++ b/tests/ConfigTests/DatafileProjectConfigTest.php
@@ -189,6 +189,55 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
             $audienceIdMap->getValue($this->config)
         );
 
+        // Check flag key variations map
+        $flagVariationsMap = new \ReflectionProperty(DatafileProjectConfig::class, '_flagVariationsMap');
+        $flagVariationsMap->setAccessible(true);
+
+        $this->assertEquals(
+            [
+                'boolean_feature' => [
+                    $this->config->getVariationFromKey('test_experiment_2', 'test_variation_1'),
+                    $this->config->getVariationFromKey('test_experiment_2', 'test_variation_2')
+                ],
+                'double_single_variable_feature' => [
+                    $this->config->getVariationFromKey('test_experiment_double_feature', 'control'),
+                    $this->config->getVariationFromKey('test_experiment_double_feature', 'variation')
+                ],
+                'integer_single_variable_feature' => [
+                    $this->config->getVariationFromKey('test_experiment_integer_feature', 'control'),
+                    $this->config->getVariationFromKey('test_experiment_integer_feature', 'variation')
+                ],
+                'boolean_single_variable_feature' => [
+                    $this->config->getVariationFromKey('rollout_1_exp_1', '177771'),
+                    $this->config->getVariationFromKey('rollout_1_exp_2', '177773'),
+                    $this->config->getVariationFromKey('rollout_1_exp_3', '177778')
+                ],
+                'string_single_variable_feature' => [
+                    $this->config->getVariationFromKey('test_experiment_with_feature_rollout', 'control'),
+                    $this->config->getVariationFromKey('test_experiment_with_feature_rollout', 'variation'),
+                    $this->config->getVariationFromKey('rollout_2_exp_1', '177775'),
+                    $this->config->getVariationFromKey('rollout_2_exp_2', '177780')
+                ],
+                'multiple_variables_feature' => [
+                    $this->config->getVariationFromKey('test_experiment_json_feature', 'json_variation')
+                ],
+                'multi_variate_feature' => [
+                    $this->config->getVariationFromKey('test_experiment_multivariate', 'Fred'),
+                    $this->config->getVariationFromKey('test_experiment_multivariate', 'Feorge'),
+                    $this->config->getVariationFromKey('test_experiment_multivariate', 'Gred'),
+                    $this->config->getVariationFromKey('test_experiment_multivariate', 'George')
+                ],
+                'mutex_group_feature' => [
+                    $this->config->getVariationFromKey('group_experiment_1', 'group_exp_1_var_1'),
+                    $this->config->getVariationFromKey('group_experiment_1', 'group_exp_1_var_2'),
+                    $this->config->getVariationFromKey('group_experiment_2', 'group_exp_2_var_1'),
+                    $this->config->getVariationFromKey('group_experiment_2', 'group_exp_2_var_2')
+                ],
+                'empty_feature' => []
+            ],
+            $flagVariationsMap->getValue($this->config)
+        );
+
         // Check variation key map
         $variationKeyMap = new \ReflectionProperty(DatafileProjectConfig::class, '_variationKeyMap');
         $variationKeyMap->setAccessible(true);

--- a/tests/ConfigTests/DatafileProjectConfigTest.php
+++ b/tests/ConfigTests/DatafileProjectConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, Optimizely
+ * Copyright 2016-2020,2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/ConfigTests/DatafileProjectConfigTest.php
+++ b/tests/ConfigTests/DatafileProjectConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020,2021, Optimizely
+ * Copyright 2016-2020, 2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -1080,11 +1080,9 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             $expected_variation,
             FeatureDecision::DECISION_SOURCE_ROLLOUT,
             [
-                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_1" and user "user_1" in the forced decision map.',
                 'Audiences for rule 1 collectively evaluated to TRUE.',
                 'User "user_1" meets condition for targeting rule "1".',
                 'User "user_1" is not in the traffic group for targeting rule "1". Checking Everyone Else rule now.',
-                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "user_1" in the forced decision map.',
                 'Audiences for rule Everyone Else collectively evaluated to TRUE.',
                 'User "user_1" meets condition for targeting rule "Everyone Else".',
                 'User "user_1" is in the traffic group of targeting rule "Everyone Else".'
@@ -1168,13 +1166,10 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             $expected_variation,
             FeatureDecision::DECISION_SOURCE_ROLLOUT,
             [
-                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_1" and user "user_1" in the forced decision map.',
                 'Audiences for rule 1 collectively evaluated to FALSE.' ,
                 'User "user_1" does not meet conditions for targeting rule "1".',
-                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_2" and user "user_1" in the forced decision map.',
                 'Audiences for rule 2 collectively evaluated to FALSE.',
                 'User "user_1" does not meet conditions for targeting rule "2".',
-                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "user_1" in the forced decision map.',
                 'Audiences for rule Everyone Else collectively evaluated to TRUE.',
                 'User "user_1" meets condition for targeting rule "Everyone Else".',
                 'User "user_1" is in the traffic group of targeting rule "Everyone Else".'
@@ -1262,13 +1257,10 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             $expected_variation,
             FeatureDecision::DECISION_SOURCE_ROLLOUT,
             [
-                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_1" and user "user_1" in the forced decision map.',
                 'Audiences for rule 1 collectively evaluated to FALSE.',
                 'User "user_1" does not meet conditions for targeting rule "1".',
-                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_2" and user "user_1" in the forced decision map.',
                 'Audiences for rule 2 collectively evaluated to FALSE.',
                 'User "user_1" does not meet conditions for targeting rule "2".',
-                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "user_1" in the forced decision map.',
                 'Audiences for rule Everyone Else collectively evaluated to TRUE.',
                 'User "user_1" meets condition for targeting rule "Everyone Else".',
                 'User "user_1" is in the traffic group of targeting rule "Everyone Else".'

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -1079,11 +1079,12 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             $experiment2,
             $expected_variation,
             FeatureDecision::DECISION_SOURCE_ROLLOUT,
-            ['Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+            [
+                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_1" and user "user_1" in the forced decision map.',
                 'Audiences for rule 1 collectively evaluated to TRUE.',
                 'User "user_1" meets condition for targeting rule "1".',
                 'User "user_1" is not in the traffic group for targeting rule "1". Checking Everyone Else rule now.',
-                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "user_1" in the forced decision map.',
                 'Audiences for rule Everyone Else collectively evaluated to TRUE.',
                 'User "user_1" meets condition for targeting rule "Everyone Else".',
                 'User "user_1" is in the traffic group of targeting rule "Everyone Else".'
@@ -1167,13 +1168,13 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             $expected_variation,
             FeatureDecision::DECISION_SOURCE_ROLLOUT,
             [
-                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_1" and user "user_1" in the forced decision map.',
                 'Audiences for rule 1 collectively evaluated to FALSE.' ,
                 'User "user_1" does not meet conditions for targeting rule "1".',
-                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_2" and user "user_1" in the forced decision map.',
                 'Audiences for rule 2 collectively evaluated to FALSE.',
                 'User "user_1" does not meet conditions for targeting rule "2".',
-                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "user_1" in the forced decision map.',
                 'Audiences for rule Everyone Else collectively evaluated to TRUE.',
                 'User "user_1" meets condition for targeting rule "Everyone Else".',
                 'User "user_1" is in the traffic group of targeting rule "Everyone Else".'
@@ -1261,13 +1262,13 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
             $expected_variation,
             FeatureDecision::DECISION_SOURCE_ROLLOUT,
             [
-                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_1" and user "user_1" in the forced decision map.',
                 'Audiences for rule 1 collectively evaluated to FALSE.',
                 'User "user_1" does not meet conditions for targeting rule "1".',
-                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_2" and user "user_1" in the forced decision map.',
                 'Audiences for rule 2 collectively evaluated to FALSE.',
                 'User "user_1" does not meet conditions for targeting rule "2".',
-                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "user_1" in the forced decision map.',
                 'Audiences for rule Everyone Else collectively evaluated to TRUE.',
                 'User "user_1" meets condition for targeting rule "Everyone Else".',
                 'User "user_1" is in the traffic group of targeting rule "Everyone Else".'

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -1078,7 +1078,16 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $expected_decision = new FeatureDecision(
             $experiment2,
             $expected_variation,
-            FeatureDecision::DECISION_SOURCE_ROLLOUT
+            FeatureDecision::DECISION_SOURCE_ROLLOUT,
+            ['Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Audiences for rule 1 collectively evaluated to TRUE.',
+                'User "user_1" meets condition for targeting rule "1".',
+                'User "user_1" is not in the traffic group for targeting rule "1". Checking Everyone Else rule now.',
+                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Audiences for rule Everyone Else collectively evaluated to TRUE.',
+                'User "user_1" meets condition for targeting rule "Everyone Else".',
+                'User "user_1" is in the traffic group of targeting rule "Everyone Else".'
+            ]
         );
 
         // Provide attributes such that user qualifies for audience
@@ -1156,7 +1165,19 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $expected_decision = new FeatureDecision(
             $experiment2,
             $expected_variation,
-            FeatureDecision::DECISION_SOURCE_ROLLOUT
+            FeatureDecision::DECISION_SOURCE_ROLLOUT,
+            [
+                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Audiences for rule 1 collectively evaluated to FALSE.' ,
+                'User "user_1" does not meet conditions for targeting rule "1".',
+                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Audiences for rule 2 collectively evaluated to FALSE.',
+                'User "user_1" does not meet conditions for targeting rule "2".',
+                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Audiences for rule Everyone Else collectively evaluated to TRUE.',
+                'User "user_1" meets condition for targeting rule "Everyone Else".',
+                'User "user_1" is in the traffic group of targeting rule "Everyone Else".'
+            ]
         );
 
         // Provide null attributes so that user does not qualify for audience
@@ -1181,8 +1202,8 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         );
 
         // Verify Logs
-        $this->assertContains([Logger::DEBUG, "User 'user_1' does not meet conditions for targeting rule 1."], $this->collectedLogs);
-        $this->assertContains([Logger::DEBUG, "User 'user_1' does not meet conditions for targeting rule 2."], $this->collectedLogs);
+        $this->assertContains([Logger::DEBUG, 'User "user_1" does not meet conditions for targeting rule "1".'], $this->collectedLogs);
+        $this->assertContains([Logger::DEBUG, 'User "user_1" does not meet conditions for targeting rule "2".'], $this->collectedLogs);
     }
 
     public function testGetVariationForFeatureRolloutWhenUserDoesNotQualifyForAnyTargetingRuleOrEveryoneElseRule()
@@ -1219,9 +1240,9 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($actualFeatureDecision->getVariation());
 
         // Verify Logs
-        $this->assertContains([Logger::DEBUG, "User 'user_1' does not meet conditions for targeting rule 1."], $this->collectedLogs);
-        $this->assertContains([Logger::DEBUG, "User 'user_1' does not meet conditions for targeting rule 2."], $this->collectedLogs);
-        $this->assertContains([Logger::DEBUG, "User 'user_1' does not meet conditions for targeting rule 'Everyone Else'."], $this->collectedLogs);
+        $this->assertContains([Logger::DEBUG, 'User "user_1" does not meet conditions for targeting rule "1".'], $this->collectedLogs);
+        $this->assertContains([Logger::DEBUG, 'User "user_1" does not meet conditions for targeting rule "2".'], $this->collectedLogs);
+        $this->assertContains([Logger::DEBUG, 'User "user_1" does not meet conditions for targeting rule "Everyone Else".'], $this->collectedLogs);
     }
 
 
@@ -1238,7 +1259,19 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
         $expected_decision = new FeatureDecision(
             $experiment2,
             $expected_variation,
-            FeatureDecision::DECISION_SOURCE_ROLLOUT
+            FeatureDecision::DECISION_SOURCE_ROLLOUT,
+            [
+                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Audiences for rule 1 collectively evaluated to FALSE.',
+                'User "user_1" does not meet conditions for targeting rule "1".',
+                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Audiences for rule 2 collectively evaluated to FALSE.',
+                'User "user_1" does not meet conditions for targeting rule "2".',
+                'Invalid variation is mapped to "boolean_single_variable_feature" and user "user_1" in the forced decision map.',
+                'Audiences for rule Everyone Else collectively evaluated to TRUE.',
+                'User "user_1" meets condition for targeting rule "Everyone Else".',
+                'User "user_1" is in the traffic group of targeting rule "Everyone Else".'
+            ]
         );
 
         // Provide null attributes so that user does not qualify for audience

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1914,7 +1914,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $expectedReasons = [
-            'Invalid variation is mapped to "double_single_variable_feature" and user "test_user" in the forced decision map.',
+            'Invalid variation is mapped to flag "double_single_variable_feature", rule "test_experiment_double_feature" and user "test_user" in the forced decision map.',
             'Audiences for experiment "test_experiment_double_feature" collectively evaluated to TRUE.',
             'Assigned bucket 4513 to user "test_user" with bucketing ID "test_user".',
             'User "test_user" is in variation control of experiment test_experiment_double_feature.',
@@ -1987,7 +1987,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $expectedReasons = [
-            'Invalid variation is mapped to "multi_variate_feature" and user "test_user" in the forced decision map.',
+            'Invalid variation is mapped to flag "multi_variate_feature", rule "test_experiment_multivariate" and user "test_user" in the forced decision map.',
             'Audiences for experiment "test_experiment_multivariate" collectively evaluated to FALSE.',
             'User "test_user" does not meet conditions to be in experiment "test_experiment_multivariate".',
             "The user 'test_user' is not bucketed into any of the experiments using the feature 'multi_variate_feature'.",

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -2256,7 +2256,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $userContext = $optimizelyMock->createUserContext('test_user', ['device_type' => 'iPhone']);
 
-        $this->notificationCenterMock->expects($this->exactly(9))
+        $this->notificationCenterMock->expects($this->exactly(10))
             ->method('sendNotifications');
 
         //assert that sendImpressionEvent is called with expected params
@@ -2287,7 +2287,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
 
         $optimizelyDecisions = $optimizelyMock->decideAll($userContext);
-        $this->assertEquals(count($optimizelyDecisions), 9);
+        $this->assertEquals(count($optimizelyDecisions), 10);
 
         $this->compareOptimizelyDecisions($expectedOptimizelyDecision1, $optimizelyDecisions['double_single_variable_feature']);
         $this->compareOptimizelyDecisions($expectedOptimizelyDecision2, $optimizelyDecisions['boolean_feature']);
@@ -2307,6 +2307,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                  'boolean_single_variable_feature',
                  'string_single_variable_feature',
                  'multiple_variables_feature',
+                 'same_variation_flag',
                  'multi_variate_feature',
                  'mutex_group_feature',
                  'empty_feature'
@@ -5098,7 +5099,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         // Mock isFeatureEnabled to return false for all calls
-        $optimizelyMock->expects($this->exactly(9))
+        $optimizelyMock->expects($this->exactly(10))
             ->method('isFeatureEnabled')
             ->will($this->returnValue(false));
 
@@ -5124,7 +5125,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         ];
 
         // Mock isFeatureEnabled to return specific values
-        $optimizelyMock->expects($this->exactly(9))
+        $optimizelyMock->expects($this->exactly(10))
             ->method('isFeatureEnabled')
             ->will($this->returnValueMap($map));
 
@@ -5147,7 +5148,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         ];
 
         // Mock isFeatureEnabled to return specific values
-        $optimizelyMock->expects($this->exactly(9))
+        $optimizelyMock->expects($this->exactly(10))
             ->method('isFeatureEnabled')
             ->will($this->returnValueMap($map));
 
@@ -5176,19 +5177,20 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ['integer_single_variable_feature','user_id', $userAttributes, false],
             ['boolean_single_variable_feature','user_id', $userAttributes, false],
             ['string_single_variable_feature','user_id', $userAttributes, false],
+            ['same_variation_flag','user_id', $userAttributes, true],
             ['multi_variate_feature','user_id', $userAttributes, false],
             ['mutex_group_feature','user_id', $userAttributes, false],
             ['empty_feature','user_id', $userAttributes, true],
         ];
 
         // Assert that isFeatureEnabled is called with the same attributes and mock to return value map
-        $optimizelyMock->expects($this->exactly(9))
+        $optimizelyMock->expects($this->exactly(10))
             ->method('isFeatureEnabled')
             ->with()
             ->will($this->returnValueMap($map));
 
         $this->assertEquals(
-            ['empty_feature'],
+            ['same_variation_flag', 'empty_feature'],
             $optimizelyMock->getEnabledFeatures("user_id", $userAttributes)
         );
     }
@@ -5250,22 +5252,27 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             FeatureDecision::DECISION_SOURCE_FEATURE_TEST
         );
         $decision7 = new FeatureDecision(
-            $disabledFeatureExperiment,
-            $disabledFeatureVariation,
-            FeatureDecision::DECISION_SOURCE_FEATURE_TEST
-        );
-        $decision8 = new FeatureDecision(
             $experiment,
             $enabledFeatureVariation,
             FeatureDecision::DECISION_SOURCE_ROLLOUT
         );
+        $decision8 = new FeatureDecision(
+            $disabledFeatureExperiment,
+            $disabledFeatureVariation,
+            FeatureDecision::DECISION_SOURCE_FEATURE_TEST
+        );
         $decision9 = new FeatureDecision(
+            $experiment,
+            $enabledFeatureVariation,
+            FeatureDecision::DECISION_SOURCE_ROLLOUT
+        );
+        $decision10 = new FeatureDecision(
             $disabledFeatureExperiment,
             $disabledFeatureVariation,
             FeatureDecision::DECISION_SOURCE_ROLLOUT
         );
 
-        $decisionServiceMock->expects($this->exactly(9))
+        $decisionServiceMock->expects($this->exactly(10))
             ->method('getVariationForFeature')
             ->will($this->onConsecutiveCalls(
                 $decision1,
@@ -5276,7 +5283,9 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 $decision6,
                 $decision7,
                 $decision8,
-                $decision9
+                $decision9,
+                $decision10
+
             ));
 
         $optimizelyMock->notificationCenter = $this->notificationCenterMock;
@@ -5394,8 +5403,24 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                     )
                 )
             );
-
         $this->notificationCenterMock->expects($this->at(6))
+            ->method('sendNotifications')
+            ->with(
+                NotificationType::DECISION,
+                array(
+                    DecisionNotificationTypes::FEATURE,
+                    'user_id',
+                    [],
+                    (object) array(
+                        'featureKey'=>'same_variation_flag',
+                        'featureEnabled'=> true,
+                        'source'=> 'rollout',
+                        'sourceInfo'=> (object) array()
+                    )
+                )
+            );
+
+        $this->notificationCenterMock->expects($this->at(7))
             ->method('sendNotifications')
             ->with(
                 NotificationType::DECISION,
@@ -5415,7 +5440,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 )
             );
 
-        $this->notificationCenterMock->expects($this->at(7))
+        $this->notificationCenterMock->expects($this->at(8))
             ->method('sendNotifications')
             ->with(
                 NotificationType::DECISION,
@@ -5432,7 +5457,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 )
             );
 
-        $this->notificationCenterMock->expects($this->at(8))
+        $this->notificationCenterMock->expects($this->at(9))
             ->method('sendNotifications')
             ->with(
                 NotificationType::DECISION,
@@ -5455,6 +5480,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 'integer_single_variable_feature',
                 'string_single_variable_feature',
                 'multiple_variables_feature',
+                'same_variation_flag',
                 'mutex_group_feature'
             ],
             $optimizelyMock->getEnabledFeatures("user_id")

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -46,6 +46,8 @@ use Optimizely\ErrorHandler\DefaultErrorHandler;
 use Optimizely\Event\Builder\EventBuilder;
 use Optimizely\Logger\DefaultLogger;
 use Optimizely\Optimizely;
+use Optimizely\OptimizelyDecisionContext;
+use Optimizely\OptimizelyForcedDecision;
 use Optimizely\OptimizelyUserContext;
 use Optimizely\UserProfile\UserProfileServiceInterface;
 
@@ -550,8 +552,9 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             );
 
         $optimizelyMock->notificationCenter = $this->notificationCenterMock;
-
-        $this->assertTrue($userContext->setForcedDecision('double_single_variable_feature', 'test_experiment_double_feature', 'variation'));
+        $context = new OptimizelyDecisionContext('double_single_variable_feature', 'test_experiment_double_feature');
+        $decision = new OptimizelyForcedDecision('variation');
+        $this->assertTrue($userContext->setForcedDecision($context, $decision));
         $optimizelyDecision = $optimizelyMock->decide($userContext, 'double_single_variable_feature');
         $expectedOptimizelyDecision = new OptimizelyDecision(
             'variation',
@@ -642,7 +645,9 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $optimizelyMock->notificationCenter = $this->notificationCenterMock;
 
-        $this->assertTrue($userContext->setForcedDecision('boolean_single_variable_feature', 'rollout_1_exp_2', '177773'));
+        $context = new OptimizelyDecisionContext('boolean_single_variable_feature', 'rollout_1_exp_2');
+        $decision = new OptimizelyForcedDecision('177773');
+        $this->assertTrue($userContext->setForcedDecision($context, $decision));
         $optimizelyDecision = $optimizelyMock->decide($userContext, 'boolean_single_variable_feature');
         $expectedOptimizelyDecision = new OptimizelyDecision(
             '177773',
@@ -722,7 +727,9 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $optimizelyMock->notificationCenter = $this->notificationCenterMock;
 
-        $this->assertTrue($userContext->setForcedDecision('double_single_variable_feature', null, 'variation'));
+        $context = new OptimizelyDecisionContext('double_single_variable_feature', null);
+        $decision = new OptimizelyForcedDecision('variation');
+        $this->assertTrue($userContext->setForcedDecision($context, $decision));
         $optimizelyDecision = $optimizelyMock->decide($userContext, 'double_single_variable_feature');
         $expectedOptimizelyDecision = new OptimizelyDecision(
             'variation',

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -551,7 +551,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $optimizelyMock->notificationCenter = $this->notificationCenterMock;
 
-        $this->assertTrue($userContext->setForcedDecision('double_single_variable_feature', 'variation', 'test_experiment_double_feature'));
+        $this->assertTrue($userContext->setForcedDecision('double_single_variable_feature', 'test_experiment_double_feature', 'variation'));
         $optimizelyDecision = $optimizelyMock->decide($userContext, 'double_single_variable_feature');
         $expectedOptimizelyDecision = new OptimizelyDecision(
             'variation',
@@ -642,7 +642,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $optimizelyMock->notificationCenter = $this->notificationCenterMock;
 
-        $this->assertTrue($userContext->setForcedDecision('boolean_single_variable_feature', '177773', 'rollout_1_exp_2'));
+        $this->assertTrue($userContext->setForcedDecision('boolean_single_variable_feature', 'rollout_1_exp_2', '177773'));
         $optimizelyDecision = $optimizelyMock->decide($userContext, 'boolean_single_variable_feature');
         $expectedOptimizelyDecision = new OptimizelyDecision(
             '177773',
@@ -722,7 +722,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
 
         $optimizelyMock->notificationCenter = $this->notificationCenterMock;
 
-        $this->assertTrue($userContext->setForcedDecision('double_single_variable_feature', 'variation'));
+        $this->assertTrue($userContext->setForcedDecision('double_single_variable_feature', null, 'variation'));
         $optimizelyDecision = $optimizelyMock->decide($userContext, 'double_single_variable_feature');
         $expectedOptimizelyDecision = new OptimizelyDecision(
             'variation',

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1914,7 +1914,6 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $expectedReasons = [
-            'Invalid variation is mapped to flag "double_single_variable_feature", rule "test_experiment_double_feature" and user "test_user" in the forced decision map.',
             'Audiences for experiment "test_experiment_double_feature" collectively evaluated to TRUE.',
             'Assigned bucket 4513 to user "test_user" with bucketing ID "test_user".',
             'User "test_user" is in variation control of experiment test_experiment_double_feature.',
@@ -1987,7 +1986,6 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $expectedReasons = [
-            'Invalid variation is mapped to flag "multi_variate_feature", rule "test_experiment_multivariate" and user "test_user" in the forced decision map.',
             'Audiences for experiment "test_experiment_multivariate" collectively evaluated to FALSE.',
             'User "test_user" does not meet conditions to be in experiment "test_experiment_multivariate".',
             "The user 'test_user' is not bucketed into any of the experiments using the feature 'multi_variate_feature'.",

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1652,6 +1652,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $expectedReasons = [
+            'Invalid variation is mapped to "double_single_variable_feature" and user "test_user" in the forced decision map.',
             'Audiences for experiment "test_experiment_double_feature" collectively evaluated to TRUE.',
             'Assigned bucket 4513 to user "test_user" with bucketing ID "test_user".',
             'User "test_user" is in variation control of experiment test_experiment_double_feature.',
@@ -1724,6 +1725,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $expectedReasons = [
+            'Invalid variation is mapped to "multi_variate_feature" and user "test_user" in the forced decision map.',
             'Audiences for experiment "test_experiment_multivariate" collectively evaluated to FALSE.',
             'User "test_user" does not meet conditions to be in experiment "test_experiment_multivariate".',
             "The user 'test_user' is not bucketed into any of the experiments using the feature 'multi_variate_feature'.",

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -5285,7 +5285,6 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
                 $decision8,
                 $decision9,
                 $decision10
-
             ));
 
         $optimizelyMock->notificationCenter = $this->notificationCenterMock;

--- a/tests/OptimizelyUserContextTest.php
+++ b/tests/OptimizelyUserContextTest.php
@@ -397,7 +397,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($decision->getUserContext()->getUserId(), $userId);
         $this->assertEquals(count($decision->getUserContext()->getAttributes()), 1);
         $this->assertEquals($decision->getReasons(), [
-            'Invalid variation is mapped to "boolean_feature" and user "test_user" in the forced decision map.',
+            'Invalid variation is mapped to flag "boolean_feature", rule "test_experiment_2" and user "test_user" in the forced decision map.',
             'Audiences for experiment "test_experiment_2" collectively evaluated to TRUE.',
             'Assigned bucket 9075 to user "test_user" with bucketing ID "test_user".',
             'User "test_user" is in variation test_variation_2 of experiment test_experiment_2.',
@@ -426,13 +426,13 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($decision->getUserContext()->getAttributes()), 1);
         $this->assertEquals($decision->getReasons(), [
             "The feature flag 'boolean_single_variable_feature' is not used in any experiments.",
-            'Invalid variation is mapped to "boolean_single_variable_feature" and user "test_user" in the forced decision map.',
+            'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_1" and user "test_user" in the forced decision map.',
             'Audiences for rule 1 collectively evaluated to FALSE.',
             'User "test_user" does not meet conditions for targeting rule "1".',
-            'Invalid variation is mapped to "boolean_single_variable_feature" and user "test_user" in the forced decision map.',
+            'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_2" and user "test_user" in the forced decision map.',
             'Audiences for rule 2 collectively evaluated to FALSE.',
             'User "test_user" does not meet conditions for targeting rule "2".',
-            'Variation "invalid" is mapped to "boolean_single_variable_feature" and user "test_user" in the forced decision map.',
+            'Variation "invalid" is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "test_user" in the forced decision map.',
             'Audiences for rule Everyone Else collectively evaluated to TRUE.',
             'User "test_user" meets condition for targeting rule "Everyone Else".',
             'Assigned bucket 3041 to user "test_user" with bucketing ID "test_user".',
@@ -460,7 +460,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($decision->getUserContext()->getUserId(), $userId);
         $this->assertEquals(1, count($decision->getUserContext()->getAttributes()));
         $this->assertEquals([
-            'Invalid variation is mapped to "boolean_feature" and user "test_user" in the forced decision map.',
+            'Invalid variation is mapped to flag "boolean_feature", rule "test_experiment_2" and user "test_user" in the forced decision map.',
             'Audiences for experiment "test_experiment_2" collectively evaluated to TRUE.',
             'Assigned bucket 9075 to user "test_user" with bucketing ID "test_user".',
             'User "test_user" is in variation test_variation_2 of experiment test_experiment_2.',

--- a/tests/OptimizelyUserContextTest.php
+++ b/tests/OptimizelyUserContextTest.php
@@ -270,7 +270,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $invalidOptlyObject = new Optimizely("Invalid datafile");
 
         $optUserContext = new OptimizelyUserContext($invalidOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("flag1", "variation1", "targeted_delivery");
+        $setForcedDecision = $optUserContext->setForcedDecision("flag1", "targeted_delivery", "variation1");
         $this->assertFalse($setForcedDecision);
 
         $getForcedDecision = $optUserContext->getForcedDecision("flag1", "targeted_delivery");
@@ -291,7 +291,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("flag1", "variation1", "targeted_delivery");
+        $setForcedDecision = $optUserContext->setForcedDecision("flag1", "targeted_delivery", "variation1");
         $this->assertTrue($setForcedDecision);
 
         $getForcedDecision = $optUserContext->getForcedDecision("flag1", "targeted_delivery");
@@ -312,7 +312,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("boolean_single_variable_feature", "177773");
+        $setForcedDecision = $optUserContext->setForcedDecision("boolean_single_variable_feature", null, "177773");
         $this->assertTrue($setForcedDecision);
 
         $getForcedDecision = $optUserContext->getForcedDecision("boolean_single_variable_feature");
@@ -349,7 +349,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("boolean_feature", "test_variation_1", "test_experiment_2");
+        $setForcedDecision = $optUserContext->setForcedDecision("boolean_feature", "test_experiment_2", "test_variation_1");
         $this->assertTrue($setForcedDecision);
 
         $getForcedDecision = $optUserContext->getForcedDecision("boolean_feature", "test_experiment_2");
@@ -386,7 +386,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("boolean_feature", "invalid");
+        $setForcedDecision = $optUserContext->setForcedDecision("boolean_feature", null, "invalid");
         $this->assertTrue($setForcedDecision);
 
         $decision = $optUserContext->decide('boolean_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -414,7 +414,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("boolean_single_variable_feature", "invalid", "rollout_1_exp_3");
+        $setForcedDecision = $optUserContext->setForcedDecision("boolean_single_variable_feature", "rollout_1_exp_3", "invalid");
         $this->assertTrue($setForcedDecision);
 
         $decision = $optUserContext->decide('boolean_single_variable_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -449,7 +449,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("boolean_feature", "invalid");
+        $setForcedDecision = $optUserContext->setForcedDecision("boolean_feature", null, "invalid");
         $this->assertTrue($setForcedDecision);
 
         $decision = $optUserContext->decide('boolean_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -477,10 +477,10 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision1 = $optUserContext->setForcedDecision($featureKey, "test_variation_1");
+        $setForcedDecision1 = $optUserContext->setForcedDecision($featureKey, null, "test_variation_1");
         $this->assertTrue($setForcedDecision1);
 
-        $setForcedDecision2 = $optUserContext->setForcedDecision($featureKey, "test_variation_2", "test_experiment_2");
+        $setForcedDecision2 = $optUserContext->setForcedDecision($featureKey, "test_experiment_2", "test_variation_2");
         $this->assertTrue($setForcedDecision2);
 
         // flag-to-decision is the 1st priority
@@ -499,16 +499,16 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_variation_1"));
+        $this->assertTrue($optUserContext->setForcedDecision($featureKey, null, "test_variation_1"));
         $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($featureKey));
 
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_variation_2"));
+        $this->assertTrue($optUserContext->setForcedDecision($featureKey, null, "test_variation_2"));
         $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey));
 
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_variation_1", "test_experiment_2"));
+        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_experiment_2", "test_variation_1"));
         $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
 
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_variation_2", "test_experiment_2"));
+        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_experiment_2", "test_variation_2"));
         $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
 
         $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey));
@@ -523,8 +523,8 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_variation_1"));
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_variation_2", "test_experiment_2"));
+        $this->assertTrue($optUserContext->setForcedDecision($featureKey, null, "test_variation_1"));
+        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_experiment_2", "test_variation_2"));
 
         $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($featureKey));
         $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
@@ -551,8 +551,8 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
         $this->assertTrue($optUserContext->removeAllForcedDecisions()); // no saved decisions
 
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_variation_1"));
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_variation_2", "test_experiment_2"));
+        $this->assertTrue($optUserContext->setForcedDecision($featureKey, null, "test_variation_1"));
+        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_experiment_2", "test_variation_2"));
 
         $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($featureKey));
         $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey, "test_experiment_2"));

--- a/tests/OptimizelyUserContextTest.php
+++ b/tests/OptimizelyUserContextTest.php
@@ -327,7 +327,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($decision->getUserContext()->getAttributes()), 1);
         $this->assertEquals($decision->getReasons(), [
             'Decided by forced decision.',
-            'Variation "177773" is mapped to flag "boolean_single_variable_feature" and user "test_user" in the forced decision map.'
+            'Variation (177773) is mapped to flag (boolean_single_variable_feature) and user (test_user) in the forced decision map.'
         ]);
 
         // Removing forced decision to test
@@ -377,7 +377,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($decision->getUserContext()->getAttributes()), 1);
         $this->assertEquals($decision->getReasons(), [
             'Decided by forced decision.',
-            'Variation "test_variation_1" is mapped to flag "boolean_feature", rule "test_experiment_2" and user "test_user" in the forced decision map.',
+            'Variation (test_variation_1) is mapped to flag (boolean_feature), rule (test_experiment_2) and user (test_user) in the forced decision map.',
             "The user 'test_user' is bucketed into experiment 'test_experiment_2' of feature 'boolean_feature'."
         ]);
 
@@ -427,7 +427,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
             'Audiences for rule 2 collectively evaluated to FALSE.',
             'User "test_user" does not meet conditions for targeting rule "2".',
             'Decided by forced decision.',
-            'Variation "177773" is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "test_user" in the forced decision map.',
+            'Variation (177773) is mapped to flag (boolean_single_variable_feature), rule (rollout_1_exp_3) and user (test_user) in the forced decision map.',
             "User 'test_user' is bucketed into rollout for feature flag 'boolean_single_variable_feature'."
         ]);
 
@@ -480,7 +480,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
             'User "test_user" does not meet conditions for targeting rule "1".',
             'Audiences for rule 2 collectively evaluated to FALSE.',
             'User "test_user" does not meet conditions for targeting rule "2".',
-            'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "test_user" in the forced decision map.',
+            'Invalid variation is mapped to flag (boolean_single_variable_feature), rule (rollout_1_exp_3) and user (test_user) in the forced decision map.',
             'Audiences for rule Everyone Else collectively evaluated to TRUE.',
             'User "test_user" meets condition for targeting rule "Everyone Else".',
             'Assigned bucket 3041 to user "test_user" with bucketing ID "test_user".',
@@ -508,7 +508,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($decision->getUserContext()->getUserId(), $userId);
         $this->assertEquals(1, count($decision->getUserContext()->getAttributes()));
         $this->assertEquals([
-            'Invalid variation is mapped to flag "boolean_feature" and user "test_user" in the forced decision map.',
+            'Invalid variation is mapped to flag (boolean_feature) and user (test_user) in the forced decision map.',
             'Audiences for experiment "test_experiment_2" collectively evaluated to TRUE.',
             'Assigned bucket 9075 to user "test_user" with bucketing ID "test_user".',
             'User "test_user" is in variation test_variation_2 of experiment test_experiment_2.',
@@ -538,7 +538,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($decision->getRuleKey());
         $this->assertEquals([
             'Decided by forced decision.',
-            'Variation "test_variation_1" is mapped to flag "boolean_feature" and user "test_user" in the forced decision map.'
+            'Variation (test_variation_1) is mapped to flag (boolean_feature) and user (test_user) in the forced decision map.'
         ], $decision->getReasons());
     }
 

--- a/tests/OptimizelyUserContextTest.php
+++ b/tests/OptimizelyUserContextTest.php
@@ -23,6 +23,8 @@ use TypeError;
 use Optimizely\Logger\NoOpLogger;
 use Optimizely\Optimizely;
 use Optimizely\OptimizelyUserContext;
+use Optimizely\OptimizelyDecisionContext;
+use Optimizely\OptimizelyForcedDecision;
 
 class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
 {
@@ -270,13 +272,17 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $invalidOptlyObject = new Optimizely("Invalid datafile");
 
         $optUserContext = new OptimizelyUserContext($invalidOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("flag1", "targeted_delivery", "variation1");
+
+        $context = new OptimizelyDecisionContext("flag1", "targeted_delivery");
+        $decision = new OptimizelyForcedDecision("variation1");
+        
+        $setForcedDecision = $optUserContext->setForcedDecision($context, $decision);
         $this->assertFalse($setForcedDecision);
 
-        $getForcedDecision = $optUserContext->getForcedDecision("flag1", "targeted_delivery");
+        $getForcedDecision = $optUserContext->getForcedDecision($context);
         $this->assertNull($getForcedDecision);
 
-        $removeForcedDecision = $optUserContext->removeForcedDecision("flag1", "targeted_delivery");
+        $removeForcedDecision = $optUserContext->removeForcedDecision($context);
         $this->assertFalse($removeForcedDecision);
 
         $removeAllForcedDecision = $optUserContext->removeAllForcedDecisions();
@@ -291,13 +297,17 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("flag1", "targeted_delivery", "variation1");
+
+        $context = new OptimizelyDecisionContext("flag1", "targeted_delivery");
+        $decision = new OptimizelyForcedDecision("variation1");
+
+        $setForcedDecision = $optUserContext->setForcedDecision($context, $decision);
         $this->assertTrue($setForcedDecision);
 
-        $getForcedDecision = $optUserContext->getForcedDecision("flag1", "targeted_delivery");
+        $getForcedDecision = $optUserContext->getForcedDecision($context);
         $this->assertEquals($getForcedDecision, "variation1");
 
-        $removeForcedDecision = $optUserContext->removeForcedDecision("flag1", "targeted_delivery");
+        $removeForcedDecision = $optUserContext->removeForcedDecision($context);
         $this->assertTrue($removeForcedDecision);
 
         $removeAllForcedDecision = $optUserContext->removeAllForcedDecisions();
@@ -312,10 +322,14 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("boolean_single_variable_feature", null, "177773");
+
+        $context = new OptimizelyDecisionContext("boolean_single_variable_feature", null);
+        $decision = new OptimizelyForcedDecision("177773");
+
+        $setForcedDecision = $optUserContext->setForcedDecision($context, $decision);
         $this->assertTrue($setForcedDecision);
 
-        $getForcedDecision = $optUserContext->getForcedDecision("boolean_single_variable_feature");
+        $getForcedDecision = $optUserContext->getForcedDecision($context);
         $this->assertEquals($getForcedDecision, "177773");
 
         $decision = $optUserContext->decide('boolean_single_variable_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -331,7 +345,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         ]);
 
         // Removing forced decision to test
-        $removeForcedDecision = $optUserContext->removeForcedDecision("boolean_single_variable_feature");
+        $removeForcedDecision = $optUserContext->removeForcedDecision($context);
         $this->assertTrue($removeForcedDecision);
 
         $decision = $optUserContext->decide('boolean_single_variable_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -362,10 +376,14 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("boolean_feature", "test_experiment_2", "test_variation_1");
+
+        $context = new OptimizelyDecisionContext("boolean_feature", 'test_experiment_2');
+        $decision = new OptimizelyForcedDecision("test_variation_1");
+
+        $setForcedDecision = $optUserContext->setForcedDecision($context, $decision);
         $this->assertTrue($setForcedDecision);
 
-        $getForcedDecision = $optUserContext->getForcedDecision("boolean_feature", "test_experiment_2");
+        $getForcedDecision = $optUserContext->getForcedDecision($context);
         $this->assertEquals($getForcedDecision, "test_variation_1");
 
         $decision = $optUserContext->decide('boolean_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -382,7 +400,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         ]);
 
         // Removing forced decision to test
-        $removeForcedDecision = $optUserContext->removeForcedDecision("boolean_feature", "test_experiment_2");
+        $removeForcedDecision = $optUserContext->removeForcedDecision($context);
         $this->assertTrue($removeForcedDecision);
 
         $decision = $optUserContext->decide('boolean_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -407,10 +425,14 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("boolean_single_variable_feature", "rollout_1_exp_3", "177773");
+        
+        $context = new OptimizelyDecisionContext("boolean_single_variable_feature", "rollout_1_exp_3");
+        $decision = new OptimizelyForcedDecision("177773");
+
+        $setForcedDecision = $optUserContext->setForcedDecision($context, $decision);
         $this->assertTrue($setForcedDecision);
 
-        $getForcedDecision = $optUserContext->getForcedDecision("boolean_single_variable_feature", "rollout_1_exp_3");
+        $getForcedDecision = $optUserContext->getForcedDecision($context);
         $this->assertEquals($getForcedDecision, "177773");
 
         $decision = $optUserContext->decide('boolean_single_variable_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -432,7 +454,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         ]);
 
         // Removing forced decision to test
-        $removeForcedDecision = $optUserContext->removeForcedDecision("boolean_single_variable_feature", "rollout_1_exp_3");
+        $removeForcedDecision = $optUserContext->removeForcedDecision($context);
         $this->assertTrue($removeForcedDecision);
 
         $decision = $optUserContext->decide('boolean_single_variable_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -464,7 +486,9 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("boolean_single_variable_feature", "rollout_1_exp_3", "invalid");
+        $context = new OptimizelyDecisionContext("boolean_single_variable_feature", "rollout_1_exp_3");
+        $decision = new OptimizelyForcedDecision("invalid");
+        $setForcedDecision = $optUserContext->setForcedDecision($context, $decision);
         $this->assertTrue($setForcedDecision);
 
         $decision = $optUserContext->decide('boolean_single_variable_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -497,7 +521,9 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision = $optUserContext->setForcedDecision("boolean_feature", null, "invalid");
+        $context = new OptimizelyDecisionContext("boolean_feature", null);
+        $decision = new OptimizelyForcedDecision("invalid");
+        $setForcedDecision = $optUserContext->setForcedDecision($context, $decision);
         $this->assertTrue($setForcedDecision);
 
         $decision = $optUserContext->decide('boolean_feature', [OptimizelyDecideOption::INCLUDE_REASONS]);
@@ -525,10 +551,14 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $setForcedDecision1 = $optUserContext->setForcedDecision($featureKey, null, "test_variation_1");
+        $context = new OptimizelyDecisionContext($featureKey, null);
+        $decision = new OptimizelyForcedDecision("test_variation_1");
+        $setForcedDecision1 = $optUserContext->setForcedDecision($context, $decision);
         $this->assertTrue($setForcedDecision1);
 
-        $setForcedDecision2 = $optUserContext->setForcedDecision($featureKey, "test_experiment_2", "test_variation_2");
+        $context = new OptimizelyDecisionContext($featureKey, "test_experiment_2");
+        $decision = new OptimizelyForcedDecision("test_variation_2");
+        $setForcedDecision2 = $optUserContext->setForcedDecision($context, $decision);
         $this->assertTrue($setForcedDecision2);
 
         // flag-to-decision is the 1st priority
@@ -551,19 +581,27 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, null, "test_variation_1"));
-        $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($featureKey));
+        $contextWithNullRuleKey = new OptimizelyDecisionContext($featureKey, null);
+        $decision = new OptimizelyForcedDecision("test_variation_1");
+        $this->assertTrue($optUserContext->setForcedDecision($contextWithNullRuleKey, $decision));
+        $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($contextWithNullRuleKey));
 
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, null, "test_variation_2"));
-        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey));
+        $context = new OptimizelyDecisionContext($featureKey, null);
+        $decision = new OptimizelyForcedDecision("test_variation_2");
+        $this->assertTrue($optUserContext->setForcedDecision($context, $decision));
+        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($context));
 
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_experiment_2", "test_variation_1"));
-        $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
+        $context = new OptimizelyDecisionContext($featureKey, "test_experiment_2");
+        $decision = new OptimizelyForcedDecision("test_variation_1");
+        $this->assertTrue($optUserContext->setForcedDecision($context, $decision));
+        $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($context));
 
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_experiment_2", "test_variation_2"));
-        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
+        $context = new OptimizelyDecisionContext($featureKey, "test_experiment_2");
+        $decision = new OptimizelyForcedDecision("test_variation_2");
+        $this->assertTrue($optUserContext->setForcedDecision($context, $decision));
+        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($context));
 
-        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey));
+        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($contextWithNullRuleKey));
     }
 
     public function testRemoveForcedDecision()
@@ -575,21 +613,25 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, null, "test_variation_1"));
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_experiment_2", "test_variation_2"));
+        $contextWithFlag = new OptimizelyDecisionContext($featureKey, null);
+        $decisionForFlag = new OptimizelyForcedDecision("test_variation_1");
+        $contextWithRule = new OptimizelyDecisionContext($featureKey, "test_experiment_2");
+        $decisionForRule = new OptimizelyForcedDecision("test_variation_2");
+        $this->assertTrue($optUserContext->setForcedDecision($contextWithFlag, $decisionForFlag));
+        $this->assertTrue($optUserContext->setForcedDecision($contextWithRule, $decisionForRule));
 
-        $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($featureKey));
-        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
+        $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($contextWithFlag));
+        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($contextWithRule));
 
-        $this->assertTrue($optUserContext->removeForcedDecision($featureKey));
-        $this->assertNull($optUserContext->getForcedDecision($featureKey));
-        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
+        $this->assertTrue($optUserContext->removeForcedDecision($contextWithFlag));
+        $this->assertNull($optUserContext->getForcedDecision($contextWithFlag));
+        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($contextWithRule));
 
-        $this->assertTrue($optUserContext->removeForcedDecision($featureKey, "test_experiment_2"));
-        $this->assertNull($optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
-        $this->assertNull($optUserContext->getForcedDecision($featureKey));
+        $this->assertTrue($optUserContext->removeForcedDecision($contextWithRule));
+        $this->assertNull($optUserContext->getForcedDecision($contextWithRule));
+        $this->assertNull($optUserContext->getForcedDecision($contextWithFlag));
 
-        $this->assertFalse($optUserContext->removeForcedDecision($featureKey));  // no more saved decisions
+        $this->assertFalse($optUserContext->removeForcedDecision($contextWithFlag));  // no more saved decisions
     }
 
     public function testRemoveAllForcedDecisions()
@@ -603,15 +645,19 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
         $this->assertTrue($optUserContext->removeAllForcedDecisions()); // no saved decisions
 
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, null, "test_variation_1"));
-        $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_experiment_2", "test_variation_2"));
+        $contextWithFlag = new OptimizelyDecisionContext($featureKey, null);
+        $decisionForFlag = new OptimizelyForcedDecision("test_variation_1");
+        $contextWithRule = new OptimizelyDecisionContext($featureKey, "test_experiment_2");
+        $decisionForRule = new OptimizelyForcedDecision("test_variation_2");
+        $this->assertTrue($optUserContext->setForcedDecision($contextWithFlag, $decisionForFlag));
+        $this->assertTrue($optUserContext->setForcedDecision($contextWithRule, $decisionForRule));
 
-        $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($featureKey));
-        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
+        $this->assertEquals("test_variation_1", $optUserContext->getForcedDecision($contextWithFlag));
+        $this->assertEquals("test_variation_2", $optUserContext->getForcedDecision($contextWithRule));
 
         $this->assertTrue($optUserContext->removeAllForcedDecisions());
-        $this->assertNull($optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
-        $this->assertNull($optUserContext->getForcedDecision($featureKey));
+        $this->assertNull($optUserContext->getForcedDecision($contextWithRule));
+        $this->assertNull($optUserContext->getForcedDecision($contextWithFlag));
 
         $this->assertTrue($optUserContext->removeAllForcedDecisions()); // no more saved decisions
     }

--- a/tests/OptimizelyUserContextTest.php
+++ b/tests/OptimizelyUserContextTest.php
@@ -279,7 +279,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $removeForcedDecision = $optUserContext->removeForcedDecision("flag1", "targeted_delivery");
         $this->assertFalse($removeForcedDecision);
 
-        $removeAllForcedDecision = $optUserContext->removeAllForcedDecisions("flag1", "targeted_delivery");
+        $removeAllForcedDecision = $optUserContext->removeAllForcedDecisions();
         $this->assertFalse($removeAllForcedDecision);
     }
 
@@ -301,7 +301,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($removeForcedDecision);
 
         $removeAllForcedDecision = $optUserContext->removeAllForcedDecisions();
-        $this->assertFalse($removeAllForcedDecision);
+        $this->assertTrue($removeAllForcedDecision);
     }
 
     public function testForcedDecisionFlagToDecision()
@@ -549,7 +549,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $validOptlyObject = new Optimizely($this->datafile);
 
         $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
-        $this->assertFalse($optUserContext->removeAllForcedDecisions()); // no saved decisions
+        $this->assertTrue($optUserContext->removeAllForcedDecisions()); // no saved decisions
 
         $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_variation_1"));
         $this->assertTrue($optUserContext->setForcedDecision($featureKey, "test_variation_2", "test_experiment_2"));
@@ -561,7 +561,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($optUserContext->getForcedDecision($featureKey, "test_experiment_2"));
         $this->assertNull($optUserContext->getForcedDecision($featureKey));
 
-        $this->assertFalse($optUserContext->removeAllForcedDecisions()); // no more saved decisions
+        $this->assertTrue($optUserContext->removeAllForcedDecisions()); // no more saved decisions
     }
 }
 

--- a/tests/OptimizelyUserContextTest.php
+++ b/tests/OptimizelyUserContextTest.php
@@ -564,4 +564,3 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($optUserContext->removeAllForcedDecisions()); // no more saved decisions
     }
 }
-

--- a/tests/OptimizelyUserContextTest.php
+++ b/tests/OptimizelyUserContextTest.php
@@ -340,8 +340,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($decision->getUserContext()->getAttributes()), 1);
         $this->assertEquals($decision->getReasons(), []);
     }
-
-    public function testForcedDecisionRuleToDecision()
+    public function testForcedDecisionExperimentRuleToDecision()
     {
         $userId = 'test_user';
         $attributes = [ "browser" => "chrome"];
@@ -373,6 +372,42 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($decision->getRuleKey(), "test_experiment_2");
         $this->assertTrue($decision->getEnabled());
         $this->assertEquals($decision->getFlagKey(), "boolean_feature");
+        $this->assertEquals($decision->getUserContext()->getUserId(), $userId);
+        $this->assertEquals(count($decision->getUserContext()->getAttributes()), 1);
+        $this->assertEquals($decision->getReasons(), []);
+    }
+    public function testForcedDecisionRuleDeliveryRuleToDecision()
+    {
+        $userId = 'test_user';
+        $attributes = [ "browser" => "chrome"];
+
+        $validOptlyObject = new Optimizely($this->datafile);
+
+        $optUserContext = new OptimizelyUserContext($validOptlyObject, $userId, $attributes);
+        $setForcedDecision = $optUserContext->setForcedDecision("boolean_single_variable_feature", "rollout_1_exp_3", "177773");
+        $this->assertTrue($setForcedDecision);
+
+        $getForcedDecision = $optUserContext->getForcedDecision("boolean_single_variable_feature", "rollout_1_exp_3");
+        $this->assertEquals($getForcedDecision, "177773");
+
+        $decision = $optUserContext->decide('boolean_single_variable_feature');
+        $this->assertEquals($decision->getVariationKey(), "177773");
+        $this->assertEquals($decision->getRuleKey(), "rollout_1_exp_3");
+        $this->assertTrue($decision->getEnabled());
+        $this->assertEquals($decision->getFlagKey(), "boolean_single_variable_feature");
+        $this->assertEquals($decision->getUserContext()->getUserId(), $userId);
+        $this->assertEquals(count($decision->getUserContext()->getAttributes()), 1);
+        $this->assertEquals($decision->getReasons(), []);
+
+        // Removing forced decision to test
+        $removeForcedDecision = $optUserContext->removeForcedDecision("boolean_single_variable_feature", "rollout_1_exp_3");
+        $this->assertTrue($removeForcedDecision);
+
+        $decision = $optUserContext->decide('boolean_single_variable_feature');
+        $this->assertEquals($decision->getVariationKey(), "177778");
+        $this->assertEquals($decision->getRuleKey(), "rollout_1_exp_3");
+        $this->assertTrue($decision->getEnabled());
+        $this->assertEquals($decision->getFlagKey(), "boolean_single_variable_feature");
         $this->assertEquals($decision->getUserContext()->getUserId(), $userId);
         $this->assertEquals(count($decision->getUserContext()->getAttributes()), 1);
         $this->assertEquals($decision->getReasons(), []);
@@ -432,7 +467,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
             'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_2" and user "test_user" in the forced decision map.',
             'Audiences for rule 2 collectively evaluated to FALSE.',
             'User "test_user" does not meet conditions for targeting rule "2".',
-            'Variation "invalid" is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "test_user" in the forced decision map.',
+            'Invalid variation is mapped to flag "boolean_single_variable_feature", rule "rollout_1_exp_3" and user "test_user" in the forced decision map.',
             'Audiences for rule Everyone Else collectively evaluated to TRUE.',
             'User "test_user" meets condition for targeting rule "Everyone Else".',
             'Assigned bucket 3041 to user "test_user" with bucketing ID "test_user".',

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -455,6 +455,21 @@ define(
   "version": "4",
   "audiences": [
     {
+		"id": "20803170009",
+		"conditions": "[\"and\", [\"or\", [\"or\", {\"match\": \"exact\", \"name\": \"device_type\", \"type\": \"custom_attribute\", \"value\": \"def\"}]]]",
+		"name": "aud2"
+	},
+	{
+		"id": "20787080332",
+		"conditions": "[\"and\", [\"or\", [\"or\", {\"match\": \"exact\", \"name\": \"device_type\", \"type\": \"custom_attribute\", \"value\": \"abc\"}]]]",
+		"name": "aud1"
+	},
+	{
+		"id": "20778250294",
+		"conditions": "[\"and\", [\"or\", [\"or\", {\"match\": \"exact\", \"name\": \"device_type\", \"type\": \"custom_attribute\", \"value\": \"ga\"}]]]",
+		"name": "aud"
+	},
+    {
       "conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"device_type\", \"type\": \"custom_attribute\", \"value\": \"iPhone\"}]], [\"or\", [\"or\", {\"name\": \"location\", \"type\": \"custom_attribute\", \"value\": \"San Francisco\"}]]]",
       "id": "7718080042",
       "name": "iPhone users in San Francisco"
@@ -759,6 +774,13 @@ define(
       ]
     },
     {
+		"experimentIds": [],
+		"rolloutId": "rollout-5969-20778120250",
+		"variables": [],
+		"id": "5969",
+		"key": "same_variation_flag"
+	},
+    {
       "id": "155559",
       "key": "multi_variate_feature",
       "rolloutId": "",
@@ -899,6 +921,82 @@ define(
         }
       ]
     },
+    {
+		"experiments": [{
+			"status": "Running",
+			"audienceConditions": ["or", "20778250294"],
+			"audienceIds": ["20778250294"],
+			"variations": [{
+				"variables": [],
+				"id": "16421",
+				"key": "new_variation",
+				"featureEnabled": true
+			}],
+			"forcedVariations": {},
+			"key": "flag1_targeted_delivery",
+			"layerId": "9300000018514",
+			"trafficAllocation": [{
+				"entityId": "16421",
+				"endOfRange": 10000
+			}],
+			"id": "9300000018548"
+		}, {
+			"status": "Running",
+			"audienceConditions": ["or", "20803170009"],
+			"audienceIds": ["20803170009"],
+			"variations": [{
+				"variables": [],
+				"id": "16421",
+				"key": "new_variation",
+				"featureEnabled": true
+			}],
+			"forcedVariations": {},
+			"key": "flag1_targeted_delivery2",
+			"layerId": "9300000018515",
+			"trafficAllocation": [{
+				"entityId": "16421",
+				"endOfRange": 10000
+			}],
+			"id": "9300000018549"
+		}, {
+			"status": "Running",
+			"audienceConditions": ["or", "20787080332"],
+			"audienceIds": ["20787080332"],
+			"variations": [{
+				"variables": [],
+				"id": "16421",
+				"key": "new_variation",
+				"featureEnabled": true
+			}],
+			"forcedVariations": {},
+			"key": "flag1_targeted_delivery3",
+			"layerId": "9300000018516",
+			"trafficAllocation": [{
+				"entityId": "16421",
+				"endOfRange": 10000
+			}],
+			"id": "9300000018550"
+		}, {
+			"status": "Running",
+			"audienceConditions": [],
+			"audienceIds": [],
+			"variations": [{
+				"variables": [],
+				"id": "16419",
+				"key": "off",
+				"featureEnabled": false
+			}],
+			"forcedVariations": {},
+			"key": "default-rollout-5969-20778120250",
+			"layerId": "default-layer-rollout-5969-20778120250",
+			"trafficAllocation": [{
+				"entityId": "16419",
+				"endOfRange": 10000
+			}],
+			"id": "default-rollout-5969-20778120250"
+		}],
+		"id": "rollout-5969-20778120250"
+	},
     {
       "id": "166661",
       "experiments": [


### PR DESCRIPTION
## Summary
Add a set of new APIs for forced-decisions to OptimizelyUserContext:
- setForcedDecision
- getForcedDecision
- removeForcedDecision
- removeAllForcedDecision

## Test plan
- unit tests for the new APIs
- FSC tests with new test cases
