### PR TITLE
Asynchronous call for the dispatcher to avoid blocking request when doing decisions

### DIFF
--- a/src/Optimizely/Event/Dispatcher/DefaultEventDispatcher.php
+++ b/src/Optimizely/Event/Dispatcher/DefaultEventDispatcher.php
@@ -50,6 +50,7 @@ class DefaultEventDispatcher implements EventDispatcherInterface
             'connect_timeout' => DefaultEventDispatcher::TIMEOUT
         ];
 
-        $this->httpClient->requestAsync($event->getHttpVerb(), $event->getUrl(), $options);
+        $this->httpClient->requestAsync($event->getHttpVerb(), $event->getUrl(), $options)
+            ->then(fn($response) => $response);
     }
 }

--- a/src/Optimizely/Event/Dispatcher/DefaultEventDispatcher.php
+++ b/src/Optimizely/Event/Dispatcher/DefaultEventDispatcher.php
@@ -50,6 +50,6 @@ class DefaultEventDispatcher implements EventDispatcherInterface
             'connect_timeout' => DefaultEventDispatcher::TIMEOUT
         ];
 
-        $this->httpClient->request($event->getHttpVerb(), $event->getUrl(), $options);
+        $this->httpClient->requestAsync($event->getHttpVerb(), $event->getUrl(), $options);
     }
 }

--- a/tests/EventTests/DefaultEventDispatcherTest.php
+++ b/tests/EventTests/DefaultEventDispatcherTest.php
@@ -49,7 +49,7 @@ class DefaultEventDispatcherTest extends TestCase
             ->getMock();
 
         $guzzleClientMock->expects($this->once())
-            ->method('request')
+            ->method('requestAsync')
             ->with($logEvent->getHttpVerb(), $logEvent->getUrl(), $expectedOptions);
 
         $eventDispatcher = new DefaultEventDispatcher($guzzleClientMock);


### PR DESCRIPTION
## Summary
- Dispatcher is supposed to be for asynchronous operation that can be done outside of the normal process like the sending of impression, however, the call to the sending of impression is synchronous and is thus creates a bottleneck in terms of performance. By making the call asynchronous, it improves the performance of decide call.