### PR TITLE
Explicitly define class properties

### DIFF
--- a/src/Optimizely/OptimizelyConfig/OptimizelyConfigService.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyConfigService.php
@@ -83,6 +83,8 @@ class OptimizelyConfigService
      */
     private readonly LoggerInterface $logger;
 
+    private ProjectConfigInterface $projectConfig;
+
     public function __construct(ProjectConfigInterface $projectConfig, LoggerInterface $logger = null)
     {
         $this->experiments = $projectConfig->getAllExperiments();

--- a/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
+++ b/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
@@ -19,6 +19,7 @@ namespace Optimizely\Utils;
 
 use Monolog\Logger;
 use Optimizely\Enums\CommonAudienceEvaluationLogs as logs;
+use Optimizely\Logger\LoggerInterface;
 use Optimizely\Utils\SemVersionConditionEvaluator;
 use Optimizely\Utils\Validator;
 
@@ -44,13 +45,15 @@ class CustomAttributeConditionEvaluator
      */
     protected $userAttributes;
 
+    private LoggerInterface $logger;
+
     /**
      * CustomAttributeConditionEvaluator constructor
      *
      * @param array $userAttributes Associative array of user attributes to values.
      * @param $logger LoggerInterface.
      */
-    public function __construct(array $userAttributes, $logger)
+    public function __construct(array $userAttributes, LoggerInterface $logger)
     {
         $this->userAttributes = $userAttributes;
         $this->logger = $logger;


### PR DESCRIPTION
## Summary
- Explicitly define class properties to get rid of deprecation warnings


## Issues
- Fixes #283 

## Issues
FSSDK-10015