### PR TITLE
fix(docs): Return type should be ProjectConfigInterface

### DIFF
--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -453,7 +453,7 @@ class DatafileProjectConfig implements ProjectConfigInterface
      * @param bool                  $skipJsonValidation boolean representing whether JSON schema validation needs to be performed.
      * @param LoggerInterface       $logger             Logger instance
      * @param ErrorHandlerInterface $errorHandler       ErrorHandler instance.
-     * @return ProjectConfig ProjectConfig instance or null;
+     * @return ProjectConfigInterface ProjectConfig instance or null;
      */
     public static function createProjectConfigFromDatafile($datafile, $skipJsonValidation, $logger, $errorHandler)
     {


### PR DESCRIPTION
## Background
This PR is copied from PR-240 contributed by @adri, Since that PR is closed by the contributor so adding this PR.

## Summary
- ProjectConfigInterface is the one used across SDK.

## Test plan
- All test must pass.
