### PR TITLE
[FSSDK-9415] Revert minor release 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Optimizely PHP SDK Changelog
 
-## 3.10.0
-June 9, 2023
-
-* Provided support for PHP version 8.x (backwards compatible with previous PHP versions).
-
 ## 3.9.4
 March 29 , 2023
 

--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -39,7 +39,7 @@ class EventBuilder
     /**
      * @const string Version of the Optimizely PHP SDK.
      */
-    const SDK_VERSION = '3.10.0';
+    const SDK_VERSION = '3.9.4';
 
     /**
      * @var string URL to send event to.

--- a/tests/EventTests/EventBuilderTest.php
+++ b/tests/EventTests/EventBuilderTest.php
@@ -69,7 +69,7 @@ class EventBuilderTest extends TestCase
                 ]],
                 'revision' => '15',
                 'client_name' => 'php-sdk',
-                'client_version' => '3.10.0',
+                'client_version' => '3.9.4',
                 'anonymize_ip'=> false,
                 'enrich_decisions' => true,
             ];


### PR DESCRIPTION
## Summary
- reverting minor release becasue it should be a major release. 
- we're still investigating if this release is a breaking change for some customers on older php bersions and what we want to do aboiut it. until then reverting.

https://jira.sso.episerver.net/browse/FSSDK-9415