### PR TITLE
Fix: Add `ReturnTypeWillChange` attribute

### DIFF
--- a/src/Optimizely/Decide/OptimizelyDecision.php
+++ b/src/Optimizely/Decide/OptimizelyDecision.php
@@ -81,6 +81,7 @@ class OptimizelyDecision implements \JsonSerializable
         return $this->reasons;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return get_object_vars($this);

--- a/src/Optimizely/OptimizelyConfig/OptimizelyAttribute.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyAttribute.php
@@ -53,6 +53,7 @@ class OptimizelyAttribute implements \JsonSerializable
     /**
      * @return string JSON representation of the object.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return get_object_vars($this);

--- a/src/Optimizely/OptimizelyConfig/OptimizelyAudience.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyAudience.php
@@ -68,6 +68,7 @@ class OptimizelyAudience implements \JsonSerializable
     /**
      * @return string JSON representation of the object.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return get_object_vars($this);

--- a/src/Optimizely/OptimizelyConfig/OptimizelyConfig.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyConfig.php
@@ -166,6 +166,7 @@ class OptimizelyConfig implements \JsonSerializable
     /**
      * @return string JSON representation of the object.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return get_object_vars($this);

--- a/src/Optimizely/OptimizelyConfig/OptimizelyEvent.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyEvent.php
@@ -68,6 +68,7 @@ class OptimizelyEvent implements \JsonSerializable
     /**
      * @return string JSON representation of the object.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return get_object_vars($this);

--- a/src/Optimizely/OptimizelyConfig/OptimizelyExperiment.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyExperiment.php
@@ -83,6 +83,7 @@ class OptimizelyExperiment implements \JsonSerializable
     /**
      * @return string JSON representation of the object.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return get_object_vars($this);

--- a/src/Optimizely/OptimizelyConfig/OptimizelyFeature.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyFeature.php
@@ -118,6 +118,7 @@ class OptimizelyFeature implements \JsonSerializable
     /**
      * @return string JSON representation of the object.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return get_object_vars($this);

--- a/src/Optimizely/OptimizelyConfig/OptimizelyVariable.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyVariable.php
@@ -82,6 +82,7 @@ class OptimizelyVariable implements \JsonSerializable
     /**
      * @return string JSON representation of the object.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return get_object_vars($this);

--- a/src/Optimizely/OptimizelyConfig/OptimizelyVariation.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyVariation.php
@@ -84,6 +84,7 @@ class OptimizelyVariation implements \JsonSerializable
      * @return string JSON representation of the object.
      *                Unsets featureEnabled property for variations of ab experiments.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $props = get_object_vars($this);


### PR DESCRIPTION
## Summary

- adds `ReturnTypeWillChange` attributes to `jsonSerialize()` methods of classes implementing the `JsonSerializable` interface

Follows #242.

💁‍♂️ This suppresses deprecation notices when running tests with `phpunit/phpunit` using these classes or using these classes in an environment where deprecations are logged.

For reference, see https://www.php.net/manual/en/class.returntypewillchange.php.

## Test plan

- n/a

## Issues

- n/a
