### PR TITLE
[FSSDK-12610] Fix: PHP 8.4 implicit nullable parameter deprecation warnings

### DIFF
--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -83,7 +83,7 @@ class DecisionService
      * @param LoggerInterface       $logger
      * @param UserProfileServiceInterface  $userProfileService
      */
-    public function __construct(LoggerInterface $logger, UserProfileServiceInterface $userProfileService = null)
+    public function __construct(LoggerInterface $logger, ?UserProfileServiceInterface $userProfileService = null)
     {
         $this->_logger = $logger;
         $this->_bucketer = new Bucketer($logger);

--- a/src/Optimizely/DecisionService/DecisionService.php
+++ b/src/Optimizely/DecisionService/DecisionService.php
@@ -81,7 +81,7 @@ class DecisionService
      * DecisionService constructor.
      *
      * @param LoggerInterface       $logger
-     * @param UserProfileServiceInterface  $userProfileService
+     * @param ?UserProfileServiceInterface  $userProfileService
      */
     public function __construct(LoggerInterface $logger, ?UserProfileServiceInterface $userProfileService = null)
     {

--- a/src/Optimizely/Event/Dispatcher/DefaultEventDispatcher.php
+++ b/src/Optimizely/Event/Dispatcher/DefaultEventDispatcher.php
@@ -36,7 +36,7 @@ class DefaultEventDispatcher implements EventDispatcherInterface
      */
     private $httpClient;
 
-    public function __construct(HttpClient $httpClient = null)
+    public function __construct(?HttpClient $httpClient = null)
     {
         $this->httpClient = $httpClient ?: new HttpClient();
     }

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -119,13 +119,13 @@ class Optimizely
      * Optimizely constructor for managing Feature Experimentation PHP projects.
      *
      * @param $datafile string JSON string representing the project.
-     * @param $eventDispatcher EventDispatcherInterface
-     * @param $logger LoggerInterface
-     * @param $errorHandler ErrorHandlerInterface
+     * @param $eventDispatcher ?EventDispatcherInterface
+     * @param $logger ?LoggerInterface
+     * @param $errorHandler ?ErrorHandlerInterface
      * @param $skipJsonValidation boolean representing whether JSON schema validation needs to be performed.
-     * @param $userProfileService UserProfileServiceInterface
-     * @param $configManager ProjectConfigManagerInterface provides ProjectConfig through getConfig method.
-     * @param $notificationCenter NotificationCenter
+     * @param $userProfileService ?UserProfileServiceInterface
+     * @param $configManager ?ProjectConfigManagerInterface provides ProjectConfig through getConfig method.
+     * @param $notificationCenter ?NotificationCenter
      * @param $sdkKey string uniquely identifying the datafile corresponding to project and environment combination. Must provide at least one of datafile or sdkKey.
      */
     public function __construct(

--- a/src/Optimizely/Optimizely.php
+++ b/src/Optimizely/Optimizely.php
@@ -130,13 +130,13 @@ class Optimizely
      */
     public function __construct(
         $datafile,
-        EventDispatcherInterface $eventDispatcher = null,
-        LoggerInterface $logger = null,
-        ErrorHandlerInterface $errorHandler = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+        ?LoggerInterface $logger = null,
+        ?ErrorHandlerInterface $errorHandler = null,
         $skipJsonValidation = false,
-        UserProfileServiceInterface $userProfileService = null,
-        ProjectConfigManagerInterface $configManager = null,
-        NotificationCenter $notificationCenter = null,
+        ?UserProfileServiceInterface $userProfileService = null,
+        ?ProjectConfigManagerInterface $configManager = null,
+        ?NotificationCenter $notificationCenter = null,
         $sdkKey = null,
         array $defaultDecideOptions = []
     ) {

--- a/src/Optimizely/OptimizelyConfig/OptimizelyConfigService.php
+++ b/src/Optimizely/OptimizelyConfig/OptimizelyConfigService.php
@@ -85,7 +85,7 @@ class OptimizelyConfigService
 
     private ProjectConfigInterface $projectConfig;
 
-    public function __construct(ProjectConfigInterface $projectConfig, LoggerInterface $logger = null)
+    public function __construct(ProjectConfigInterface $projectConfig, ?LoggerInterface $logger = null)
     {
         $this->experiments = $projectConfig->getAllExperiments();
         $this->featureFlags = $projectConfig->getFeatureFlags();

--- a/src/Optimizely/ProjectConfigManager/HTTPProjectConfigManager.php
+++ b/src/Optimizely/ProjectConfigManager/HTTPProjectConfigManager.php
@@ -89,9 +89,9 @@ class HTTPProjectConfigManager implements ProjectConfigManagerInterface
         $fetchOnInit = true,
         $datafile = null,
         $skipJsonValidation = false,
-        LoggerInterface $logger = null,
-        ErrorHandlerInterface $errorHandler = null,
-        NotificationCenter $notificationCenter = null,
+        ?LoggerInterface $logger = null,
+        ?ErrorHandlerInterface $errorHandler = null,
+        ?NotificationCenter $notificationCenter = null,
         $datafileAccessToken = null
     ) {
         $this->_skipJsonValidation = $skipJsonValidation;

--- a/src/Optimizely/Utils/Validator.php
+++ b/src/Optimizely/Utils/Validator.php
@@ -31,7 +31,7 @@ class Validator
      *
      * @return boolean Representing whether schema is valid or not.
      */
-    public static function validateJsonSchema($datafile, LoggerInterface $logger = null)
+    public static function validateJsonSchema($datafile, ?LoggerInterface $logger = null)
     {
         $data = json_decode($datafile);
 

--- a/src/Optimizely/Utils/VariableTypeUtils.php
+++ b/src/Optimizely/Utils/VariableTypeUtils.php
@@ -24,7 +24,7 @@ use Optimizely\Logger\LoggerInterface;
 
 class VariableTypeUtils
 {
-    public static function castStringToType($value, $variableType, LoggerInterface $logger = null)
+    public static function castStringToType($value, $variableType, ?LoggerInterface $logger = null)
     {
         if ($variableType == FeatureVariable::STRING_TYPE) {
             return $value;


### PR DESCRIPTION
## Summary
- Fixes PHP 8.4 deprecation warnings for implicitly nullable parameter types across 7 files (14 parameters total)
- Changes `Type $param = null` to `?Type $param = null` in constructors and methods
- Updates PHPDoc to reflect nullable types
- No behavioral change — parameters already accepted `null`, this makes the nullable type explicit as PHP 8.4 requires

## Jira
[FSSDK-12610](https://optimizely.atlassian.net/browse/FSSDK-12610)

## Related
- #283 (PHP 8.2 dynamic property deprecation — same PHP compat area)
- Follows precedent of FSSDK-8597 (PHP 8.1 `strlen(null)`) and FSSDK-9573 (PHP 8.2 dynamic properties)

## Files changed
| File | Parameters fixed |
|------|-----------------|
| `src/Optimizely/Optimizely.php` | `$eventDispatcher`, `$logger`, `$errorHandler`, `$userProfileService`, `$configManager`, `$notificationCenter` |
| `src/Optimizely/ProjectConfigManager/HTTPProjectConfigManager.php` | `$logger`, `$errorHandler`, `$notificationCenter` |
| `src/Optimizely/DecisionService/DecisionService.php` | `$userProfileService` |
| `src/Optimizely/Utils/Validator.php` | `$logger` |
| `src/Optimizely/Utils/VariableTypeUtils.php` | `$logger` |
| `src/Optimizely/Event/Dispatcher/DefaultEventDispatcher.php` | `$httpClient` |
| `src/Optimizely/OptimizelyConfig/OptimizelyConfigService.php` | `$logger` |

## Test plan
- [ ] Run `composer test` on PHP 8.4 to confirm deprecation warnings are gone
- [ ] Run full test suite to verify no regressions
- [ ] Verify SDK works correctly on PHP 8.1+ (backward compatible per composer.json constraint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FSSDK-12610]: https://optimizely-ext.atlassian.net/browse/FSSDK-12610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ