### PR TITLE
fix: avoid deprecation notices in php 8.1 when passing null to strlen

### DIFF
--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -510,7 +510,7 @@ class DecisionService
         $experimentId = $projectConfig->getExperimentFromKey($experimentKey)->getId();
 
         // check for null and empty string experiment ID
-        if (strlen($experimentId) == 0) {
+        if (strlen((string)$experimentId) == 0) {
             // this case is logged in getExperimentFromKey
             return [ null, $decideReasons];
         }
@@ -554,7 +554,7 @@ class DecisionService
         $experimentId = $experiment->getId();
 
         // check if the experiment exists in the datafile (a new experiment is returned if it is not in the datafile)
-        if (strlen($experimentId) == 0) {
+        if (strlen((string)$experimentId) == 0) {
             // this case is logged in getExperimentFromKey
             return false;
         }
@@ -570,7 +570,7 @@ class DecisionService
         $variationId = $variation->getId();
 
         // check if the variation exists in the datafile (a new variation is returned if it is not in the datafile)
-        if (strlen($variationId) == 0) {
+        if (strlen((string)$variationId) == 0) {
             // this case is logged in getVariationFromKey
             return false;
         }


### PR DESCRIPTION
The following deprecation notice is popping up in conjunction with php 8.1 when calling `$optimizelyClient->setForcedVariation(...);` and the experiment is not active for the related environment.

> PHP Deprecated:  strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /path/to/project/vendor/optimizely/optimizely-sdk/src/Optimizely/DecisionService/DecisionService.php on line 557

In order to fix this it is necessary to cast `$experimentId` and `$variationId` to string when passing them to `strlen(...)` function in `Optimizely\DecisionService\DecisionService::setForcedVariation` method.

Detailed infos about the deprecation notice can be found here: https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation