### PR TITLE
Add proper return type to user context json serialize

### DIFF
--- a/src/Optimizely/OptimizelyUserContext.php
+++ b/src/Optimizely/OptimizelyUserContext.php
@@ -147,6 +147,9 @@ class OptimizelyUserContext implements \JsonSerializable
         return $this->optimizelyClient;
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {


### PR DESCRIPTION
## Summary
The following indirect deprecation notice is popping up when calling OptimizelyUserContext::jsonSerialize in php 8+:

```
1x: Method "JsonSerializable::jsonSerialize()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Optimizely\OptimizelyUserContext" now to avoid errors or add an explicit @return annotation to suppress this message.
```

To remove the notice, the proper return type is added.
