### PR TITLE
[FSSDK-9415] Prep for 4.0.0 release

### DIFF
--- a/src/Optimizely/Event/Builder/EventBuilder.php
+++ b/src/Optimizely/Event/Builder/EventBuilder.php
@@ -39,7 +39,7 @@ class EventBuilder
     /**
      * @const string Version of the Optimizely PHP SDK.
      */
-    const SDK_VERSION = '3.9.4';
+    const SDK_VERSION = '4.0.0';
 
     /**
      * @var string URL to send event to.


### PR DESCRIPTION
## Summary
- Update php-sdk to support php versions 8.x
- php versions 6, 7.x are no longer supported, we are upgrading to get up to date

## Test plan - testing w php version 8.2
- unit tests, passing
- FSC tests passing
- manual bug bash 

## Issues
[FSSDK-9415](https://jira.sso.episerver.net/browse/FSSDK-9415)
