### PR TITLE
refac: Moves findValidatedForcedDecision method to decision service

### DIFF
--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2021, Optimizely Inc and Contributors
+ * Copyright 2017-2022, Optimizely Inc and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -355,7 +355,7 @@ class Optimizely
         $decision = null;
         // check forced-decisions first
         $context = new OptimizelyDecisionContext($flagKey, $ruleKey);
-        list($forcedDecisionResponse, $reasons) = $userContext->findValidatedForcedDecision($context);
+        list($forcedDecisionResponse, $reasons) = $this->_decisionService->findValidatedForcedDecision($context, $config, $userContext);
         if ($forcedDecisionResponse) {
             $decision = new FeatureDecision(null, $forcedDecisionResponse, FeatureDecision::DECISION_SOURCE_FEATURE_TEST, $decideReasons);
         } else {
@@ -1304,18 +1304,5 @@ class Optimizely
         }
 
         return $isValid;
-    }
-
-    /**
-     * Gets the variation associated with experiment or rollout in instance of given feature flag key
-     *
-     * @param string Feature flag key
-     * @param string variation key
-     *
-     * @return Variation / null
-     */
-    public function getFlagVariationByKey($flagKey, $variationKey)
-    {
-        return $this->getConfig()->getFlagVariationByKey($flagKey, $variationKey);
     }
 }

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2021, Optimizely
+ * Copyright 2016-2022, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -74,25 +74,6 @@ class OptimizelyUserContext implements \JsonSerializable
         return true;
     }
 
-    public function findValidatedForcedDecision($context)
-    {
-        $decideReasons = [];
-        $flagKey = $context->getFlagKey();
-        $ruleKey = $context->getRuleKey();
-        $variationKey = $this->findForcedDecision($context);
-        $variation = null;
-        if ($variationKey) {
-            $variation = $this->optimizelyClient->getFlagVariationByKey($flagKey, $variationKey);
-            if ($variation) {
-                array_push($decideReasons, 'Decided by forced decision.');
-                array_push($decideReasons, sprintf('Variation (%s) is mapped to %s and user (%s) in the forced decision map.', $variationKey, $ruleKey? 'flag ('.$flagKey.'), rule ('.$ruleKey.')': 'flag ('.$flagKey.')', $this->userId));
-            } else {
-                array_push($decideReasons, sprintf('Invalid variation is mapped to %s and user (%s) in the forced decision map.', $ruleKey? 'flag ('.$flagKey.'), rule ('.$ruleKey.')': 'flag ('.$flagKey.')', $this->userId));
-            }
-        }
-        return [$variation, $decideReasons];
-    }
-
     private function findExistingRuleAndFlagKey($context)
     {
         if ($this->forcedDecisions) {

--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2021, Optimizely
+ * Copyright 2021-2022, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Removed getFlagVariationByKey from optimizely and using it directly from project config.
- Moved findValidatedForcedDecision method to decision service to remove cyclic dependency.

## Test plan
All unit test and FSC tests should pass.