### PR TITLE
[FSSDK-10015] Fix: Explicitly define class properties

### DIFF
--- a/src/Optimizely/OptimizelyConfig/OptimizelyConfigService.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyConfigService.php
@@ -83,6 +83,8 @@ class OptimizelyConfigService
      */
     private readonly LoggerInterface $logger;
 
+    private ProjectConfigInterface $projectConfig;
+
     public function __construct(ProjectConfigInterface $projectConfig, LoggerInterface $logger = null)
     {
         $this->experiments = $projectConfig->getAllExperiments();

--- a/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
+++ b/src/Optimizely/Utils/CustomAttributeConditionEvaluator.php
@@ -19,6 +19,7 @@ namespace Optimizely\Utils;
 
 use Monolog\Logger;
 use Optimizely\Enums\CommonAudienceEvaluationLogs as logs;
+use Optimizely\Logger\LoggerInterface;
 use Optimizely\Utils\SemVersionConditionEvaluator;
 use Optimizely\Utils\Validator;
 
@@ -44,13 +45,15 @@ class CustomAttributeConditionEvaluator
      */
     protected $userAttributes;
 
+    private LoggerInterface $logger;
+
     /**
      * CustomAttributeConditionEvaluator constructor
      *
      * @param array $userAttributes Associative array of user attributes to values.
      * @param $logger LoggerInterface.
      */
-    public function __construct(array $userAttributes, $logger)
+    public function __construct(array $userAttributes, LoggerInterface $logger)
     {
         $this->userAttributes = $userAttributes;
         $this->logger = $logger;

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorLoggingTest.php
@@ -20,12 +20,13 @@ namespace Optimizely\Tests;
 use Monolog\Logger;
 use Optimizely\Utils\CustomAttributeConditionEvaluator;
 use PHPUnit\Framework\TestCase;
+use Optimizely\Logger\LoggerInterface;
 
 class CustomAttributeConditionEvaluatorLoggingTest extends TestCase
 {
     protected function setUp() :void
     {
-        $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
             ->setMethods(array('log'))
             ->getMock();
     }

--- a/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
+++ b/tests/UtilsTests/CustomAttributeConditionEvaluatorTest.php
@@ -19,12 +19,13 @@ namespace Optimizely\Tests;
 
 use Optimizely\Utils\CustomAttributeConditionEvaluator;
 use PHPUnit\Framework\TestCase;
+use Optimizely\Logger\LoggerInterface;
 
 class CustomAttributeConditionEvaluatorTest extends TestCase
 {
     protected function setUp() : void
     {
-        $this->loggerMock = $this->getMockBuilder(NoOpLogger::class)
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
             ->setMethods(array('log'))
             ->getMock();
 


### PR DESCRIPTION
## Summary
- Explicitly define class properties to get rid of deprecation warnings
- Internal pull request of third party PR 

## Issues
[FSSDK-10015](https://jira.sso.episerver.net/browse/FSSDK-10015)