### PR TITLE
Fix: Wrap arguments in code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ $optimizely = new Optimizely(<<DATAFILE>>);
 Or you may also use OptimizelyFactory method to create an optimizely client using your SDK key, an optional fallback datafile and an optional datafile access token. Using this method internally creates an HTTPProjectConfigManager. See [HTTPProjectConfigManager](#use-httpprojectconfigmanager) for further detail.
 
 ```php
-$optimizelyClient = OptimizelyFactory::createDefaultInstance("your-sdk-key", <<DATAFILE>>, <<DATAFILE_AUTH_TOKEN>>);
+$optimizelyClient = OptimizelyFactory::createDefaultInstance(
+    "your-sdk-key",
+    <<DATAFILE>>,
+    <<DATAFILE_AUTH_TOKEN>>
+);
 ```
 To access your HTTPProjectConfigManager:
 
@@ -55,7 +59,15 @@ Or you can also provide an implementation of the [`ProjectConfigManagerInterface
 
 ```php
 $configManager = new HTTPProjectConfigManager(<<SDK_KEY>>);
-$optimizely = new Optimizely(<<DATAFILE>>, null, null, null, false, null, $configManager);
+$optimizely = new Optimizely(
+    <<DATAFILE>>,
+    null,
+    null,
+    null,
+    false,
+    null,
+    $configManager
+);
 ```
 
 ### ProjectConfigManagerInterface


### PR DESCRIPTION
## Summary
- wraps arguments in code examples

💁‍♂️ This helps to avoid unnecessary horizontal scrolling when inspecting code examples.

<img width="1912" alt="CleanShot 2023-07-21 at 17 31 17@2x" src="https://github.com/optimizely/php-sdk/assets/605483/29952c3e-f5cd-4530-9e06-12318bb72935">

## Test plan
n/a

## Issues
n/a
