### PR TITLE
chore: Removed Monolog version restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - '7.1'
   - '7.2'
   - '7.3.24' # revert it back to 7.3 once 7.3.25 latest build gets fixed.
-  - '7.4'
 install: "composer install"
 script:
 - mkdir -p build/logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - '7.1'
   - '7.2'
   - '7.3.24' # revert it back to 7.3 once 7.3.25 latest build gets fixed.
+  - '7.4'
 install: "composer install"
 script:
 - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "beautify": "phpcbf"
   },
   "require": {
-    "php": ">=7.4",
+    "php": ">=5.5",
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
     "lastguest/murmurhash": "1.3.0",
     "guzzlehttp/guzzle": "~6.2",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
     "lastguest/murmurhash": "1.3.0",
     "guzzlehttp/guzzle": "~6.2",
-    "monolog/monolog": "=2.0.0"
+    "monolog/monolog": ">=1.21"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=5.5",
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
     "lastguest/murmurhash": "1.3.0",
-    "guzzlehttp/guzzle": "~6.2",
+    "guzzlehttp/guzzle": ">=6.2",
     "monolog/monolog": ">=1.21"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         "beautify": "phpcbf"
   },
   "require": {
-    "php": ">=5.5",
+    "php": ">=7.4",
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
     "lastguest/murmurhash": "1.3.0",
     "guzzlehttp/guzzle": "~6.2",
-    "monolog/monolog": "~1.21"
+    "monolog/monolog": "=2.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",


### PR DESCRIPTION
## Summary
- Monolog and guzzlehttp/guzzle version restriction removed.

## Test plan
All Existing unit and Integration tests pass
