### PR TITLE
HTTPProjectConfigManager: datafile should be a string

### DIFF
--- a/src/Optimizely/ProjectConfigManager/HTTPProjectConfigManager.php
+++ b/src/Optimizely/ProjectConfigManager/HTTPProjectConfigManager.php
@@ -211,7 +211,7 @@ class HTTPProjectConfigManager implements ProjectConfigManagerInterface
                 $this->_lastModifiedSince = $response->getHeader(ProjectConfigManagerConstants::LAST_MODIFIED)[0];
             }
 
-            $datafile = $response->getBody();
+            $datafile = $response->getBody()->getContents();
 
             if ($this->handleResponse($datafile) === true) {
                 return $datafile;


### PR DESCRIPTION


## Summary
- By using `->getContents()` the actual string is returned instead of a Guzzle Stream object. The interface uses string everywhere.


