### PR TITLE
FIX: Forced variation not available in experiment

### DIFF
--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -256,7 +256,7 @@ class EventBuilder
         $variation = $config->getVariationFromKeyByExperimentId($experimentId, $variationKey);
 
         // Mapped flagKey can be directly used in variation in that case no experimentKey exist
-        if ($variation && !$variation->getKey()){
+        if ($variation && !$variation->getKey()) {
             $variation = $config->getFlagVariationByKey($flagKey, $variationKey);
         }
         $impressionParams = $this->getImpressionParams($experiment, $variation, $flagKey, $ruleKey, $ruleType, $enabled);

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -252,11 +252,14 @@ class EventBuilder
         $eventParams = $this->getCommonParams($config, $userId, $attributes);
         $experiment = $config->getExperimentFromId($experimentId);
 
+        $variation = "";
         // Mapped flagKey can be directly used in variation in that case no experimentKey exist
-        $variation = $config->getFlagVariationByKey($flagKey, $variationKey);
-
+        if (!empty($flagKey)) {
+            $variation = $config->getFlagVariationByKey($flagKey, $variationKey);
+        }
+        
         // When variation is not mapped to any flagKey
-        if (!$variation) {
+        if (!$variation && !empty($experimentId)) {
             $variation = $config->getVariationFromKeyByExperimentId($experimentId, $variationKey);
         }
 

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -255,7 +255,7 @@ class EventBuilder
         // Mapped flagKey can be directly used in variation in that case no experimentKey exist
         $variation = $config->getFlagVariationByKey($flagKey, $variationKey);
 
-        // When variation is not mapped to any flagKey 
+        // When variation is not mapped to any flagKey
         if (!$variation) {
             $variation = $config->getVariationFromKeyByExperimentId($experimentId, $variationKey);
         }

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -251,8 +251,11 @@ class EventBuilder
     {
         $eventParams = $this->getCommonParams($config, $userId, $attributes);
         $experiment = $config->getExperimentFromId($experimentId);
+
+        // Mapped flagKey can be directly used in variation in that case no experimentKey exist
         $variation = $config->getFlagVariationByKey($flagKey, $variationKey);
 
+        // When variation is not mapped to any flagKey 
         if (!$variation) {
             $variation = $config->getVariationFromKeyByExperimentId($experimentId, $variationKey);
         }

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -251,10 +251,9 @@ class EventBuilder
     {
         $eventParams = $this->getCommonParams($config, $userId, $attributes);
         $experiment = $config->getExperimentFromId($experimentId);
+        $variation = $config->getFlagVariationByKey($flagKey, $variationKey);
 
-        if (empty($experimentId)) {
-            $variation = $config->getFlagVariationByKey($flagKey, $variationKey);
-        } else {
+        if (!$variation) {
             $variation = $config->getVariationFromKeyByExperimentId($experimentId, $variationKey);
         }
 

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -252,17 +252,13 @@ class EventBuilder
         $eventParams = $this->getCommonParams($config, $userId, $attributes);
         $experiment = $config->getExperimentFromId($experimentId);
 
-        $variation = "";
+        // When variation is not mapped to any flagKey
+        $variation = $config->getVariationFromKeyByExperimentId($experimentId, $variationKey);
+
         // Mapped flagKey can be directly used in variation in that case no experimentKey exist
-        if (!empty($flagKey)) {
+        if ($variation && !$variation->getKey()){
             $variation = $config->getFlagVariationByKey($flagKey, $variationKey);
         }
-        
-        // When variation is not mapped to any flagKey
-        if (!$variation && !empty($experimentId)) {
-            $variation = $config->getVariationFromKeyByExperimentId($experimentId, $variationKey);
-        }
-
         $impressionParams = $this->getImpressionParams($experiment, $variation, $flagKey, $ruleKey, $ruleType, $enabled);
 
         $eventParams[VISITORS][0][SNAPSHOTS][] = $impressionParams;

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -157,6 +157,53 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($result[0], $result[1]);
     }
 
+    public function testCreateImpressionEventVariationFromSameFlagButDifferentExperiments()
+    {
+        $decisions = array('decisions' => [[
+            'campaign_id'=> '5',
+            'experiment_id'=> '122235',
+            'variation_id'=> '177775',
+            'metadata'=> [
+                'flag_key' => 'string_single_variable_feature',
+                'rule_key' => 'test_experiment_with_feature_rollout',
+                'rule_type' => 'experiment',
+                'variation_key'=> '177775',
+                'enabled' => true
+            ]
+          ]]
+        );
+        $this->expectedImpressionEventParams['visitors'][0]['snapshots'][0] = $decisions +
+                                                                    $this->expectedImpressionEventParams['visitors'][0]['snapshots'][0];
+        $this->expectedImpressionEventParams['visitors'][0]['snapshots'][0]['events'][0] =
+        [
+            'entity_id'=> '5',
+            'timestamp'=> $this->timestamp,
+            'uuid'=> $this->uuid,
+            'key'=> 'campaign_activated'
+        ];
+        $expectedLogEvent = new LogEvent(
+            $this->expectedEventUrl,
+            $this->expectedImpressionEventParams,
+            $this->expectedEventHttpVerb,
+            $this->expectedEventHeaders
+        );
+
+        $logEvent = $this->eventBuilder->createImpressionEvent(
+            $this->config,
+            '122235',
+            '177775',
+            'string_single_variable_feature',
+            'test_experiment_with_feature_rollout',
+            'experiment',
+            true,
+            $this->testUserId,
+            null
+        );
+        $logEvent = $this->fakeParamsToReconcile($logEvent);
+        $result = $this->areLogEventsEqual($expectedLogEvent, $logEvent);
+        $this->assertTrue($result[0], $result[1]);
+    }
+
     public function testCreateImpressionEventWithAttributesNoValue()
     {
         array_unshift(


### PR DESCRIPTION
## Summary
- Searching forced decision variation from flags first if its not available then we search it in experiment variation map. This is because of forced decision setting variation of flag delivery rule and setting rule key of experiment rule 

## Test plan
All unit test and FSC tests should pass
