### PR TITLE
Fix faulty return type hint.

### DIFF
--- a/src/Optimizely/UserProfile/UserProfileServiceInterface.php
+++ b/src/Optimizely/UserProfile/UserProfileServiceInterface.php
@@ -23,7 +23,7 @@ interface UserProfileServiceInterface
      *
      * @param $userId      string The ID of the user whose profile will be retrieved.
      *
-     * @return userProfile array  The user profile.
+     * @return array  The user profile.
      */
     public function lookup($userId);
 


### PR DESCRIPTION
## Summary
- Fixes faultu return type hint which leads to PHPStan reporting following error:
```
Return type (array<int, mixed>|null) of method App\UserProfileService::lookup()
should be compatible with return type (Optimizely\UserProfile\userProfile) of
method Optimizely\UserProfile\UserProfileServiceInterface::lookup()
```
