### PR TITLE
Only for testing purpose for pr-243

### DIFF
--- a/src/Optimizely/ProjectConfigManager/HTTPProjectConfigManager.php
+++ b/src/Optimizely/ProjectConfigManager/HTTPProjectConfigManager.php
@@ -211,7 +211,7 @@ class HTTPProjectConfigManager implements ProjectConfigManagerInterface
                 $this->_lastModifiedSince = $response->getHeader(ProjectConfigManagerConstants::LAST_MODIFIED)[0];
             }
 
-            $datafile = $response->getBody();
+            $datafile = $response->getBody()->getContents();
 
             if ($this->handleResponse($datafile) === true) {
                 return $datafile;


### PR DESCRIPTION
By using `->getContents()` the actual string is returned instead of a Guzzle Stream object. The interface uses string everywhere.

## Summary
- The "what"; a concise description of each logical change
- Another change

The "why", or other context.

## Test plan

## Issues
- "THING-1234" or "Fixes #123"
