### PR TITLE
[FSSDK-9022] Update to support PHP 8.x

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -64,6 +64,7 @@ jobs:
           php_version: ${{ matrix.php-versions }}
           memory_limit: 256M
           coverage_clover: ./build/logs/clover.xml
+          bootstrap: phpunit_bootstrap.php
       - name: Verify clover.xml created
         run: |
           if [ ! -f ./build/logs/clover.xml ]; then

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -51,13 +51,13 @@ jobs:
             ${{ runner.os }}-php-
       - name: Install dependencies
         run: composer install
-      - name: run tests
+      - name: Run tests
         run: |
-          mkdir -p build/logs
-          ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+          mkdir -p ./build/logs
+          ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml
       - name: Upload coverage results to Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer global require php-coveralls/php-coveralls
-          php-coveralls --coverage_clover=build/logs/clover.xml -v
+          php-coveralls --coverage_clover=./build/logs/clover.xml -v

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,53 +8,56 @@ on:
 
 jobs:
   linting:
+    name: Linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up PHP 7.0
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '7.0'
-    - name: Install php code sniffer
-      run: composer require "squizlabs/php_codesniffer=*"
-    - name: Run linting
-      run: composer lint
+      - uses: actions/checkout@v3
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install php code sniffer
+        run: composer require "squizlabs/php_codesniffer=*"
+      - name: Run linting
+        run: composer lint
 
   integration_tests:
+    name: Integration Tests
     uses: optimizely/php-sdk/.github/workflows/integration_test.yml@uzair/test-with-fsc
     secrets:
       CI_USER_TOKEN: ${{ secrets.CI_USER_TOKEN }}
       TRAVIS_COM_TOKEN: ${{ secrets.TRAVIS_COM_TOKEN }}
 
   unit_tests:
+    name: Unit Tests ${{ matrix.php-versions }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3' ]
+        php-versions: [ '8.0', '8.1', '8.2' ]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up PHP ${{ matrix.ruby }}
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v3
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
-    - name: Install dependencies
-      run: composer install
-    - name: run tests
-      run: |
-        mkdir -p build/logs
-        ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-    - name: Upload coverage results to Coveralls
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        composer global require php-coveralls/php-coveralls
-        php-coveralls --coverage_clover=build/logs/clover.xml -v
+      - uses: actions/checkout@v3
+      - name: Set up PHP v${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+      - name: Install dependencies
+        run: composer install
+      - name: run tests
+        run: |
+          mkdir -p build/logs
+          ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+      - name: Upload coverage results to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          composer global require php-coveralls/php-coveralls
+          php-coveralls --coverage_clover=build/logs/clover.xml -v

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -51,20 +51,10 @@ jobs:
             ${{ runner.os }}-php-
       - name: Install dependencies
         run: composer install
-      - name: Create build/logs directory
-        run: mkdir -p ./build/logs
-      - name: Run unit tests
-        uses: php-actions/phpunit@v3
-        env:
-          XDEBUG_MODE: coverage
-        with:
-          configuration: phpunit.xml
-          php_extensions: xdebug
-          version: 8.5
-          php_version: ${{ matrix.php-versions }}
-          memory_limit: 256M
-          coverage_clover: ./build/logs/clover.xml
-          bootstrap: phpunit_bootstrap.php
+      - name: Run tests
+        run: |
+          mkdir -p ./build/logs
+          ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml
       - name: Verify clover.xml created
         run: |
           if [ ! -f ./build/logs/clover.xml ]; then

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,10 +58,12 @@ jobs:
         env:
           XDEBUG_MODE: coverage
         with:
-          bootstrap: vendor/autoload.php
           configuration: phpunit.xml
           php_extensions: xdebug
-          args: tests --coverage-clover ./build/logs/coverage.xml
+          version: 8.5
+          php_version: ${{ matrix.php-versions }}
+          memory_limit: 256M
+          coverage_clover: ./build/logs/clover.xml
       - name: Verify clover.xml created
         run: |
           if [ ! -f ./build/logs/clover.xml ]; then

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -51,10 +51,17 @@ jobs:
             ${{ runner.os }}-php-
       - name: Install dependencies
         run: composer install
-      - name: Run tests
-        run: |
-          mkdir -p ./build/logs
-          ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml
+      - name: Create build/logs directory
+        run: mkdir -p ./build/logs
+      - name: Run unit tests
+        uses: php-actions/phpunit@v3
+        env:
+          XDEBUG_MODE: coverage
+        with:
+          bootstrap: vendor/autoload.php
+          configuration: phpunit.xml
+          php_extensions: xdebug
+          args: tests --coverage-clover ./build/logs/coverage.xml
       - name: Verify clover.xml created
         run: |
           if [ ! -f ./build/logs/clover.xml ]; then

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -55,6 +55,12 @@ jobs:
         run: |
           mkdir -p ./build/logs
           ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml
+      - name: Verify clover.xml created
+        run: |
+          if [ ! -f ./build/logs/clover.xml ]; then
+            echo "clover.xml was not created"
+            exit 1
+          fi
       - name: Upload coverage results to Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 vendor/
 composer.lock
 composer.phar
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,16 @@
         "beautify": "phpcbf"
   },
   "require": {
-    "php": ">=5.5",
+    "php": ">=8.0",
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
-    "lastguest/murmurhash": "1.3.0",
+    "lastguest/murmurhash": "^2.1.1",
     "guzzlehttp/guzzle": ">=6.2",
     "monolog/monolog": ">=1.21"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8|^5.0",
-    "php-coveralls/php-coveralls": "v2.3.0",
-    "squizlabs/php_codesniffer": "3.*",
+    "phpunit/phpunit": "^9.0",
+    "php-coveralls/php-coveralls": "v2.5.3",
+    "squizlabs/php_codesniffer": "3.7",
     "icecave/parity": "^1.0 || ^2.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "monolog/monolog": ">=1.21"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0",
+    "phpunit/phpunit": "^9.3",
     "php-coveralls/php-coveralls": "v2.5.3",
     "squizlabs/php_codesniffer": "3.7",
     "icecave/parity": "^3.0.1"

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
   "require": {
     "php": ">=8.0",
     "justinrainbow/json-schema": "^1.6 || ^2.0 || ^4.0 || ^5.0",
-    "lastguest/murmurhash": "^2.1.1",
+    "lastguest/murmurhash": "^1.3.0",
     "guzzlehttp/guzzle": ">=6.2",
     "monolog/monolog": ">=1.21"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^8.0",
     "php-coveralls/php-coveralls": "v2.5.3",
     "squizlabs/php_codesniffer": "3.7",
-    "icecave/parity": "^1.0 || ^2.0"
+    "icecave/parity": "^3.0.1"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,12 @@
 <phpunit
         colors="true"
         stderr="true"
+        beStrictAboutTestsThatDoNotTestAnything="false"
         convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
         stopOnFailure="false"
-        bootstrap="vendor/autoload.php">
+        bootstrap="phpunit_bootstrap.php">
     <testsuites>
         <testsuite name="Optimizely PHP SDK Tests">
             <directory>tests</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,4 +17,7 @@
             <directory suffix=".php">./src/Optimizely</directory>
         </whitelist>
     </filter>
+    <php>
+        <ini name="memory_limit" value="256M"/>
+    </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,8 +19,5 @@
     </filter>
     <php>
         <ini name="memory_limit" value="256M"/>
-        <ini name="xdebug.mode" value="coverage" />
-        <ini name="xdebug.client_host" value="localhost" />
-        <ini name="xdebug.client_port" value="9000" />
     </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,11 +13,14 @@
         </testsuite>
     </testsuites>
     <filter>
-        <whitelist>
-            <directory suffix=".php">./src/Optimizely</directory>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/Optimizely</directory>
         </whitelist>
     </filter>
     <php>
         <ini name="memory_limit" value="256M"/>
+        <ini name="xdebug.mode" value="coverage" />
+        <ini name="xdebug.client_host" value="localhost" />
+        <ini name="xdebug.client_port" value="9000" />
     </php>
 </phpunit>

--- a/phpunit_bootstrap.php
+++ b/phpunit_bootstrap.php
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace Optimizely\Tests;
 
 use Exception;

--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2021, Optimizely
+ * Copyright 2016-2021, 2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 namespace Optimizely;
 
+use lastguest\Murmur;
 use Monolog\Logger;
 use Optimizely\Config\ProjectConfigInterface;
 use Optimizely\Entity\Experiment;
@@ -73,7 +74,7 @@ class Bucketer
      */
     private function generateHashCode($bucketingKey)
     {
-        return murmurhash3_int($bucketingKey, Bucketer::$HASH_SEED) & Bucketer::$UNSIGNED_MAX_32_BIT_VALUE;
+        return Murmur::hash3($bucketingKey, Bucketer::$HASH_SEED) & Bucketer::$UNSIGNED_MAX_32_BIT_VALUE;
     }
 
     /**

--- a/src/Optimizely/Bucketer.php
+++ b/src/Optimizely/Bucketer.php
@@ -16,11 +16,9 @@
  */
 namespace Optimizely;
 
-use lastguest\Murmur;
 use Monolog\Logger;
 use Optimizely\Config\ProjectConfigInterface;
 use Optimizely\Entity\Experiment;
-use Optimizely\Entity\Variation;
 use Optimizely\Logger\LoggerInterface;
 
 /**
@@ -74,7 +72,7 @@ class Bucketer
      */
     private function generateHashCode($bucketingKey)
     {
-        return Murmur::hash3($bucketingKey, Bucketer::$HASH_SEED) & Bucketer::$UNSIGNED_MAX_32_BIT_VALUE;
+        return murmurhash3_int($bucketingKey, Bucketer::$HASH_SEED) & Bucketer::$UNSIGNED_MAX_32_BIT_VALUE;
     }
 
     /**

--- a/src/Optimizely/Config/DatafileProjectConfig.php
+++ b/src/Optimizely/Config/DatafileProjectConfig.php
@@ -470,8 +470,8 @@ class DatafileProjectConfig implements ProjectConfigInterface
             $config = new DatafileProjectConfig($datafile, $logger, $errorHandler);
         } catch (Exception $exception) {
             $defaultLogger = new DefaultLogger();
-            $errorMsg = $exception->getCode() == InvalidDatafileVersionException::class ? $exception->getMessage() : sprintf(Errors::INVALID_FORMAT, 'datafile');
-            $errorToHandle = $exception->getCode() == InvalidDatafileVersionException::class ? new InvalidDatafileVersionException($errorMsg) : new InvalidInputException($errorMsg);
+            $errorMsg = $exception instanceof InvalidDatafileVersionException ? $exception->getMessage() : sprintf(Errors::INVALID_FORMAT, 'datafile');
+            $errorToHandle = $exception instanceof InvalidDatafileVersionException ? new InvalidDatafileVersionException($errorMsg) : new InvalidInputException($errorMsg);
             $defaultLogger->log(Logger::ERROR, $errorMsg);
             $logger->log(Logger::ERROR, $errorMsg);
             $errorHandler->handleError($errorToHandle);

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -38,7 +38,7 @@ class BucketerTest extends \PHPUnit_Framework_TestCase
     private $config;
     private $loggerMock;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->testBucketingIdControl = 'testBucketingIdControl!';  // generates bucketing number 3741
         $this->testBucketingIdVariation = '123456789'; // generates bucketing number 4567

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2021, Optimizely
+ * Copyright 2016-2021, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,9 @@ use Optimizely\Entity\Variation;
 use Optimizely\ErrorHandler\NoOpErrorHandler;
 use Optimizely\Logger\DefaultLogger;
 use Optimizely\Logger\NoOpLogger;
+use PHPUnit\Framework\TestCase;
 
-class BucketerTest extends \PHPUnit_Framework_TestCase
+class BucketerTest extends TestCase
 {
     private $testBucketingIdControl;
     private $testBucketingIdVariation;

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -21,10 +21,8 @@ use Monolog\Logger;
 use Optimizely\Config\DatafileProjectConfig;
 use Optimizely\Bucketer;
 use Optimizely\Entity\Experiment;
-use Optimizely\Entity\Rollout;
 use Optimizely\Entity\Variation;
 use Optimizely\ErrorHandler\NoOpErrorHandler;
-use Optimizely\Logger\DefaultLogger;
 use Optimizely\Logger\NoOpLogger;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/ConfigTests/DatafileProjectConfigTest.php
+++ b/tests/ConfigTests/DatafileProjectConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2020, 2021, Optimizely
+ * Copyright 2016-2020, 2021, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,9 @@ use Optimizely\Logger\NoOpLogger;
 use Optimizely\Optimizely;
 use Optimizely\Tests\ValidEventDispatcher;
 use Optimizely\Utils\ConfigParser;
+use PHPUnit\Framework\TestCase;
 
-class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
+class DatafileProjectConfigTest extends TestCase
 {
     private $config;
     private $loggerMock;

--- a/tests/ConfigTests/DatafileProjectConfigTest.php
+++ b/tests/ConfigTests/DatafileProjectConfigTest.php
@@ -51,7 +51,7 @@ class DatafileProjectConfigTest extends \PHPUnit_Framework_TestCase
     private $loggerMock;
     private $errorHandlerMock;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         // Mock Logger
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)

--- a/tests/ConfigTests/DatafileProjectConfigTest.php
+++ b/tests/ConfigTests/DatafileProjectConfigTest.php
@@ -17,12 +17,9 @@
 
 namespace Optimizely\Config\Tests;
 
-require(dirname(__FILE__).'/../TestData.php');
-
 use Monolog\Logger;
 use Optimizely\Config\DatafileProjectConfig;
 use Optimizely\Entity\Attribute;
-use Optimizely\Entity\Audience;
 use Optimizely\Entity\Event;
 use Optimizely\Entity\Experiment;
 use Optimizely\Entity\FeatureFlag;
@@ -41,8 +38,6 @@ use Optimizely\Exceptions\InvalidRolloutException;
 use Optimizely\Exceptions\InvalidGroupException;
 use Optimizely\Exceptions\InvalidVariationException;
 use Optimizely\Logger\NoOpLogger;
-use Optimizely\Optimizely;
-use Optimizely\Tests\ValidEventDispatcher;
 use Optimizely\Utils\ConfigParser;
 use PHPUnit\Framework\TestCase;
 
@@ -474,7 +469,7 @@ class DatafileProjectConfigTest extends TestCase
     public function testExceptionThrownForUnsupportedVersion()
     {
         // Verify that an exception is thrown when given datafile version is unsupported //
-        $this->setExpectedException(
+        $this->expectException(
             InvalidDatafileVersionException::class,
             'This version of the PHP SDK does not support the given datafile version: 5.'
         );

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2021, Optimizely
+ * Copyright 2017-2021, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,9 @@ use Optimizely\Optimizely;
 use Optimizely\OptimizelyUserContext;
 use Optimizely\UserProfile\UserProfileServiceInterface;
 use Optimizely\Utils\Validator;
+use PHPUnit\Framework\TestCase;
 
-class DecisionServiceTest extends \PHPUnit_Framework_TestCase
+class DecisionServiceTest extends TestCase
 {
     private $bucketerMock;
     private $config;

--- a/tests/DecisionServiceTests/DecisionServiceTest.php
+++ b/tests/DecisionServiceTests/DecisionServiceTest.php
@@ -42,7 +42,7 @@ class DecisionServiceTest extends \PHPUnit_Framework_TestCase
     private $testUserId;
     private $userProvideServiceMock;
     private $optimizely;
-    public function setUp()
+    protected function setUp() : void
     {
         $this->testUserId = 'testUserId';
         $this->testUserIdWhitelisted = 'user1';

--- a/tests/ErrorHandlerTests/DefaultErrorHandlerTest.php
+++ b/tests/ErrorHandlerTests/DefaultErrorHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ namespace Optimizely\Tests;
 
 use Exception;
 use Optimizely\ErrorHandler\DefaultErrorHandler;
+use PHPUnit\Framework\TestCase;
 
-class DefaultErrorHandlerTest extends \PHPUnit_Framework_TestCase
+class DefaultErrorHandlerTest extends TestCase
 {
     /**
      * @expectedException Exception

--- a/tests/ErrorHandlerTests/DefaultErrorHandlerTest.php
+++ b/tests/ErrorHandlerTests/DefaultErrorHandlerTest.php
@@ -22,12 +22,10 @@ use PHPUnit\Framework\TestCase;
 
 class DefaultErrorHandlerTest extends TestCase
 {
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage Throw me please.
-     */
     public function testHandleError()
     {
+        $this->expectExceptionMessage("Throw me please.");
+        $this->expectException(Exception::class);
         $exception = new Exception('Throw me please.');
         $errorHandler = new DefaultErrorHandler();
 

--- a/tests/ErrorHandlerTests/NoOpErrorHandlerTest.php
+++ b/tests/ErrorHandlerTests/NoOpErrorHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ namespace Optimizely\Tests;
 
 use Exception;
 use Optimizely\ErrorHandler\NoOpErrorHandler;
+use PHPUnit\Framework\TestCase;
 
-class NoOpErrorHandlerTest extends \PHPUnit_Framework_TestCase
+class NoOpErrorHandlerTest extends TestCase
 {
     public function testHandleError()
     {

--- a/tests/EventTests/DefaultEventDispatcherTest.php
+++ b/tests/EventTests/DefaultEventDispatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ namespace Optimizely\Tests;
 use GuzzleHttp\Client as HttpClient;
 use Optimizely\Event\Dispatcher\DefaultEventDispatcher;
 use Optimizely\Event\LogEvent;
+use PHPUnit\Framework\TestCase;
 
-class DefaultEventDispatcherTest extends \PHPUnit_Framework_TestCase
+class DefaultEventDispatcherTest extends TestCase
 {
     public function testDispatchEvent()
     {

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -18,6 +18,7 @@
 namespace Optimizely\Tests;
 
 use Icecave\Parity\Parity;
+use PHPUnit\Framework\TestCase;
 use SebastianBergmann\Diff\Differ;
 use Optimizely\Bucketer;
 use Optimizely\Config\DatafileProjectConfig;
@@ -27,7 +28,7 @@ use Optimizely\Event\Builder\EventBuilder;
 use Optimizely\Event\LogEvent;
 use Optimizely\Logger\NoOpLogger;
 
-class EventBuilderTest extends \PHPUnit_Framework_TestCase
+class EventBuilderTest extends TestCase
 {
     private $testUserId;
     private $config;
@@ -35,7 +36,7 @@ class EventBuilderTest extends \PHPUnit_Framework_TestCase
     private $timestamp;
     private $uuid;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->testUserId = 'testUserId';
         $logger = new NoOpLogger();

--- a/tests/EventTests/LogEventTest.php
+++ b/tests/EventTests/LogEventTest.php
@@ -23,7 +23,7 @@ class LogEventTest extends \PHPUnit_Framework_TestCase
 {
     private $logEvent;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->logEvent = new LogEvent(
             'https://logx.optimizely.com',

--- a/tests/EventTests/LogEventTest.php
+++ b/tests/EventTests/LogEventTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@
 namespace Optimizely\Tests;
 
 use Optimizely\Event\LogEvent;
+use PHPUnit\Framework\TestCase;
 
-class LogEventTest extends \PHPUnit_Framework_TestCase
+class LogEventTest extends TestCase
 {
     private $logEvent;
 

--- a/tests/LoggerTests/DefaultLoggerTest.php
+++ b/tests/LoggerTests/DefaultLoggerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016,2018 Optimizely
+ * Copyright 2016, 2018, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ namespace Optimizely\Tests;
 
 use Monolog\Logger;
 use Optimizely\Logger\DefaultLogger;
+use PHPUnit\Framework\TestCase;
 
-class DefaultLoggerTest extends \PHPUnit_Framework_TestCase
+class DefaultLoggerTest extends TestCase
 {
     public function testDefaultLogger()
     {

--- a/tests/LoggerTests/NoOpLoggerTest.php
+++ b/tests/LoggerTests/NoOpLoggerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016, Optimizely
+ * Copyright 2016, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ namespace Optimizely\Tests;
 
 use Monolog\Logger;
 use Optimizely\Logger\NoOpLogger;
+use PHPUnit\Framework\TestCase;
 
-class NoOpLoggerTest extends \PHPUnit_Framework_TestCase
+class NoOpLoggerTest extends TestCase
 {
     public function testNoOpLogger()
     {

--- a/tests/NotificationTests/NotificationCenterTest.php
+++ b/tests/NotificationTests/NotificationCenterTest.php
@@ -32,7 +32,7 @@ class NotificationCenterTest extends \PHPUnit_Framework_TestCase
     private $notificationCenterObj;
     private $loggerMock;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
             ->setMethods(array('log'))

--- a/tests/NotificationTests/NotificationCenterTest.php
+++ b/tests/NotificationTests/NotificationCenterTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2019, Optimizely
+ * Copyright 2017-2019, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,9 @@ use Optimizely\Notification\NotificationCenter;
 use Optimizely\Notification\NotificationType;
 use Optimizely\Exceptions\InvalidCallbackArgumentCountException;
 use Optimizely\Exceptions\InvalidNotificationTypeException;
+use PHPUnit\Framework\TestCase;
 
-class NotificationCenterTest extends \PHPUnit_Framework_TestCase
+class NotificationCenterTest extends TestCase
 {
     private $notificationCenterObj;
     private $loggerMock;

--- a/tests/OptimizelyConfigTests/OptimizelyConfigServiceTest.php
+++ b/tests/OptimizelyConfigTests/OptimizelyConfigServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2020-2021, Optimizely
+ * Copyright 2020-2021, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,9 @@ use Optimizely\OptimizelyConfig\OptimizelyExperiment;
 use Optimizely\OptimizelyConfig\OptimizelyFeature;
 use Optimizely\OptimizelyConfig\OptimizelyVariable;
 use Optimizely\OptimizelyConfig\OptimizelyVariation;
+use PHPUnit\Framework\TestCase;
 
-class OptimizelyConfigServiceTest extends \PHPUnit_Framework_TestCase
+class OptimizelyConfigServiceTest extends TestCase
 {
 
     protected function setUp() : void

--- a/tests/OptimizelyConfigTests/OptimizelyConfigServiceTest.php
+++ b/tests/OptimizelyConfigTests/OptimizelyConfigServiceTest.php
@@ -33,7 +33,7 @@ use Optimizely\OptimizelyConfig\OptimizelyVariation;
 class OptimizelyConfigServiceTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->datafile = DATAFILE_FOR_OPTIMIZELY_CONFIG;
 

--- a/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
+++ b/tests/OptimizelyConfigTests/OptimizelyEntitiesTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2020, Optimizely
+ * Copyright 2020, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,9 @@ use Optimizely\OptimizelyConfig\OptimizelyExperiment;
 use Optimizely\OptimizelyConfig\OptimizelyFeature;
 use Optimizely\OptimizelyConfig\OptimizelyVariable;
 use Optimizely\OptimizelyConfig\OptimizelyVariation;
+use PHPUnit\Framework\TestCase;
 
-class OptimizelyEntitiesTest extends \PHPUnit_Framework_TestCase
+class OptimizelyEntitiesTest extends TestCase
 {
     public function testOptimizelyConfigEntity()
     {

--- a/tests/OptimizelyFactoryTest.php
+++ b/tests/OptimizelyFactoryTest.php
@@ -24,10 +24,11 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use Optimizely\OptimizelyFactory;
 use Optimizely\ProjectConfigManager\HTTPProjectConfigManager;
+use PHPUnit\Framework\TestCase;
 
-class OptimizelyFactoryTest extends \PHPUnit_Framework_TestCase
+class OptimizelyFactoryTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->datafile = DATAFILE;
         $this->typedAudiencesDataFile = DATAFILE_WITH_TYPED_AUDIENCES;

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -76,7 +76,7 @@ class OptimizelyTest extends \PHPUnit_Framework_TestCase
         $optimizely->configManager = $configManager;
     }
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->datafile = DATAFILE;
         $this->typedAudiencesDataFile = DATAFILE_WITH_TYPED_AUDIENCES;

--- a/tests/OptimizelyTest.php
+++ b/tests/OptimizelyTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2021, Optimizely
+ * Copyright 2016-2021, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,8 +50,9 @@ use Optimizely\OptimizelyDecisionContext;
 use Optimizely\OptimizelyForcedDecision;
 use Optimizely\OptimizelyUserContext;
 use Optimizely\UserProfile\UserProfileServiceInterface;
+use PHPUnit\Framework\TestCase;
 
-class OptimizelyTest extends \PHPUnit_Framework_TestCase
+class OptimizelyTest extends TestCase
 {
     const OUTPUT_STREAM = 'output';
 

--- a/tests/OptimizelyUserContextTest.php
+++ b/tests/OptimizelyUserContextTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2021, Optimizely
+ * Copyright 2021, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@ namespace Optimizely\Tests;
 use Exception;
 use Optimizely\Decide\OptimizelyDecideOption;
 use TypeError;
-
 use Optimizely\Logger\NoOpLogger;
 use Optimizely\Optimizely;
 use Optimizely\OptimizelyUserContext;
 use Optimizely\OptimizelyDecisionContext;
 use Optimizely\OptimizelyForcedDecision;
+use PHPUnit\Framework\TestCase;
 
-class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
+class OptimizelyUserContextTest extends TestCase
 {
     private $datafile;
     private $loggerMock;

--- a/tests/OptimizelyUserContextTest.php
+++ b/tests/OptimizelyUserContextTest.php
@@ -32,7 +32,7 @@ class OptimizelyUserContextTest extends \PHPUnit_Framework_TestCase
     private $loggerMock;
     private $optimizelyObject;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->datafile = DATAFILE;
 

--- a/tests/ProjectConfigManagerTests/HTTPProjectConfigManagerTest.php
+++ b/tests/ProjectConfigManagerTests/HTTPProjectConfigManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019-2020, Optimizely
+ * Copyright 2019-2020, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,9 @@ use Optimizely\Logger\NoOpLogger;
 use Optimizely\Notification\NotificationCenter;
 use Optimizely\Notification\NotificationType;
 use Optimizely\ProjectConfigManager\HTTPProjectConfigManager;
+use PHPUnit\Framework\TestCase;
 
-class HTTPProjectConfigManagerTest extends \PHPUnit_Framework_TestCase
+class HTTPProjectConfigManagerTest extends TestCase
 {
     private $loggerMock;
     private $errorHandlerMock;

--- a/tests/ProjectConfigManagerTests/HTTPProjectConfigManagerTest.php
+++ b/tests/ProjectConfigManagerTests/HTTPProjectConfigManagerTest.php
@@ -39,7 +39,7 @@ class HTTPProjectConfigManagerTest extends \PHPUnit_Framework_TestCase
     private $url;
     private $template;
 
-    public function setUp()
+    protected function setUp() : void
     {
         // Mock Logger
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)

--- a/tests/ProjectConfigManagerTests/HTTPProjectConfigManagerTest.php
+++ b/tests/ProjectConfigManagerTests/HTTPProjectConfigManagerTest.php
@@ -115,12 +115,9 @@ class HTTPProjectConfigManagerTest extends TestCase
          $this->assertInstanceOf(DatafileProjectConfig::class, $config);
     }
 
-    /**
-    * @expectedException Exception
-    *
-    */
     public function testConfigManagerThrowsErrorWhenBothSDKKeyAndURLNotProvided()
     {
+        $this->expectException(Exception::class);
         $this->errorHandlerMock->expects($this->once())
             ->method('handleError')
             ->with(new Exception("One of the SDK key or URL must be provided."));

--- a/tests/ProjectConfigManagerTests/StaticProjectConfigManagerTest.php
+++ b/tests/ProjectConfigManagerTests/StaticProjectConfigManagerTest.php
@@ -29,7 +29,7 @@ class StaticProjectConfigManagerTest extends \PHPUnit_Framework_TestCase
     private $loggerMock;
     private $errorHandlerMock;
 
-    public function setUp()
+    protected function setUp() : void
     {
         // Mock Logger
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)

--- a/tests/ProjectConfigManagerTests/StaticProjectConfigManagerTest.php
+++ b/tests/ProjectConfigManagerTests/StaticProjectConfigManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019, Optimizely
+ * Copyright 2019, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,9 @@ use Optimizely\ErrorHandler\NoOpErrorHandler;
 use Optimizely\Exceptions\InvalidDatafileVersionException;
 use Optimizely\Logger\NoOpLogger;
 use Optimizely\ProjectConfigManager\StaticProjectConfigManager;
+use PHPUnit\Framework\TestCase;
 
-class StaticProjectConfigManagerTest extends \PHPUnit_Framework_TestCase
+class StaticProjectConfigManagerTest extends TestCase
 {
     private $loggerMock;
     private $errorHandlerMock;

--- a/tests/UserProfileTests/UserProfileTest.php
+++ b/tests/UserProfileTests/UserProfileTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017, Optimizely Inc and Contributors
+ * Copyright 2017, 2023 Optimizely Inc and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ namespace Optimizely\Tests;
 
 use Optimizely\UserProfile\Decision;
 use Optimizely\UserProfile\UserProfile;
+use PHPUnit\Framework\TestCase;
 
-class UserProfileTest extends \PHPUnit_Framework_TestCase
+class UserProfileTest extends TestCase
 {
     private $userProfile;
 

--- a/tests/UserProfileTests/UserProfileTest.php
+++ b/tests/UserProfileTests/UserProfileTest.php
@@ -24,7 +24,7 @@ class UserProfileTest extends \PHPUnit_Framework_TestCase
 {
     private $userProfile;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $experimentBucketMap = array();
         $experimentBucketMap['111111'] = new Decision('211111');

--- a/tests/UserProfileTests/UserProfileUtilsTest.php
+++ b/tests/UserProfileTests/UserProfileUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017, Optimizely Inc and Contributors
+ * Copyright 2017, 2023 Optimizely Inc and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,9 @@ use Optimizely\Entity\Experiment;
 use Optimizely\UserProfile\Decision;
 use Optimizely\UserProfile\UserProfile;
 use Optimizely\UserProfile\UserProfileUtils;
+use PHPUnit\Framework\TestCase;
 
-class UserProfileUtilsTest extends \PHPUnit_Framework_TestCase
+class UserProfileUtilsTest extends TestCase
 {
     private $userProfileMap;
 

--- a/tests/UserProfileTests/UserProfileUtilsTest.php
+++ b/tests/UserProfileTests/UserProfileUtilsTest.php
@@ -26,7 +26,7 @@ class UserProfileUtilsTest extends \PHPUnit_Framework_TestCase
 {
     private $userProfileMap;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->userProfileMap = array(
             'user_id' => 'test_user',

--- a/tests/UtilsTests/ConditionTreeEvaluatorTest.php
+++ b/tests/UtilsTests/ConditionTreeEvaluatorTest.php
@@ -21,7 +21,7 @@ use Optimizely\Utils\ConditionTreeEvaluator;
 
 class ConditionTreeEvaluatorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->conditionA = [
             'name' => 'browser_type',

--- a/tests/UtilsTests/ConditionTreeEvaluatorTest.php
+++ b/tests/UtilsTests/ConditionTreeEvaluatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018-2019, Optimizely
+ * Copyright 2018-2019, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@
 namespace Optimizely\Tests;
 
 use Optimizely\Utils\ConditionTreeEvaluator;
+use PHPUnit\Framework\TestCase;
 
-class ConditionTreeEvaluatorTest extends \PHPUnit_Framework_TestCase
+class ConditionTreeEvaluatorTest extends TestCase
 {
     protected function setUp() : void
     {

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
@@ -22,7 +22,7 @@ use Optimizely\Utils\CustomAttributeConditionEvaluator;
 
 class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp() :void
     {
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
             ->setMethods(array('log'))

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019-2020, Optimizely
+ * Copyright 2019-2020, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ namespace Optimizely\Tests;
 
 use Monolog\Logger;
 use Optimizely\Utils\CustomAttributeConditionEvaluator;
+use PHPUnit\Framework\TestCase;
 
-class CustomAttributeConditionEvaluatorLoggingTest extends \PHPUnit_Framework_TestCase
+class CustomAttributeConditionEvaluatorLoggingTest extends TestCase
 {
     protected function setUp() :void
     {

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018-2020, Optimizely
+ * Copyright 2018-2020, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@
 namespace Optimizely\Tests;
 
 use Optimizely\Utils\CustomAttributeConditionEvaluator;
+use PHPUnit\Framework\TestCase;
 
-class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
+class CustomAttributeConditionEvaluatorTest extends TestCase
 {
     protected function setUp() : void
     {

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
@@ -21,7 +21,7 @@ use Optimizely\Utils\CustomAttributeConditionEvaluator;
 
 class CustomAttributeConditionEvaluatorTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
             ->setMethods(array('log'))

--- a/tests/UtilsTests/EventTagUtilsTest.php
+++ b/tests/UtilsTests/EventTagUtilsTest.php
@@ -29,7 +29,7 @@ class EventTagUtilsTest extends \PHPUnit_Framework_TestCase
     const MIN_FLOAT = -1.8e307;
     protected $loggerMock;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         // Mock Logger
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)

--- a/tests/UtilsTests/EventTagUtilsTest.php
+++ b/tests/UtilsTests/EventTagUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017-2019, Optimizely
+ * Copyright 2017-2019, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,9 @@ namespace Optimizely\Tests;
 use Optimizely\Utils\EventTagUtils;
 use Optimizely\Logger\NoOpLogger;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 
-class EventTagUtilsTest extends \PHPUnit_Framework_TestCase
+class EventTagUtilsTest extends TestCase
 {
     // The size of a float is platform-dependent, although a maximum of ~1.8e308 with a precision of roughly 14 decimal digits is a common value (the 64 bit IEEE format). http://php.net/manual/en/language.types.float.php
     // PHP_FLOAT_MAX - Available as of PHP7.2.0 http://php.net/manual/en/reserved.constants.php

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -25,7 +25,7 @@
 
 class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
             ->setMethods(array('log'))

--- a/tests/UtilsTests/ValidatorLoggingTest.php
+++ b/tests/UtilsTests/ValidatorLoggingTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2019-2021, Optimizely
+ * Copyright 2019-2021, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,9 @@
  use Optimizely\ErrorHandler\NoOpErrorHandler;
  use Optimizely\Logger\NoOpLogger;
  use Optimizely\Utils\Validator;
+ use PHPUnit\Framework\TestCase;
 
-class ValidatorLoggingTest extends \PHPUnit_Framework_TestCase
+class ValidatorLoggingTest extends TestCase
 {
     protected function setUp() : void
     {

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016-2021, Optimizely
+ * Copyright 2016-2021, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,9 @@ use Optimizely\Entity\Audience;
 use Optimizely\ErrorHandler\NoOpErrorHandler;
 use Optimizely\Logger\NoOpLogger;
 use Optimizely\Utils\Validator;
+use PHPUnit\Framework\TestCase;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
     protected $loggerMock;
 

--- a/tests/UtilsTests/ValidatorTest.php
+++ b/tests/UtilsTests/ValidatorTest.php
@@ -28,7 +28,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
     protected $loggerMock;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         // Mock Logger
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)

--- a/tests/UtilsTests/VariableTypeUtilsTest.php
+++ b/tests/UtilsTests/VariableTypeUtilsTest.php
@@ -27,7 +27,7 @@ class VariableTypeUtilsTest extends \PHPUnit_Framework_TestCase
     protected $loggerMock;
     protected $variableUtilObj;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         // Mock Logger
         $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)

--- a/tests/UtilsTests/VariableTypeUtilsTest.php
+++ b/tests/UtilsTests/VariableTypeUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017, Optimizely
+ * Copyright 2017, 2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,9 @@ use Monolog\Logger;
 use Optimizely\ErrorHandler\NoOpErrorHandler;
 use Optimizely\Logger\NoOpLogger;
 use Optimizely\Utils\VariableTypeUtils;
+use PHPUnit\Framework\TestCase;
 
-class VariableTypeUtilsTest extends \PHPUnit_Framework_TestCase
+class VariableTypeUtilsTest extends TestCase
 {
     protected $loggerMock;
     protected $variableUtilObj;


### PR DESCRIPTION
## Summary
As a PHP developer, I want to use SDKs that are compatible with versions of PHP in active support so that the versions of PHP I am running receive updates and security patches.

## Test plan

- Existing unit tests & FSC test should pass

## Issues
- FSSDK-9022
