### PR TITLE
Suppress jsonSerialize deprecation notice for php 8.1+

### DIFF
--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -147,6 +147,7 @@ class OptimizelyUserContext implements \JsonSerializable
         return $this->optimizelyClient;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
## Summary
Since php 8.1 internal functions are using proper return types. This results in deprecation notices for some of the methods. To  suppress the notice for php8.1+ the proper return type or the new `ReturnTypeWillChange` attribute needs to be added to the method in question. If extending a class or implementing an interface (like `JsonSerializable `), the return type or attribute needs to be added as well. For more info check out https://stitcher.io/blog/new-in-php-81#interal-method-return-types-rfc