### PR TITLE
[FSSDK-8972] Run test cases in PHP v8.2 

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3' ]
+        php-versions: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '8.2' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up PHP ${{ matrix.ruby }}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",
-    "php-coveralls/php-coveralls": "v2.3.0",
+    "php-coveralls/php-coveralls": "v2.4.0",
     "squizlabs/php_codesniffer": "3.*",
     "icecave/parity": "^1.0 || ^2.0"
   },


### PR DESCRIPTION
## Summary
- Check if testcases pass for php version 8.2, hence concluding it supports php version 8.2

## Test plan
- No changes here

## Issues
- https://jira.sso.episerver.net/browse/FSSDK-8972
